### PR TITLE
updates a broken internal cross-reference link in the nft-consecutive.adoc file

### DIFF
--- a/docs/modules/ROOT/pages/tokens/nft-consecutive.adoc
+++ b/docs/modules/ROOT/pages/tokens/nft-consecutive.adoc
@@ -5,7 +5,7 @@
 
 https://github.com/OpenZeppelin/stellar-contracts/tree/main/packages/tokens/non-fungible/src/extensions/consecutive[Source Code]
 
-Consecutive extension for xref:tokens/non-fungible.adoc[Non-Fungible Token] is useful
+Consecutive extension for xref:non-fungible.adoc[Non-Fungible Token] is useful
 for efficiently minting multiple tokens in a single transaction. This can significantly
 reduce costs and improve performance when creating a large number of tokens at once.
 


### PR DESCRIPTION
The original xref:tokens/non-fungible.adoc link returned a 404 error because the file path was already within the tokens directory. The corrected xref:non-fungible.adoc link uses the relative path and now works as expected in the documentation build system.



