### PR TITLE
Access control is admin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ version = "0.2.0"
 dependencies = [
  "soroban-sdk",
  "stellar-access-control",
- "stellar-access-control-macro",
+ "stellar-access-control-macros",
  "stellar-default-impl-macro",
  "stellar-non-fungible",
 ]
@@ -1361,7 +1361,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-access-control-macro"
+name = "stellar-access-control-macros"
 version = "0.2.0"
 dependencies = [
  "proc-macro2",
@@ -1392,7 +1392,7 @@ version = "0.2.0"
 dependencies = [
  "soroban-sdk",
  "stellar-access-control",
- "stellar-access-control-macro",
+ "stellar-access-control-macros",
  "stellar-default-impl-macro",
  "stellar-event-assertion",
  "stellar-fungible",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ syn = { version = "2.0", features = ["full"] }
 
 # members
 stellar-access-control = { path = "packages/access/access-control" }
-stellar-access-control-macro = { path = "packages/access/access-control-macro" }
+stellar-access-control-macros = { path = "packages/access/access-control-macros" }
 stellar-constants = { path = "packages/constants" }
 stellar-default-impl-macro = { path = "packages/contract-utils/default-impl-macro" }
 stellar-event-assertion = { path = "packages/test-utils/event-assertion" }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 ignore:
-  - "packages/contract-utils/access-control-macro"
+  - "packages/contract-utils/access-control-macros"
   - "packages/contract-utils/ownable-macro"
   - "packages/contract-utils/macro-helpers"
   - "packages/tokens/fungible/src/impl_token_interface_macro.rs"

--- a/examples/nft-access-control/Cargo.toml
+++ b/examples/nft-access-control/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 stellar-access-control = { workspace = true }
-stellar-access-control-macro = { workspace = true }
+stellar-access-control-macros = { workspace = true }
 stellar-default-impl-macro = { workspace = true }
 stellar-non-fungible = { workspace = true }
 

--- a/examples/nft-access-control/src/contract.rs
+++ b/examples/nft-access-control/src/contract.rs
@@ -2,9 +2,9 @@
 //!
 //! Demonstrates how can Access Control be utilized.
 
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, vec, Address, Env, String, Vec};
 use stellar_access_control::{set_admin, AccessControl};
-use stellar_access_control_macro::has_role;
+use stellar_access_control_macro::{has_role, only_admin};
 use stellar_default_impl_macro::default_impl;
 use stellar_non_fungible::{burnable::NonFungibleBurnable, Base, NonFungibleToken};
 
@@ -21,6 +21,11 @@ impl ExampleContract {
             String::from_str(e, "My Token"),
             String::from_str(e, "TKN"),
         );
+    }
+
+    #[only_admin]
+    pub fn admin_restricted_function(e: &Env) -> Vec<String> {
+        vec![&e, String::from_str(&e, "seems sus")]
     }
 
     #[has_role(caller, "minter")]

--- a/examples/nft-access-control/src/contract.rs
+++ b/examples/nft-access-control/src/contract.rs
@@ -4,7 +4,7 @@
 
 use soroban_sdk::{contract, contractimpl, vec, Address, Env, String, Vec};
 use stellar_access_control::{set_admin, AccessControl};
-use stellar_access_control_macro::{has_role, only_admin};
+use stellar_access_control_macros::{has_role, only_admin};
 use stellar_default_impl_macro::default_impl;
 use stellar_non_fungible::{burnable::NonFungibleBurnable, Base, NonFungibleToken};
 

--- a/examples/nft-access-control/src/contract.rs
+++ b/examples/nft-access-control/src/contract.rs
@@ -25,7 +25,7 @@ impl ExampleContract {
 
     #[only_admin]
     pub fn admin_restricted_function(e: &Env) -> Vec<String> {
-        vec![&e, String::from_str(&e, "seems sus")]
+        vec![&e, String::from_str(e, "seems sus")]
     }
 
     #[has_role(caller, "minter")]

--- a/examples/nft-access-control/src/test.rs
+++ b/examples/nft-access-control/src/test.rs
@@ -5,7 +5,7 @@ extern crate std;
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
-    Address, Env, IntoVal, Symbol,
+    vec, Address, Env, IntoVal, String, Symbol,
 };
 
 use crate::contract::{ExampleContract, ExampleContractClient};
