### PR TITLE
Remove cdylib crate type from default-impl-macro-test Cargo.toml

### DIFF
--- a/packages/test-utils/default-impl-macro-test/Cargo.toml
+++ b/packages/test-utils/default-impl-macro-test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version.workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 doctest = false
 
 


### PR DESCRIPTION
Remove `cdylib` `crate-type` from `default-impl-macro-test` Cargo.toml.

It doesn't appear that the crate is intended to build for cdylib. It contains only tests.

By specifying the `cdylib` `crate-type`, tooling that identifies crates that can be built to wasm thinks this crate in the repo can be built to wasm.

#### PR Checklist

- [ ] ~Tests~
- [ ] ~Documentation~

