### PR TITLE
Add access control to Upgrader example #192

### DIFF
--- a/examples/upgradeable/upgrader/src/contract.rs
+++ b/examples/upgradeable/upgrader/src/contract.rs
@@ -5,15 +5,70 @@ use stellar_upgradeable::UpgradeableClient;
 
 pub const MIGRATE: Symbol = symbol_short!("migrate");
 pub const ROLLBACK: Symbol = symbol_short!("rollback");
+pub const ADMIN: Symbol = symbol_short!("ADMIN");
 
 #[contract]
 pub struct Upgrader;
 
 #[contractimpl]
 impl Upgrader {
-    pub fn upgrade(env: Env, contract_address: Address, operator: Address, wasm_hash: BytesN<32>) {
-        let contract_client = UpgradeableClient::new(&env, &contract_address);
+    /// Initialize the contract with an admin address that will have the authority to perform upgrades
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&ADMIN) {
+            panic!("contract already initialized");
+        }
+        env.storage().instance().set(&ADMIN, &admin);
+    }
 
+    /// Updates the admin address
+    /// 
+    /// # Arguments
+    /// 
+    /// * `env` - The Soroban environment
+    /// * `current_admin` - The current admin address (must be authenticated)
+    /// * `new_admin` - The new admin address
+    pub fn set_admin(env: Env, current_admin: Address, new_admin: Address) {
+        // Verify the current admin is calling this function
+        current_admin.require_auth();
+        
+        // Verify current_admin is actually the admin
+        let stored_admin: Address = env.storage().instance().get(&ADMIN).unwrap_or_else(|| {
+            panic!("contract not initialized");
+        });
+        
+        if current_admin != stored_admin {
+            panic!("not authorized");
+        }
+        
+        // Update the admin
+        env.storage().instance().set(&ADMIN, &new_admin);
+    }
+    
+    /// Get the current admin address
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&ADMIN).unwrap_or_else(|| {
+            panic!("contract not initialized");
+        })
+    }
+
+    /// Ensure the operator is authorized to perform upgrade operations
+    fn check_authorization(env: &Env, operator: &Address) {
+        operator.require_auth();
+        
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap_or_else(|| {
+            panic!("contract not initialized");
+        });
+        
+        if *operator != admin {
+            panic!("not authorized");
+        }
+    }
+
+    pub fn upgrade(env: Env, contract_address: Address, operator: Address, wasm_hash: BytesN<32>) {
+        // Verify the operator is authorized
+        Self::check_authorization(&env, &operator);
+        
+        let contract_client = UpgradeableClient::new(&env, &contract_address);
         contract_client.upgrade(&wasm_hash, &operator);
     }
 
@@ -24,8 +79,10 @@ impl Upgrader {
         wasm_hash: BytesN<32>,
         migration_data: soroban_sdk::Vec<Val>,
     ) {
+        // Verify the operator is authorized
+        Self::check_authorization(&env, &operator);
+        
         let contract_client = UpgradeableClient::new(&env, &contract_address);
-
         contract_client.upgrade(&wasm_hash, &operator);
         // The types of the arguments to the migrate function are unknown to this
         // contract, so we need to call it with invoke_contract.
@@ -39,8 +96,10 @@ impl Upgrader {
         wasm_hash: BytesN<32>,
         rollback_data: soroban_sdk::Vec<Val>,
     ) {
+        // Verify the operator is authorized
+        Self::check_authorization(&env, &operator);
+        
         let contract_client = UpgradeableClient::new(&env, &contract_address);
-
         // The types of the arguments to the rollback function are unknown to this
         // contract, so we need to call it with invoke_contract.
         env.invoke_contract::<()>(&contract_address, &ROLLBACK, rollback_data);

--- a/examples/upgradeable/upgrader/src/test.rs
+++ b/examples/upgradeable/upgrader/src/test.rs
@@ -38,6 +38,12 @@ fn test_upgrade_with_upgrader() {
 
     let upgrader = env.register(Upgrader, ());
     let upgrader_client = UpgraderClient::new(&env, &upgrader);
+    
+    // Initialize the upgrader with an admin
+    upgrader_client.initialize(&admin);
+    
+    // Verify the admin was set correctly
+    assert_eq!(upgrader_client.get_admin(), admin);
 
     let new_wasm_hash = install_new_wasm(&env);
     let data = Data { num1: 12, num2: 34 };
@@ -63,4 +69,89 @@ fn test_upgrade_with_upgrader() {
 
     assert!(client_v2.try_rollback(&()).is_err());
     assert!(client_v2.try_migrate(&data).is_err());
+}
+
+#[test]
+fn test_admin_transfer_successful() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let initial_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    let upgrader = env.register(Upgrader, ());
+    let upgrader_client = UpgraderClient::new(&env, &upgrader);
+    
+    // Initialize the upgrader with an admin
+    upgrader_client.initialize(&initial_admin);
+    
+    // Verify initial admin was set correctly
+    assert_eq!(upgrader_client.get_admin(), initial_admin);
+    
+    // Transfer admin rights
+    upgrader_client.set_admin(&initial_admin, &new_admin);
+    
+    // Verify the admin was updated
+    assert_eq!(upgrader_client.get_admin(), new_admin);
+    
+    // New admin should be able to perform admin actions
+    let another_admin = Address::generate(&env);
+    upgrader_client.set_admin(&new_admin, &another_admin);
+    
+    // Verify the admin was updated again
+    assert_eq!(upgrader_client.get_admin(), another_admin);
+}
+
+#[test]
+#[should_panic(expected = "not authorized")]
+fn test_upgrade_with_upgrader_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+    let contract_id = env.register(contract_v1::WASM, (&admin,));
+
+    let upgrader = env.register(Upgrader, ());
+    let upgrader_client = UpgraderClient::new(&env, &upgrader);
+    
+    // Initialize the upgrader with an admin
+    upgrader_client.initialize(&admin);
+    
+    let new_wasm_hash = install_new_wasm(&env);
+    
+    // This should panic with "not authorized"
+    upgrader_client.upgrade(
+        &contract_id,
+        &not_admin,
+        &new_wasm_hash,
+    );
+}
+
+#[test]
+#[should_panic(expected = "not authorized")]
+fn test_admin_transfer_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let initial_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    let upgrader = env.register(Upgrader, ());
+    let upgrader_client = UpgraderClient::new(&env, &upgrader);
+    
+    // Initialize the upgrader with an admin
+    upgrader_client.initialize(&initial_admin);
+    
+    // Verify initial admin was set correctly
+    assert_eq!(upgrader_client.get_admin(), initial_admin);
+    
+    // Transfer admin rights
+    upgrader_client.set_admin(&initial_admin, &new_admin);
+    
+    // Verify the admin was updated
+    assert_eq!(upgrader_client.get_admin(), new_admin);
+    
+    // Try to set admin using the old admin (should panic with "not authorized")
+    upgrader_client.set_admin(&initial_admin, &initial_admin);
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #192

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This PR adds access control to the Upgrader example contract to ensure that only authorized administrators can perform upgrade operations. The changes include:

1. Implemented an admin mechanism with storage for admin address
2. Added initialize() function to set the initial admin
3. Added get_admin() and set_admin() functions for admin management
4. Added authorization checks for all upgrade operations (upgrade, upgrade_and_migrate, rollback_and_upgrade)
5. Updated tests to verify access control functionality

This prevents unauthorized users from performing upgrades, adding an essential security feature to the example.

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation