### PR TITLE
sale price type to u128

### DIFF
--- a/examples/nft-royalties/src/contract.rs
+++ b/examples/nft-royalties/src/contract.rs
@@ -49,7 +49,7 @@ impl ExampleContract {
         token_id
     }
 
-    pub fn get_royalty_info(e: &Env, token_id: u32, sale_price: u32) -> (Address, u32) {
+    pub fn get_royalty_info(e: &Env, token_id: u32, sale_price: u128) -> (Address, u128) {
         Base::royalty_info(e, token_id, sale_price)
     }
 }
@@ -78,7 +78,7 @@ impl NonFungibleRoyalties for ExampleContract {
         Base::set_token_royalty(e, token_id, &receiver, basis_points);
     }
 
-    fn royalty_info(e: &Env, token_id: u32, sale_price: u32) -> (Address, u32) {
+    fn royalty_info(e: &Env, token_id: u32, sale_price: u128) -> (Address, u128) {
         Base::royalty_info(e, token_id, sale_price)
     }
 }

--- a/examples/sac-admin-generic/test_snapshots/test/test_sac_generic.1.json
+++ b/examples/sac-admin-generic/test_snapshots/test/test_sac_generic.1.json
@@ -129,7 +129,7 @@
                           ]
                         },
                         "val": {
-                          "bytes": "4ad122a0de43b0d8062f86c8a27ea25b4ad357e00bd5e1a37d5da691fba5b36a"
+                          "bytes": "f17cc66ffefccae2fe109506de80b1738c9801ecbc0c5f5926a81a88c054d26e"
                         }
                       },
                       {
@@ -139,7 +139,7 @@
                               "symbol": "MintingLimit"
                             },
                             {
-                              "bytes": "63d651f104bedc4976ff029dd502ade784745e70340c381218cf559ff5058545"
+                              "bytes": "9ab118c4f983b5fa268ac6e96d2ce0cc3173be2b9e23ce7747e3aae863948565"
                             }
                           ]
                         },
@@ -167,7 +167,7 @@
                               "symbol": "Operator"
                             },
                             {
-                              "bytes": "63d651f104bedc4976ff029dd502ade784745e70340c381218cf559ff5058545"
+                              "bytes": "9ab118c4f983b5fa268ac6e96d2ce0cc3173be2b9e23ce7747e3aae863948565"
                             }
                           ]
                         },

--- a/packages/tokens/non-fungible/src/extensions/royalties/mod.rs
+++ b/packages/tokens/non-fungible/src/extensions/royalties/mod.rs
@@ -89,7 +89,7 @@ pub trait NonFungibleRoyalties: NonFungibleToken {
         operator: Address,
     );
 
-    /// Returns `(Address, u32)` - A tuple containing the receiver address and
+    /// Returns `(Address, u128)` - A tuple containing the receiver address and
     /// the royalty amount.
     ///
     /// # Arguments
@@ -103,7 +103,7 @@ pub trait NonFungibleRoyalties: NonFungibleToken {
     ///
     /// * [`crate::NonFungibleTokenError::NonExistentToken`] - If the token does
     ///   not exist.
-    fn royalty_info(e: &Env, token_id: u32, sale_price: u32) -> (Address, u32);
+    fn royalty_info(e: &Env, token_id: u32, sale_price: u128) -> (Address, u128);
 }
 
 // ################## EVENTS ##################

--- a/packages/tokens/non-fungible/src/extensions/royalties/storage.rs
+++ b/packages/tokens/non-fungible/src/extensions/royalties/storage.rs
@@ -121,7 +121,7 @@ impl Base {
     /// * [`NonFungibleTokenError::NonExistentToken`] - If the token does not
     ///   exist.
     /// * refer to [`Base::owner_of`] errors.
-    pub fn royalty_info(e: &Env, token_id: u32, sale_price: u32) -> (Address, u32) {
+    pub fn royalty_info(e: &Env, token_id: u32, sale_price: u128) -> (Address, u128) {
         // Verify token exists by checking owner
         let _ = Base::owner_of(e, token_id);
 
@@ -133,8 +133,7 @@ impl Base {
                 OWNER_TTL_THRESHOLD,
                 OWNER_EXTEND_AMOUNT,
             );
-            let royalty_amount =
-                (sale_price as u64 * royalty_info.basis_points as u64 / 10000) as u32;
+            let royalty_amount = sale_price * royalty_info.basis_points as u128 / 10000;
             return (royalty_info.receiver, royalty_amount);
         }
 
@@ -142,8 +141,7 @@ impl Base {
         let default_key = NFTRoyaltiesStorageKey::DefaultRoyalty;
         if let Some(royalty_info) = e.storage().instance().get::<_, RoyaltyInfo>(&default_key) {
             e.storage().instance().extend_ttl(OWNER_TTL_THRESHOLD, OWNER_EXTEND_AMOUNT);
-            let royalty_amount =
-                (sale_price as u64 * royalty_info.basis_points as u64 / 10000) as u32;
+            let royalty_amount = sale_price * royalty_info.basis_points as u128 / 10000;
             return (royalty_info.receiver, royalty_amount);
         }
 

--- a/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_set_default_royalty.1.json
+++ b/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_set_default_royalty.1.json
@@ -431,5 +431,29 @@
       ]
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_default_royalty"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            ],
+            "data": {
+              "u32": 1000
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
 }

--- a/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_set_token_royalty.1.json
+++ b/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_set_token_royalty.1.json
@@ -486,6 +486,32 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_token_royalty"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              },
+              {
+                "u32": 0
+              }
+            ],
+            "data": {
+              "u32": 500
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }

--- a/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_token_royalty_overrides_default.1.json
+++ b/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_token_royalty_overrides_default.1.json
@@ -761,6 +761,29 @@
           "v0": {
             "topics": [
               {
+                "symbol": "set_default_royalty"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u32": 1000
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
                 "symbol": "mint"
               },
               {
@@ -769,6 +792,32 @@
             ],
             "data": {
               "u32": 0
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_token_royalty"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "u32": 0
+              }
+            ],
+            "data": {
+              "u32": 500
             }
           }
         }

--- a/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_zero_royalty.1.json
+++ b/packages/tokens/non-fungible/test_snapshots/extensions/royalties/test/test_zero_royalty.1.json
@@ -486,6 +486,32 @@
         }
       },
       "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_token_royalty"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              },
+              {
+                "u32": 0
+              }
+            ],
+            "data": {
+              "u32": 0
+            }
+          }
+        }
+      },
+      "failed_call": false
     }
   ]
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #255 

Changes `sale_price` type from `u32` to `u128` in order to support a wider range, due to Stellar has 7 decimals for actual prices.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation

