### PR TITLE
netlify antora docs preview setup

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+base = "docs/"
+command = "npm run docs"
+publish = "build/site"


### PR DESCRIPTION
Closes #92 

`netlify.toml` file is there for convenience, one can set the netlify website by entering those info manually. 

I've (hopefully) setup the netlify website correctly, so we should see the preview here.