### PR TITLE
`update` inline docs & readme wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenZeppelin Soroban Contracts
+# OpenZeppelin Stellar Soroban Contracts
 
 
 ## Security
@@ -9,4 +9,4 @@
 
 ## License
 
-OpenZeppelin Soroban Contracts are released under the [MIT LICENSE](LICENSE).
+OpenZeppelin Stellar Soroban Contracts are released under the [MIT LICENSE](LICENSE).


### PR DESCRIPTION
Based on Leigh's comments on `update` function's cognitive load, adding one-liner inline comments to ease the navigation between branches for the reader.

Also, updated readme (wording purposes) -> 
- previously: `Soroban Contracts`
- now: `Stellar Soroban Contract`

the reason I didn't remove the word `Soroban` altogether is, search engines are indexing readme content as well, and I reckoned keeping the word `Soroban` will be useful for SEO purposes.