### PR TITLE
fix: make event_assert crate handle multiple events in sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ OpenZeppelin Stellar Soroban Contracts is a collection of contracts for the Stel
 - `docs/`: Documentation
 - `audits/`: Audit reports
 
+
 ## Docs
 We have a [documentation website](https://docs.openzeppelin.com/stellar-contracts/) explaining the high-level concepts of the library. You can find code-specific inline documentation in the source code, or alternatively you can locally generate the documentation using the `cargo doc --no-deps --lib --open` command, which will generate the documentation and open it using your default browser.
 
@@ -25,18 +26,45 @@ We have a [documentation website](https://docs.openzeppelin.com/stellar-contract
 Stellar smart contracts are programs written in Rust leveraging the [Soroban SDK](https://crates.io/crates/soroban-sdk). Please, follow the setup process as outlined in the [Stellar documentation](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup).
 
 
-## Usage
+## How To Test/Play With Example Contracts
+The below section is based on [Official Stellar Docs](https://developers.stellar.org/docs/build/smart-contracts/getting-started/hello-world). If you are stuck on any of the steps below, or want to dive in deeper, please refer to the official documentation.
 
-The library has not been published yet to `crates.io`, and this will be the case until we reach a stable version. However, one can [specify a git dependency](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) in a `Cargo.toml`, like so:
+We provide a set of example contracts that demonstrate how to use the library. You can find them in the `examples/` directory. If you want to deploy the example contracts to the testnet and play with them, you can follow the instructions below:
+1. `git clone https://github.com/OpenZeppelin/stellar-contracts.git`
+2. `cd stellar-contracts/examples`
+3. Take a look at the current folder, and select an example contract you are interested in. We will go with the `fungible-pausable` in this guide.
+4. `cd fungible-pausable`
+5. `cargo build --target wasm32-unknown-unknown --release`
+6. Now, the `target/wasm32-unknown-unknown/release/` directory will contain the compiled contracts. In this case, `target/wasm32-unknown-unknown/release/fungible_pausable_example.wasm` is the compiled wasm file.
+7. Deploying to the testnet is no different than any other contract. You can follow the instructions in the [Stellar documentation](https://developers.stellar.org/docs/build/smart-contracts/getting-started/deploy-to-testnet).
 
+
+## How To Use This Library As A Dependency
+
+The library has not been published yet to `crates.io`, and this will be the case until we reach a stable version. However, one can [specify a git dependency](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) in a `Cargo.toml`. We also recommend pinning to a specific commit/tag, because rapid iterations are expected as the library is in an active development phase, like so for:
+
+- **v0.1.0 (audited)**
 ```toml
 [dependencies]
-stellar-pausable = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
-stellar-fungible = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+openzeppelin-pausable = { git = "https://github.com/OpenZeppelin/stellar-contracts", tag = "v0.1.0" }
+openzeppelin-pausable-macros = { git = "https://github.com/OpenZeppelin/stellar-contracts", tag = "v0.1.0" }
+openzeppelin-fungible-token = { git = "https://github.com/OpenZeppelin/stellar-contracts", tag = "v0.1.0" }
 ```
 
-We recommend pinning to a specific version, because rapid iterations are expected as the library is in an active development phase.
+- **latest**
+```toml
+[dependencies]
+stellar-constants = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-default-impl-macro = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-event-assertion = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-fungible = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-non-fungible = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-pausable = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-pausable-macros = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-upgradeable = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
+stellar-upgradeable-macros = { git = "https://github.com/OpenZeppelin/stellar-contracts" }
 
+```
 
 ## Security
 

--- a/packages/test-utils/event-assertion/src/lib.rs
+++ b/packages/test-utils/event-assertion/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use soroban_sdk::{symbol_short, testutils::Events, Address, Env, IntoVal, Symbol, Val, Vec};
 use std::collections::HashSet;
+
+use soroban_sdk::{symbol_short, testutils::Events, Address, Env, IntoVal, Symbol, Val, Vec};
 use stellar_non_fungible::TokenId;
 
 pub struct EventAssertion<'a> {
@@ -72,7 +73,12 @@ impl<'a> EventAssertion<'a> {
         assert_eq!(event_amount, amount, "Transfer event has wrong amount");
     }
 
-    pub fn assert_non_fungible_transfer(&mut self, from: &Address, to: &Address, token_id: TokenId) {
+    pub fn assert_non_fungible_transfer(
+        &mut self,
+        from: &Address,
+        to: &Address,
+        token_id: TokenId,
+    ) {
         let transfer_event = self.find_event_by_symbol("transfer");
 
         assert!(transfer_event.is_some(), "Transfer event not found in event log");

--- a/packages/test-utils/event-assertion/src/lib.rs
+++ b/packages/test-utils/event-assertion/src/lib.rs
@@ -43,7 +43,7 @@ impl<'a> EventAssertion<'a> {
 
                 if topic_symbol == target_symbol {
                     self.processed_events.insert(index_u32);
-                    return Some((contract.clone(), topics_clone, data.clone()));
+                    return Some((contract.clone(), topics_clone, data));
                 }
             }
         }

--- a/packages/tokens/fungible/src/extensions/burnable/test.rs
+++ b/packages/tokens/fungible/src/extensions/burnable/test.rs
@@ -28,7 +28,7 @@ fn burn_works() {
         assert_eq!(balance(&e, &account), 50);
         assert_eq!(total_supply(&e), 50);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_fungible_mint(&account, 100);
         event_assert.assert_fungible_burn(&account, 50);
@@ -50,7 +50,7 @@ fn burn_with_allowance_works() {
         assert_eq!(balance(&e, &spender), 0);
         assert_eq!(total_supply(&e), 70);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_fungible_mint(&owner, 100);
         event_assert.assert_fungible_approve(&owner, &spender, 30, 1000);

--- a/packages/tokens/fungible/src/extensions/mintable/test.rs
+++ b/packages/tokens/fungible/src/extensions/mintable/test.rs
@@ -24,7 +24,7 @@ fn mint_works() {
         assert_eq!(balance(&e, &account), 100);
         assert_eq!(total_supply(&e), 100);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(1);
         event_assert.assert_fungible_mint(&account, 100);
     });

--- a/packages/tokens/fungible/src/test.rs
+++ b/packages/tokens/fungible/src/test.rs
@@ -238,7 +238,7 @@ fn transfer_works() {
         assert_eq!(balance(&e, &from), 50);
         assert_eq!(balance(&e, &recipient), 50);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_fungible_mint(&from, 100);
         event_assert.assert_fungible_transfer(&from, &recipient, 50);
@@ -309,7 +309,7 @@ fn approve_and_transfer_from() {
         let updated_allowance = allowance(&e, &owner, &spender);
         assert_eq!(updated_allowance, 20);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_fungible_mint(&owner, 100);
         event_assert.assert_fungible_approve(&owner, &spender, 50, 1000);

--- a/packages/tokens/non-fungible/src/extensions/burnable/test.rs
+++ b/packages/tokens/non-fungible/src/extensions/burnable/test.rs
@@ -24,7 +24,7 @@ fn burn_works() {
 
         assert!(Base::balance(&e, &owner) == 0);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_non_fungible_burn(&owner, token_id);
@@ -47,7 +47,7 @@ fn burn_from_with_approve_works() {
 
         assert!(Base::balance(&e, &owner) == 0);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_non_fungible_approve(&owner, &spender, token_id, 1000);
@@ -72,7 +72,7 @@ fn burn_from_with_operator_works() {
 
         assert!(Base::balance(&e, &owner) == 0);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_approve_for_all(&owner, &operator, 1000);
@@ -94,7 +94,7 @@ fn burn_from_with_owner_works() {
 
         assert!(Base::balance(&e, &owner) == 0);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_non_fungible_burn(&owner, token_id);

--- a/packages/tokens/non-fungible/src/extensions/consecutive/test.rs
+++ b/packages/tokens/non-fungible/src/extensions/consecutive/test.rs
@@ -25,7 +25,7 @@ fn consecutive_batch_mint_works() {
     e.as_contract(&address, || {
         Consecutive::batch_mint(&e, &owner, amount);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(1);
         event_assert.assert_consecutive_mint(&owner, 0, 99);
 
@@ -94,7 +94,7 @@ fn consecutive_transfer_works() {
         let _owner = e.storage().persistent().get::<_, Address>(&StorageKey::Owner(51)).unwrap();
         assert_eq!(_owner, owner);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_consecutive_mint(&owner, 0, 99);
         event_assert.assert_non_fungible_transfer(&owner, &recipient, 50);
@@ -114,7 +114,7 @@ fn consecutive_transfer_edge_works() {
     e.as_contract(&address, || {
         Consecutive::batch_mint(&e, &owner, amount);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(1);
         event_assert.assert_consecutive_mint(&owner, 0, 99);
 
@@ -154,7 +154,7 @@ fn consecutive_transfer_from_works() {
 
         assert_eq!(Consecutive::owner_of(&e, token_id + 1), owner);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_consecutive_mint(&owner, 0, 99);
         event_assert.assert_non_fungible_approve(&owner, &spender, token_id, 100);
@@ -185,7 +185,7 @@ fn consecutive_burn_works() {
             e.storage().persistent().get::<_, Address>(&StorageKey::Owner(token_id + 1)).unwrap();
         assert_eq!(_owner, owner);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_consecutive_mint(&owner, 0, 99);
         event_assert.assert_non_fungible_burn(&owner, token_id);
@@ -214,7 +214,7 @@ fn consecutive_burn_from_works() {
         assert!(burned);
         assert_eq!(Consecutive::owner_of(&e, token_id + 1), owner);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let  mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_consecutive_mint(&owner, 0, 99);
         event_assert.assert_non_fungible_approve(&owner, &spender, token_id, 100);

--- a/packages/tokens/non-fungible/src/extensions/consecutive/test.rs
+++ b/packages/tokens/non-fungible/src/extensions/consecutive/test.rs
@@ -214,7 +214,7 @@ fn consecutive_burn_from_works() {
         assert!(burned);
         assert_eq!(Consecutive::owner_of(&e, token_id + 1), owner);
 
-        let  mut event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_consecutive_mint(&owner, 0, 99);
         event_assert.assert_non_fungible_approve(&owner, &spender, token_id, 100);

--- a/packages/tokens/non-fungible/src/extensions/enumerable/test.rs
+++ b/packages/tokens/non-fungible/src/extensions/enumerable/test.rs
@@ -19,17 +19,14 @@ fn test_total_supply() {
 
     e.as_contract(&address, || {
         let token_id1 = Enumerable::sequential_mint(&e, &owner);
-        let _token_id2 = Enumerable::sequential_mint(&e, &owner);
+        let token_id2 = Enumerable::sequential_mint(&e, &owner);
 
         assert_eq!(Enumerable::total_supply(&e), 2);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_non_fungible_mint(&owner, token_id1);
-
-        // TODO: below fails because the same event is read by the
-        // `event_assert`, not the next one. event_assert.
-        // assert_non_fungible_mint(&owner, token_id2);
+        event_assert.assert_non_fungible_mint(&owner, token_id2);
     });
 }
 

--- a/packages/tokens/non-fungible/src/test.rs
+++ b/packages/tokens/non-fungible/src/test.rs
@@ -55,7 +55,7 @@ fn approve_for_all_works() {
         let is_approved = Base::is_approved_for_all(&e, &owner, &operator);
         assert!(is_approved);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(1);
         event_assert.assert_approve_for_all(&owner, &operator, 1000);
     });
@@ -85,7 +85,7 @@ fn revoke_approve_for_all_works() {
         let is_approved = Base::is_approved_for_all(&e, &owner, &operator);
         assert!(!is_approved);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(1);
         event_assert.assert_approve_for_all(&owner, &operator, 0);
     });
@@ -108,7 +108,7 @@ fn approve_nft_works() {
         let approved_address = Base::get_approved(&e, token_id);
         assert_eq!(approved_address, Some(approved.clone()));
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(1);
         event_assert.assert_non_fungible_approve(&owner, &approved, token_id, 1000);
     });
@@ -135,7 +135,7 @@ fn approve_with_operator_works() {
         let approved_address = Base::get_approved(&e, token_id);
         assert_eq!(approved_address, Some(approved.clone()));
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_approve_for_all(&owner, &operator, 1000);
         event_assert.assert_non_fungible_approve(&operator, &approved, token_id, 1000);
@@ -159,7 +159,7 @@ fn transfer_nft_works() {
         assert_eq!(Base::balance(&e, &recipient), 1);
         assert_eq!(Base::owner_of(&e, token_id), recipient);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_non_fungible_transfer(&owner, &recipient, token_id);
@@ -188,7 +188,7 @@ fn transfer_from_nft_approved_works() {
         assert_eq!(Base::balance(&e, &recipient), 1);
         assert_eq!(Base::owner_of(&e, token_id), recipient);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_non_fungible_approve(&owner, &spender, token_id, 1000);
@@ -218,7 +218,7 @@ fn transfer_from_nft_operator_works() {
         assert_eq!(Base::balance(&e, &recipient), 1);
         assert_eq!(Base::owner_of(&e, token_id), recipient);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(3);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_approve_for_all(&owner, &spender, 1000);
@@ -244,7 +244,7 @@ fn transfer_from_nft_owner_works() {
         assert_eq!(Base::balance(&e, &recipient), 1);
         assert_eq!(Base::owner_of(&e, token_id), recipient);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_non_fungible_mint(&owner, token_id);
         event_assert.assert_non_fungible_transfer(&owner, &recipient, token_id);
@@ -420,7 +420,7 @@ fn mint_works() {
         let token_id = Base::sequential_mint(&e, &account);
         assert_eq!(Base::balance(&e, &account), 1);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(1);
         event_assert.assert_non_fungible_mint(&account, token_id);
     });
@@ -437,7 +437,7 @@ fn test_counter_works() {
         let token_id1 = Base::sequential_mint(&e, &owner);
         let _token_id2 = Base::sequential_mint(&e, &owner);
 
-        let event_assert = EventAssertion::new(&e, address.clone());
+        let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_non_fungible_mint(&owner, token_id1);
 

--- a/packages/tokens/non-fungible/src/test.rs
+++ b/packages/tokens/non-fungible/src/test.rs
@@ -435,15 +435,12 @@ fn test_counter_works() {
 
     e.as_contract(&address, || {
         let token_id1 = Base::sequential_mint(&e, &owner);
-        let _token_id2 = Base::sequential_mint(&e, &owner);
+        let token_id2 = Base::sequential_mint(&e, &owner);
 
         let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_non_fungible_mint(&owner, token_id1);
-
-        // TODO: below fails because the same event is read by the
-        // `event_assert`, not the next one. event_assert.
-        // assert_non_fungible_mint(&owner, token_id2);
+        event_assert.assert_non_fungible_mint(&owner, token_id2);
     });
 }
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #123 
<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This PR changes how the `find_event_by_symbol` from `EventAssertion` handles multiple events in sequence. To achieve this, we introduced a `HashSet` called `processed_events` to keep track of the indices of the events that have already been read.

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [ ] Tests
- [ ] Documentation