@@ -405,4 +405,45 @@ fn non_admin_cannot_set_role_admin() {
 
     // Non-admin attempts to set a role admin
     client.set_role_admin(&Symbol::new(&e, "minter"), &Symbol::new(&e, "minter_admin"));
+}
+
+#[test]
+fn admin_can_call_admin_restricted_function() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let client = create_client(&e, &admin);
+
+    e.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "admin_restricted_function",
+            args: ().into_val(&e),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let secret = client.admin_restricted_function();
+    assert_eq!(secret, vec![&e, String::from_str(&e, "seems sus")]);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn non_admin_cannot_call_admin_restricted_function() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let non_admin = Address::generate(&e);
+    let client = create_client(&e, &admin);
+
+    e.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "admin_restricted_function",
+            args: ().into_val(&e),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let _ = client.admin_restricted_function();
 }

--- a/examples/nft-access-control/test_snapshots/test/admin_can_call_admin_restricted_function.1.json
+++ b/examples/nft-access-control/test_snapshots/test/admin_can_call_admin_restricted_function.1.json
@@ -1,0 +1,206 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 1
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "function_name": "admin_restricted_function",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Metadata"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "base_uri"
+                              },
+                              "val": {
+                                "string": "www.mytoken.com"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "My Token"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "TKN"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/examples/nft-access-control/test_snapshots/test/non_admin_cannot_call_admin_restricted_function.1.json
+++ b/examples/nft-access-control/test_snapshots/test/non_admin_cannot_call_admin_restricted_function.1.json
@@ -1,0 +1,159 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 1
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Metadata"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "base_uri"
+                              },
+                              "val": {
+                                "string": "www.mytoken.com"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "My Token"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "TKN"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/packages/access/access-control-macros/Cargo.toml
+++ b/packages/access/access-control-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stellar-access-control-macro"
+name = "stellar-access-control-macros"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/packages/access/access-control-macros/src/lib.rs
+++ b/packages/access/access-control-macros/src/lib.rs
@@ -6,26 +6,6 @@ use syn::{
     parse_macro_input, FnArg, Ident, ItemFn, LitStr, Pat, Token, Type,
 };
 
-/// A procedural macro that ensures the parameter has the specified role.
-///
-/// # Usage
-///
-/// ```rust
-/// #[has_role(account, "minter")]
-/// pub fn mint_tokens(e: &Env, amount: u32, account: Address) {
-///     // Function body
-/// }
-/// ```
-///
-/// This will expand to:
-///
-/// ```rust
-/// pub fn mint_tokens(e: &Env, amount: u32, account: Address) {
-///     stellar_access_control::ensure_role(e, &account, &soroban_sdk::Symbol::new(e, "minter"));
-///     // Function body
-/// }
-/// ```
-
 /// A procedural macro that ensures the caller is the admin before executing the
 /// function.
 ///
@@ -60,6 +40,25 @@ pub fn only_admin(_attrs: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
+/// A procedural macro that ensures the parameter has the specified role.
+///
+/// # Usage
+///
+/// ```rust
+/// #[has_role(account, "minter")]
+/// pub fn mint_tokens(e: &Env, amount: u32, account: Address) {
+///     // Function body
+/// }
+/// ```
+///
+/// This will expand to:
+///
+/// ```rust
+/// pub fn mint_tokens(e: &Env, amount: u32, account: Address) {
+///     stellar_access_control::ensure_role(e, &account, &soroban_sdk::Symbol::new(e, "minter"));
+///     // Function body
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn has_role(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as HasRoleArgs);

--- a/packages/access/access-control/src/lib.rs
+++ b/packages/access/access-control/src/lib.rs
@@ -85,11 +85,11 @@ pub use crate::{
         emit_role_granted, emit_role_revoked, AccessControl, AccessControlError,
     },
     storage::{
-        accept_admin_transfer, add_to_role_enumeration, enforce_admin_auth, ensure_if_admin_or_admin_role, ensure_role,
-        get_admin, get_role_admin, get_role_member, get_role_member_count, grant_role,
-        grant_role_without_auth, has_role, remove_from_role_enumeration, renounce_role,
-        revoke_role, set_admin, set_role_admin, set_role_admin_without_auth, transfer_admin_role,
-        AccessControlStorageKey,
+        accept_admin_transfer, add_to_role_enumeration, enforce_admin_auth,
+        ensure_if_admin_or_admin_role, ensure_role, get_admin, get_role_admin, get_role_member,
+        get_role_member_count, grant_role, grant_role_without_auth, has_role,
+        remove_from_role_enumeration, renounce_role, revoke_role, set_admin, set_role_admin,
+        set_role_admin_without_auth, transfer_admin_role, AccessControlStorageKey,
     },
 };
 

--- a/packages/access/access-control/src/lib.rs
+++ b/packages/access/access-control/src/lib.rs
@@ -85,9 +85,10 @@ pub use crate::{
         emit_role_granted, emit_role_revoked, AccessControl, AccessControlError,
     },
     storage::{
-        accept_admin_transfer, add_to_role_enumeration, ensure_role, get_admin, get_role_admin,
-        get_role_member, get_role_member_count, grant_role, has_role, remove_from_role_enumeration,
-        renounce_role, revoke_role, set_admin, set_role_admin, transfer_admin_role,
+        accept_admin_transfer, add_to_role_enumeration, ensure_if_admin_or_admin_role, ensure_role,
+        get_admin, get_role_admin, get_role_member, get_role_member_count, grant_role,
+        grant_role_without_auth, has_role, remove_from_role_enumeration, renounce_role,
+        revoke_role, set_admin, set_role_admin, set_role_admin_without_auth, transfer_admin_role,
         AccessControlStorageKey,
     },
 };

