### PR TITLE
[DOCS] add utils to nav

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * Token Standards
 ** xref:tokens/fungible.adoc[Fungible Tokens]
 
-
+* Utilities
+** xref:utils/pausable.adoc[Pausable]

--- a/docs/modules/ROOT/pages/utils/pausable.adoc
+++ b/docs/modules/ROOT/pages/utils/pausable.adoc
@@ -1,9 +1,9 @@
 :source-highlighter: highlight.js
 :highlightjs-languages: rust
 :github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
-= Fungible Token Standard
+= Utilities
 
-== Source Code link: https://github.com/OpenZeppelin/stellar-contracts/tree/main/contracts/utils/pausable[pausable]
+https://github.com/OpenZeppelin/stellar-contracts/tree/main/contracts/utils/pausable[Source Code]
 
 == Purpose
 


### PR DESCRIPTION
I just added the utils to the nav, because I expected the to be there.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Pallets, that require benchmarks, are added to `scripts/assets/pallets.txt` (Pallet require benchmark if it has WeightInfo config type)
