### PR TITLE
inline docs standardized, and emit removed from set_allowance

### DIFF
--- a/contracts/token/fungible/src/extensions/burnable/mod.rs
+++ b/contracts/token/fungible/src/extensions/burnable/mod.rs
@@ -33,6 +33,7 @@ pub trait FungibleBurnable {
     ///
     /// * [`crate::FungibleTokenError::InsufficientBalance`] - When attempting
     ///   to burn more tokens than `from` current balance.
+    /// * [`FungibleTokenError::LessThanZero`] - When `amount < 0`.
     ///
     /// # Events
     ///
@@ -61,6 +62,7 @@ pub trait FungibleBurnable {
     ///   to burn more tokens than `from` current balance.
     /// * [`crate::FungibleTokenError::InsufficientAllowance`] - When attempting
     ///   to burn more tokens than `from` allowance.
+    /// * [`FungibleTokenError::LessThanZero`] - When `amount < 0`.
     ///
     /// # Events
     ///

--- a/contracts/token/fungible/src/extensions/burnable/storage.rs
+++ b/contracts/token/fungible/src/extensions/burnable/storage.rs
@@ -16,9 +16,7 @@ use crate::{
 ///
 /// # Errors
 ///
-/// * [`crate::FungibleTokenError::InsufficientBalance`] - When attempting to
-///   burn more tokens than `from` current balance.
-/// * [`crate::FungibleTokenError::LessThanZero`] - When `amount < 0`.
+/// * refer to [`update`] errors.
 ///
 /// # Events
 ///
@@ -48,11 +46,8 @@ pub fn burn(e: &Env, from: &Address, amount: i128) {
 ///
 /// # Errors
 ///
-/// * [`crate::FungibleTokenError::InsufficientBalance`] - When attempting to
-///   burn more tokens than `from` current balance.
-/// * [`crate::FungibleTokenError::InsufficientAllowance`] - When attempting to
-///   burn more tokens than `spender`s current allowance.
-/// * [`crate::FungibleTokenError::LessThanZero`] - When `amount < 0`.
+/// * refer to [`spend_allowance`] errors.
+/// * refer to [`update`] errors.
 ///
 /// # Events
 ///

--- a/contracts/token/fungible/src/extensions/capped/storage.rs
+++ b/contracts/token/fungible/src/extensions/capped/storage.rs
@@ -28,7 +28,7 @@ pub fn set_cap(e: &Env, cap: i128) {
     e.storage().instance().set(&CAP_KEY, &cap);
 }
 
-/// Query the maximum supply of tokens.
+/// Returns the maximum supply of tokens.
 ///
 /// # Arguments
 ///
@@ -37,10 +37,6 @@ pub fn set_cap(e: &Env, cap: i128) {
 /// # Errors
 ///
 /// * [`FungibleTokenError::CapNotSet`] - Occurs when the cap has not been set.
-///
-/// # Returns
-///
-/// the maximum supply of tokens.
 pub fn query_cap(e: &Env) -> i128 {
     e.storage()
         .instance()

--- a/contracts/token/fungible/src/extensions/capped/storage.rs
+++ b/contracts/token/fungible/src/extensions/capped/storage.rs
@@ -18,9 +18,9 @@ pub const CAP_KEY: Symbol = symbol_short!("CAP");
 ///
 /// # Notes
 ///
-/// We recommend using this function in the constructor of your smart contract.
-/// Cap functionality is designed to be used in conjunction with the `mintable`
-/// extension.
+/// * We recommend using this function in the constructor of your smart contract.
+/// * Cap functionality is designed to be used in conjunction with the `mintable`
+///   extension.
 pub fn set_cap(e: &Env, cap: i128) {
     if cap < 0 {
         panic_with_error!(e, FungibleTokenError::InvalidCap);

--- a/contracts/token/fungible/src/extensions/capped/storage.rs
+++ b/contracts/token/fungible/src/extensions/capped/storage.rs
@@ -18,9 +18,10 @@ pub const CAP_KEY: Symbol = symbol_short!("CAP");
 ///
 /// # Notes
 ///
-/// * We recommend using this function in the constructor of your smart contract.
-/// * Cap functionality is designed to be used in conjunction with the `mintable`
-///   extension.
+/// * We recommend using this function in the constructor of your smart
+///   contract.
+/// * Cap functionality is designed to be used in conjunction with the
+///   `mintable` extension.
 pub fn set_cap(e: &Env, cap: i128) {
     if cap < 0 {
         panic_with_error!(e, FungibleTokenError::InvalidCap);

--- a/contracts/token/fungible/src/extensions/metadata/storage.rs
+++ b/contracts/token/fungible/src/extensions/metadata/storage.rs
@@ -38,8 +38,7 @@ pub fn get_metadata(e: &Env) -> Metadata {
 ///
 /// # Errors
 ///
-/// * [`FungibleTokenError::UnsetMetadata`] - When trying to access
-///   uninitialized metadata.
+/// * refer to [`get_metadata`] errors.
 pub fn decimals(e: &Env) -> u32 {
     get_metadata(e).decimals
 }
@@ -52,8 +51,7 @@ pub fn decimals(e: &Env) -> u32 {
 ///
 /// # Errors
 ///
-/// * [`FungibleTokenError::UnsetMetadata`] - When trying to access
-///   uninitialized metadata.
+/// * refer to [`get_metadata`] errors.
 pub fn name(e: &Env) -> String {
     get_metadata(e).name
 }
@@ -66,8 +64,7 @@ pub fn name(e: &Env) -> String {
 ///
 /// # Errors
 ///
-/// * [`FungibleTokenError::UnsetMetadata`] - When trying to access
-///   uninitialized metadata.
+/// * refer to [`get_metadata`] errors.
 pub fn symbol(e: &Env) -> String {
     get_metadata(e).symbol
 }

--- a/contracts/token/fungible/src/extensions/mintable/mod.rs
+++ b/contracts/token/fungible/src/extensions/mintable/mod.rs
@@ -25,6 +25,11 @@ pub trait FungibleMintable {
     /// * `account` - The address receiving the new tokens.
     /// * `amount` - The amount of tokens to mint.
     ///
+    /// # Errors
+    ///
+    /// * [`FungibleTokenError::LessThanZero`] - When `amount < 0`.
+    /// * [`FungibleTokenError::MathOverflow`] - When `total_supply` overflows.
+    ///
     /// # Events
     ///
     /// * topics - `["mint", account: Address]`
@@ -45,6 +50,7 @@ pub trait FungibleMintable {
     /// some authorization controls for minting tokens.
     fn mint(e: &Env, account: Address, amount: i128);
 }
+
 // ################## EVENTS ##################
 
 /// Emits an event indicating a mint of tokens.

--- a/contracts/token/fungible/src/extensions/mintable/storage.rs
+++ b/contracts/token/fungible/src/extensions/mintable/storage.rs
@@ -11,6 +11,10 @@ use crate::{extensions::mintable::emit_mint, storage::update};
 /// * `account` - The address receiving the new tokens.
 /// * `amount` - The amount of tokens to mint.
 ///
+/// # Errors
+///
+/// refer to [`update`] errors.
+///
 /// # Events
 ///
 /// * topics - `["mint", account: Address]`

--- a/contracts/token/fungible/src/fungible.rs
+++ b/contracts/token/fungible/src/fungible.rs
@@ -63,8 +63,8 @@ pub trait FungibleToken {
     ///
     /// # Errors
     ///
-    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to transfer
-    ///   more tokens than `from` current balance.
+    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to
+    ///   transfer more tokens than `from` current balance.
     /// * [`FungibleTokenError::LessThanZero`] - When `amount < 0`.
     ///
     /// # Events
@@ -93,8 +93,8 @@ pub trait FungibleToken {
     ///
     /// # Errors
     ///
-    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to transfer
-    ///   more tokens than `from` current balance.
+    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to
+    ///   transfer more tokens than `from` current balance.
     /// * [`FungibleTokenError::LessThanZero`] - When `amount < 0`.
     /// * [`FungibleTokenError::InsufficientAllowance`] - When attempting to
     ///   transfer more tokens than `spender` current allowance.

--- a/contracts/token/fungible/src/fungible.rs
+++ b/contracts/token/fungible/src/fungible.rs
@@ -63,8 +63,9 @@ pub trait FungibleToken {
     ///
     /// # Errors
     ///
-    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to
-    ///   transfer more tokens than `from` current balance.
+    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to transfer
+    ///   more tokens than `from` current balance.
+    /// * [`FungibleTokenError::LessThanZero`] - When `amount < 0`.
     ///
     /// # Events
     ///
@@ -92,11 +93,11 @@ pub trait FungibleToken {
     ///
     /// # Errors
     ///
-    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to
-    ///   transfer more tokens than `from` current balance.
+    /// * [`FungibleTokenError::InsufficientBalance`] - When attempting to transfer
+    ///   more tokens than `from` current balance.
+    /// * [`FungibleTokenError::LessThanZero`] - When `amount < 0`.
     /// * [`FungibleTokenError::InsufficientAllowance`] - When attempting to
     ///   transfer more tokens than `spender` current allowance.
-    ///
     ///
     /// # Events
     ///
@@ -127,6 +128,7 @@ pub trait FungibleToken {
     /// * [`FungibleTokenError::InvalidLiveUntilLedger`] - Occurs when
     ///   attempting to set `live_until_ledger` that is less than the current
     ///   ledger number and greater than `0`.
+    /// * [`FungibleTokenError::LessThanZero`] - Occurs when `amount < 0`.
     ///
     /// # Events
     ///

--- a/contracts/token/fungible/src/storage.rs
+++ b/contracts/token/fungible/src/storage.rs
@@ -125,10 +125,7 @@ pub fn allowance(e: &Env, owner: &Address, spender: &Address) -> i128 {
 ///
 /// # Errors
 ///
-/// * [`FungibleTokenError::InvalidLiveUntilLedger`] - Occurs when attempting to
-///   set `live_until_ledger` that is 1) greater than the maximum allowed or 2)
-///   less than the current ledger number and `amount` is greater than `0`.
-/// * [`FungibleTokenError::LessThanZero`] - Occurs when `amount < 0`.
+/// * refer to [`set_allowance`] errors.
 ///
 /// # Events
 ///
@@ -144,14 +141,13 @@ pub fn allowance(e: &Env, owner: &Address, spender: &Address) -> i128 {
 ///   "Stellar Asset Contract" implementation for consistency reasons.
 pub fn approve(e: &Env, owner: &Address, spender: &Address, amount: i128, live_until_ledger: u32) {
     owner.require_auth();
-    set_allowance(e, owner, spender, amount, live_until_ledger, true);
+    set_allowance(e, owner, spender, amount, live_until_ledger);
+    emit_approve(e, owner, spender, amount, live_until_ledger);
 }
 
 /// Sets the amount of tokens a `spender` is allowed to spend on behalf of an
 /// `owner`. Overrides any existing allowance set between `spender` and `owner`.
-/// Variant of [`approve()`] that doesn't handle authorization, but controls
-/// event emission. That can be useful in operations like spending allowance
-/// during [`transfer_from()`].
+/// Doesn't handle authorization, nor event emission.
 ///
 /// # Arguments
 ///
@@ -160,7 +156,6 @@ pub fn approve(e: &Env, owner: &Address, spender: &Address, amount: i128, live_u
 /// * `spender` - The address authorized to spend the tokens.
 /// * `amount` - The amount of tokens made available to `spender`.
 /// * `live_until_ledger` - The ledger number at which the allowance expires.
-/// * `emit` - A flag to enable or disable event emission.
 ///
 /// # Errors
 ///
@@ -169,15 +164,9 @@ pub fn approve(e: &Env, owner: &Address, spender: &Address, amount: i128, live_u
 ///   less than the current ledger number and `amount` is greater than `0`.
 /// * [`FungibleTokenError::LessThanZero`] - Occurs when `amount < 0`.
 ///
-/// # Events
-///
-/// Emits an event if `emit` is `true`.
-/// * topics - `["approve", from: Address, spender: Address]`
-/// * data - `[amount: i128, live_until_ledger: u32]`
-///
 /// # Notes
 ///
-/// * No authorization is required.
+/// * It is expected that the caller of this function handles the authorization.
 /// * Allowance is implicitly timebound by the maximum allowed storage TTL value
 ///   which is a network parameter, i.e. one cannot set an allowance for a
 ///   longer period. This behavior closely mirrors the functioning of the
@@ -188,7 +177,6 @@ pub fn set_allowance(
     spender: &Address,
     amount: i128,
     live_until_ledger: u32,
-    emit: bool,
 ) {
     if amount < 0 {
         panic_with_error!(e, FungibleTokenError::LessThanZero);
@@ -216,10 +204,6 @@ pub fn set_allowance(
 
         e.storage().temporary().extend_ttl(&key, live_for, live_for)
     }
-
-    if emit {
-        emit_approve(e, owner, spender, amount, live_until_ledger);
-    }
 }
 
 /// Deducts the amount of tokens a `spender` is allowed to spend on behalf of an
@@ -237,10 +221,11 @@ pub fn set_allowance(
 /// * [`FungibleTokenError::InsufficientAllowance`] - When attempting to
 ///   transfer more tokens than `spender` current allowance.
 /// * [`FungibleTokenError::LessThanZero`] - Occurs when `amount < 0`.
+/// * also refer to [`set_allowance`] errors.
 ///
 /// # Notes
 ///
-/// No authorization is required.
+/// * It is expected that the caller of this function handles the authorization.
 pub fn spend_allowance(e: &Env, owner: &Address, spender: &Address, amount: i128) {
     if amount < 0 {
         panic_with_error!(e, FungibleTokenError::LessThanZero)
@@ -253,14 +238,7 @@ pub fn spend_allowance(e: &Env, owner: &Address, spender: &Address, amount: i128
     }
 
     if amount > 0 {
-        set_allowance(
-            e,
-            owner,
-            spender,
-            allowance.amount - amount,
-            allowance.live_until_ledger,
-            false,
-        );
+        set_allowance(e, owner, spender, allowance.amount - amount, allowance.live_until_ledger);
     }
 }
 
@@ -275,13 +253,11 @@ pub fn spend_allowance(e: &Env, owner: &Address, spender: &Address, amount: i128
 ///
 /// # Errors
 ///
-/// * [`FungibleTokenError::InsufficientBalance`] - When attempting to transfer
-///   more tokens than `from` current balance.
+/// * refer to [`do_transfer`] errors.
 ///
 /// # Events
 ///
-/// * topics - `["transfer", from: Address, to: Address]`
-/// * data - `[amount: i128]`
+/// * refer to [`do_transfer`] events.
 ///
 /// # Notes
 ///
@@ -305,16 +281,12 @@ pub fn transfer(e: &Env, from: &Address, to: &Address, amount: i128) {
 ///
 /// # Errors
 ///
-/// * [`FungibleTokenError::InsufficientBalance`] - When attempting to transfer
-///   more tokens than `from` current balance.
-/// * [`FungibleTokenError::InsufficientAllowance`] - When attempting to
-///   transfer more tokens than `spender` current allowance.
-///
+/// * refer to [`spend_allowance`] errors.
+/// * refer to [`do_transfer`] errors.
 ///
 /// # Events
 ///
-/// * topics - `["transfer", from: Address, to: Address]`
-/// * data - `[amount: i128]`
+/// * refer to [`do_transfer`] events.
 ///
 /// # Notes
 ///
@@ -325,7 +297,9 @@ pub fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, a
     do_transfer(e, from, to, amount);
 }
 
-/// Equivalent to [`transfer()`] but doesn't handle authorization.
+/// Equivalent to [`transfer()`] but:
+/// - does NOT handle authorization.
+/// - does handles event emission
 ///
 /// # Arguments
 ///
@@ -336,8 +310,7 @@ pub fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, a
 ///
 /// # Errors
 ///
-/// * [`FungibleTokenError::InsufficientBalance`] - When attempting to transfer
-///   more tokens than `from` current balance.
+/// * refer to [`update`] errors.
 ///
 /// # Events
 ///
@@ -346,10 +319,9 @@ pub fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, a
 ///
 /// # Notes
 ///
-/// No authorization is required.
+/// * It is expected that the caller of this function handles the authorization.
 pub fn do_transfer(e: &Env, from: &Address, to: &Address, amount: i128) {
     update(e, Some(from), Some(to), amount);
-
     emit_transfer(e, from, to, amount);
 }
 
@@ -373,7 +345,7 @@ pub fn do_transfer(e: &Env, from: &Address, to: &Address, amount: i128) {
 ///
 /// # Notes
 ///
-/// No authorization is required.
+/// * It is expected that the caller of this function handles the authorization.
 pub fn update(e: &Env, from: Option<&Address>, to: Option<&Address>, amount: i128) {
     if amount < 0 {
         panic_with_error!(e, FungibleTokenError::LessThanZero);

--- a/contracts/token/fungible/src/storage.rs
+++ b/contracts/token/fungible/src/storage.rs
@@ -166,7 +166,8 @@ pub fn approve(e: &Env, owner: &Address, spender: &Address, amount: i128, live_u
 ///
 /// # Notes
 ///
-/// * It is expected that the caller of this function handles the authorization.
+/// * This function does not enforce authorization. Ensure that authorization
+///   is handled at a higher level.
 /// * Allowance is implicitly timebound by the maximum allowed storage TTL value
 ///   which is a network parameter, i.e. one cannot set an allowance for a
 ///   longer period. This behavior closely mirrors the functioning of the
@@ -225,7 +226,8 @@ pub fn set_allowance(
 ///
 /// # Notes
 ///
-/// * It is expected that the caller of this function handles the authorization.
+/// This function does not enforce authorization. Ensure that authorization
+/// is handled at a higher level.
 pub fn spend_allowance(e: &Env, owner: &Address, spender: &Address, amount: i128) {
     if amount < 0 {
         panic_with_error!(e, FungibleTokenError::LessThanZero)
@@ -319,7 +321,8 @@ pub fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, a
 ///
 /// # Notes
 ///
-/// * It is expected that the caller of this function handles the authorization.
+/// This function does not enforce authorization. Ensure that authorization
+/// is handled at a higher level.
 pub fn do_transfer(e: &Env, from: &Address, to: &Address, amount: i128) {
     update(e, Some(from), Some(to), amount);
     emit_transfer(e, from, to, amount);
@@ -345,7 +348,8 @@ pub fn do_transfer(e: &Env, from: &Address, to: &Address, amount: i128) {
 ///
 /// # Notes
 ///
-/// * It is expected that the caller of this function handles the authorization.
+/// This function does not enforce authorization. Ensure that authorization
+/// is handled at a higher level.
 pub fn update(e: &Env, from: Option<&Address>, to: Option<&Address>, amount: i128) {
     if amount < 0 {
         panic_with_error!(e, FungibleTokenError::LessThanZero);

--- a/contracts/token/fungible/src/storage.rs
+++ b/contracts/token/fungible/src/storage.rs
@@ -166,8 +166,8 @@ pub fn approve(e: &Env, owner: &Address, spender: &Address, amount: i128, live_u
 ///
 /// # Notes
 ///
-/// * This function does not enforce authorization. Ensure that authorization
-///   is handled at a higher level.
+/// * This function does not enforce authorization. Ensure that authorization is
+///   handled at a higher level.
 /// * Allowance is implicitly timebound by the maximum allowed storage TTL value
 ///   which is a network parameter, i.e. one cannot set an allowance for a
 ///   longer period. This behavior closely mirrors the functioning of the

--- a/contracts/token/fungible/src/test.rs
+++ b/contracts/token/fungible/src/test.rs
@@ -173,7 +173,7 @@ fn set_allowance_with_expired_ledger_fails() {
 
     e.as_contract(&address, || {
         e.ledger().set_sequence_number(10);
-        set_allowance(&e, &owner, &spender, 50, 5, true);
+        set_allowance(&e, &owner, &spender, 50, 5);
     });
 }
 
@@ -187,7 +187,7 @@ fn set_allowance_with_greater_than_max_ledger_fails() {
 
     e.as_contract(&address, || {
         let ttl = e.storage().max_ttl() + 1;
-        set_allowance(&e, &owner, &spender, 50, ttl, true);
+        set_allowance(&e, &owner, &spender, 50, ttl);
     });
 }
 
@@ -200,7 +200,7 @@ fn set_allowance_with_neg_amount_fails() {
     let spender = Address::generate(&e);
 
     e.as_contract(&address, || {
-        set_allowance(&e, &owner, &spender, -1, 5, true);
+        set_allowance(&e, &owner, &spender, -1, 5);
     });
 }
 
@@ -213,13 +213,13 @@ fn set_allowance_with_zero_amount() {
     let spender = Address::generate(&e);
 
     e.as_contract(&address, || {
-        set_allowance(&e, &owner, &spender, 0, 5, false);
+        set_allowance(&e, &owner, &spender, 0, 5);
         let allowance_val = allowance(&e, &owner, &spender);
         assert_eq!(allowance_val, 0);
 
         // should pass for a past ledger
         e.ledger().set_sequence_number(10);
-        set_allowance(&e, &owner2, &spender, 0, 5, false);
+        set_allowance(&e, &owner2, &spender, 0, 5);
         let allowance_val = allowance(&e, &owner2, &spender);
         assert_eq!(allowance_val, 0);
     });

--- a/contracts/utils/pausable-macros/src/helper.rs
+++ b/contracts/utils/pausable-macros/src/helper.rs
@@ -39,8 +39,9 @@ fn check_env_arg(input_fn: &ItemFn) -> (syn::Ident, bool) {
     // Extract the pattern and type from the argument
     let (pat, ty) = match first_arg {
         FnArg::Typed(PatType { pat, ty, .. }) => (pat, ty),
-        _ =>
-            panic!("first argument of function '{}' must be a typed parameter", input_fn.sig.ident),
+        _ => {
+            panic!("first argument of function '{}' must be a typed parameter", input_fn.sig.ident)
+        }
     };
 
     // Get the identifier from the pattern

--- a/contracts/utils/pausable/src/storage.rs
+++ b/contracts/utils/pausable/src/storage.rs
@@ -28,8 +28,7 @@ pub fn paused(e: &Env) -> bool {
 ///
 /// # Errors
 ///
-/// * [`PausableError::EnforcedPause`] - Occurs when the contract is already in
-///   `Paused` state.
+/// * refer to [`when_not_paused`] errors.
 ///
 /// # Events
 ///
@@ -55,8 +54,7 @@ pub fn pause(e: &Env, caller: &Address) {
 ///
 /// # Errors
 ///
-/// * [`PausableError::ExpectedPause`] - Occurs when the contract is already in
-///   `Unpaused` state.
+/// * refer to [`when_paused`] errors.
 ///
 /// # Events
 ///
@@ -83,10 +81,6 @@ pub fn unpause(e: &Env, caller: &Address) {
 ///
 /// * [`PausableError::EnforcedPause`] - Occurs when the contract is already in
 ///   `Paused` state.
-///
-/// # Notes
-///
-/// No authorization is required.
 pub fn when_not_paused(e: &Env) {
     if paused(e) {
         panic_with_error!(e, PausableError::EnforcedPause);
@@ -103,10 +97,6 @@ pub fn when_not_paused(e: &Env) {
 ///
 /// * [`PausableError::ExpectedPause`] - Occurs when the contract is already in
 ///   `Unpaused` state.
-///
-/// # Notes
-///
-/// No authorization is required.
 pub fn when_paused(e: &Env) {
     if !paused(e) {
         panic_with_error!(e, PausableError::ExpectedPause);


### PR DESCRIPTION
Fixes #86 

Also, whilst standardizing events and errors, I've noticed something and tinkered with it. 

`set_allowance()` function is taking a flag as a parameter on whether to emit an event or not. 

I've followed the every path to `set_allowance()`, and noticed the this flag is only set to true (event is emitted) when it is called by the `approve()` function. 

I believe `set_allowance` is there to provide the low-level logic for setting the allowance. And `approve()` function is the high-level one, which should be responsible from:
- authorization
- event emission

So, I moved the event responsibility to `approve()` function, and the code logic became simpler and shorter as well in return. 

@brozorec please let me know if this change will have a downside that I didn't think of yet.