--- a/packages/access/access-control/src/lib.rs
+++ b/packages/access/access-control/src/lib.rs
@@ -85,7 +85,7 @@ pub use crate::{
         emit_role_granted, emit_role_revoked, AccessControl, AccessControlError,
     },
     storage::{
-        accept_admin_transfer, add_to_role_enumeration, ensure_if_admin_or_admin_role, ensure_role,
+        accept_admin_transfer, add_to_role_enumeration, enforce_admin_auth, ensure_if_admin_or_admin_role, ensure_role,
         get_admin, get_role_admin, get_role_member, get_role_member_count, grant_role,
         grant_role_without_auth, has_role, remove_from_role_enumeration, renounce_role,
         revoke_role, set_admin, set_role_admin, set_role_admin_without_auth, transfer_admin_role,

--- a/packages/access/access-control/src/storage.rs
+++ b/packages/access/access-control/src/storage.rs
@@ -27,6 +27,27 @@ pub enum AccessControlStorageKey {
 
 // ################## QUERY STATE ##################
 
+/// Enforces that the caller is the admin and returns the admin address.
+/// This function retrieves the admin from storage, requires authorization,
+/// and returns the admin address.
+///
+/// # Arguments
+///
+/// * `e` - Access to Soroban environment.
+///
+/// # Returns
+///
+/// The admin address if authorization is successful.
+///
+/// # Errors
+///
+/// * [`AccessControlError::AdminNotSet`] - If no admin account is set.
+pub fn enforce_admin_auth(e: &Env) -> Address {
+    let admin = get_admin(e);
+    admin.require_auth();
+    admin
+}
+
 /// Returns `Some(index)` if the account has the specified role,
 /// where `index` is the position of the account for that role,
 /// and can be used to query [`get_role_member`].

--- a/packages/access/access-control/src/storage.rs
+++ b/packages/access/access-control/src/storage.rs
@@ -235,12 +235,13 @@ pub fn grant_role(e: &Env, caller: &Address, account: &Address, role: &Symbol) {
 ///
 /// # Security Warning
 ///
-/// **IMPORTANT**: This function bypasses authorization checks and should only be used:
+/// **IMPORTANT**: This function bypasses authorization checks and should only
+/// be used:
 /// - During contract initialization/construction
 /// - In admin functions that implement their own authorization logic
 ///
-/// Using this function in public-facing methods creates significant security risks
-/// as it could allow unauthorized role assignments.
+/// Using this function in public-facing methods creates significant security
+/// risks as it could allow unauthorized role assignments.
 pub fn grant_role_without_auth(e: &Env, caller: &Address, account: &Address, role: &Symbol) {
     // Return early if account already has the role
     if has_role(e, account, role).is_some() {
@@ -427,7 +428,8 @@ pub fn set_role_admin(e: &Env, role: &Symbol, admin_role: &Symbol) {
     set_role_admin_without_auth(e, role, admin_role);
 }
 
-/// Sets the admin role for a specified role without performing authorization checks.
+/// Sets the admin role for a specified role without performing authorization
+/// checks.
 ///
 /// # Arguments
 ///
@@ -442,12 +444,13 @@ pub fn set_role_admin(e: &Env, role: &Symbol, admin_role: &Symbol) {
 ///
 /// # Security Warning
 ///
-/// **IMPORTANT**: This function bypasses authorization checks and should only be used:
+/// **IMPORTANT**: This function bypasses authorization checks and should only
+/// be used:
 /// - During contract initialization/construction
 /// - In admin functions that implement their own authorization logic
 ///
-/// Using this function in public-facing methods creates significant security risks
-/// as it could allow unauthorized admin role assignments.
+/// Using this function in public-facing methods creates significant security
+/// risks as it could allow unauthorized admin role assignments.
 pub fn set_role_admin_without_auth(e: &Env, role: &Symbol, admin_role: &Symbol) {
     let key = AccessControlStorageKey::RoleAdmin(role.clone());
 

--- a/packages/access/ownable-macro/src/lib.rs
+++ b/packages/access/ownable-macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use stellar_macro_helpers::parse_env_arg;
+use stellar_macro_helpers::generate_auth_check;
 use syn::{parse_macro_input, ItemFn};
 
 /// A procedural macro that ensures the caller is the owner before executing the
@@ -32,22 +32,9 @@ use syn::{parse_macro_input, ItemFn};
 pub fn only_owner(_attrs: TokenStream, input: TokenStream) -> TokenStream {
     let input_fn = parse_macro_input!(input as ItemFn);
 
-    // Use the utility function to get the environment parameter
-    let env_param = parse_env_arg(&input_fn);
-
-    // Generate the function with the owner retrieval and authorization check
-    let fn_attrs = &input_fn.attrs;
-    let fn_vis = &input_fn.vis;
-    let fn_sig = &input_fn.sig;
-    let fn_block = &input_fn.block;
-
-    let expanded = quote! {
-        #(#fn_attrs)*
-        #fn_vis #fn_sig {
-            stellar_ownable::enforce_owner_auth(#env_param);
-            #fn_block
-        }
-    };
+    // Generate the function with the owner authorization check
+    let auth_check_path = quote! { stellar_ownable::enforce_owner_auth };
+    let expanded = generate_auth_check(&input_fn, auth_check_path);
 
     TokenStream::from(expanded)
 }

--- a/packages/contract-utils/default-impl-macro-test/Cargo.toml
+++ b/packages/contract-utils/default-impl-macro-test/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 stellar-access-control = { workspace = true }
-stellar-access-control-macro = { workspace = true }
+stellar-access-control-macros = { workspace = true }
 stellar-event-assertion = { workspace = true }
 stellar-default-impl-macro = { workspace = true }
 stellar-fungible = { workspace = true }

--- a/packages/contract-utils/default-impl-macro-test/tests/access_control.rs
+++ b/packages/contract-utils/default-impl-macro-test/tests/access_control.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, testutils::Address as _, Address, Env, String, Symbol,
 };
 use stellar_access_control::{set_admin, AccessControl};
-use stellar_access_control_macro::has_role;
+use stellar_access_control_macros::has_role;
 use stellar_default_impl_macro::default_impl;
 use stellar_fungible::FungibleToken;
 

--- a/packages/contract-utils/macro-helpers/src/lib.rs
+++ b/packages/contract-utils/macro-helpers/src/lib.rs
@@ -68,17 +68,15 @@ pub fn find_address_param(func: &ItemFn) -> Option<(proc_macro2::TokenStream, bo
             if let Pat::Ident(PatIdent { ident, .. }) = &**pat {
                 match &**ty {
                     // Check for &Address
-                    Type::Reference(TypeReference { elem, .. }) => {
+                    Type::Reference(TypeReference { elem, .. }) =>
                         if is_address_type(elem) {
                             return Some((quote! { #ident }, true));
-                        }
-                    }
+                        },
                     // Check for Address
-                    Type::Path(_) => {
+                    Type::Path(_) =>
                         if is_address_type(ty) {
                             return Some((quote! { #ident }, false));
-                        }
-                    }
+                        },
                     _ => {}
                 }
             }
@@ -98,13 +96,14 @@ fn is_address_type(ty: &Type) -> bool {
 
 /// Generates a function that enforces authorization for a specific role
 ///
-/// This function is used by macros like `only_owner` and `only_admin` to generate
-/// code that checks authorization before executing the function body.
+/// This function is used by macros like `only_owner` and `only_admin` to
+/// generate code that checks authorization before executing the function body.
 ///
 /// # Arguments
 ///
 /// * `input_fn` - The function to wrap with authorization check
-/// * `auth_check_func` - The function to be called to enforce authorization (e.g., `stellar_ownable::enforce_owner_auth`)
+/// * `auth_check_func` - The function to be called to enforce authorization
+///   (e.g., `stellar_ownable::enforce_owner_auth`)
 ///
 /// # Returns
 ///


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #227 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation

This PR, additionally:
- exports the forgotten item `ensure_if_admin_or_admin_role`, 
- adds the `non_auth` version of the functions `grant_role` and `set_admin_role` to be used in constructors