### PR TITLE
Use ownable in examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,8 @@ name = "fungible-capped-example"
 version = "0.5.1"
 dependencies = [
  "soroban-sdk",
+ "stellar-access",
+ "stellar-macros",
  "stellar-tokens",
 ]
 
@@ -632,6 +634,7 @@ name = "fungible-pausable-example"
 version = "0.5.1"
 dependencies = [
  "soroban-sdk",
+ "stellar-access",
  "stellar-contract-utils",
  "stellar-macros",
  "stellar-tokens",
@@ -967,6 +970,8 @@ name = "nft-consecutive-example"
 version = "0.5.1"
 dependencies = [
  "soroban-sdk",
+ "stellar-access",
+ "stellar-macros",
  "stellar-tokens",
 ]
 
@@ -975,6 +980,7 @@ name = "nft-enumerable-example"
 version = "0.5.1"
 dependencies = [
  "soroban-sdk",
+ "stellar-access",
  "stellar-macros",
  "stellar-tokens",
 ]
@@ -994,6 +1000,7 @@ name = "nft-sequential-minting-example"
 version = "0.5.1"
 dependencies = [
  "soroban-sdk",
+ "stellar-access",
  "stellar-macros",
  "stellar-tokens",
 ]
@@ -1081,6 +1088,7 @@ name = "pausable-example"
 version = "0.5.1"
 dependencies = [
  "soroban-sdk",
+ "stellar-access",
  "stellar-contract-utils",
  "stellar-macros",
 ]

--- a/examples/DEPLOY.md
+++ b/examples/DEPLOY.md
@@ -1,0 +1,187 @@
+# Example Contract Deployment Commands
+
+Sample Stellar CLI deployment commands for all example contracts in this repository.
+All examples target the testnet network and use mock parameter values.
+
+You can create a testnet identity (e.g., `alice`) using the following command:
+
+```bash
+stellar keys generate alice --network testnet --fund
+```
+
+## Examples included:
+
+- fungible_allowlist_example
+- fungible_blocklist_example
+- fungible_capped_example
+- fungible_merkle_airdrop_example
+- fungible_pausable_example
+- fungible_vault_example
+- merkle_voting_example
+- multisig_account_example
+- multisig_ed25519_verifier_example
+- multisig_spending_limit_policy_example
+- multisig_threshold_policy_example
+- multisig_webauthn_verifier_example
+- nft_access_control_example
+- nft_consecutive_example
+- nft_enumerable_example
+- nft_royalties_example
+- nft_sequential_minting_example
+- ownable_example
+- pausable_example
+- sac_admin_generic_example
+- sac_admin_wrapper_example
+- upgrader_example
+- upgradeable_v1_example
+- upgradeable_v2_example
+
+RWA examples are not yet included.
+
+---
+
+## FungibleAllowList
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/fungible_allowlist_example.wasm --source-account alice --network testnet -- --admin alice --manager bob --initial_supply "1000000"
+```
+
+## FungibleBlockList
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/fungible_blocklist_example.wasm --source-account alice --network testnet -- --admin alice --manager bob --initial_supply "1000000"
+```
+
+## FungibleCapped
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/fungible_capped_example.wasm --source-account alice --network testnet -- --owner alice --cap "1000000"
+```
+
+## FungibleMerkleAirdrop
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/fungible_merkle_airdrop_example.wasm --source-account alice --network testnet -- --root_hash 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --token CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC --funding_amount 100000000 --funding_source alice
+```
+
+## FungiblePausable
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/fungible_pausable_example.wasm --source-account alice --network testnet -- --owner alice --initial_supply "1000000"
+```
+
+## FungibleVault
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/fungible_vault_example.wasm --source-account alice --network testnet -- --owner alice --asset CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC --decimals_offset 6
+```
+
+## MerkleVoting
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/merkle_voting_example.wasm --source-account alice --network testnet -- --root_hash 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+```
+
+## MultisigAccount
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/multisig_account_example.wasm --source-account alice --network testnet -- --signers '[{"Delegated":"GCXWIES6GBSIFK3UXNUV2O2XGZSVOQR4VVWRC65UXVMXSYOPE6BCO27K"}]' --policies '{}'
+```
+
+## MultisigEd25519Verifier
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/multisig_ed25519_verifier_example.wasm --source-account alice --network testnet
+```
+
+## MultisigSpendingLimitPolicy
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/multisig_spending_limit_policy_example.wasm --source-account alice --network testnet
+```
+
+## MultisigThresholdPolicy
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/multisig_threshold_policy_example.wasm --source-account alice --network testnet
+```
+
+## MultisigWebauthnVerifier
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/multisig_webauthn_verifier_example.wasm --source-account alice --network testnet
+```
+
+## NFTAccessControl
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/nft_access_control_example.wasm --source-account alice --network testnet -- --admin alice
+```
+
+## NFTConsecutive
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/nft_consecutive_example.wasm --source-account alice --network testnet -- --owner alice
+```
+
+## NFTEnumerable
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/nft_enumerable_example.wasm --source-account alice --network testnet -- --owner alice
+```
+
+## NFTRoyalties
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/nft_royalties_example.wasm --source-account alice --network testnet -- --admin alice --manager bob
+```
+
+## NFTSequentialMinting
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/nft_sequential_minting_example.wasm --source-account alice --network testnet -- --owner alice
+```
+
+## Ownable
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/ownable_example.wasm --source-account alice --network testnet -- --owner alice
+```
+
+## Pausable
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/pausable_example.wasm --source-account alice --network testnet -- --owner alice
+```
+
+## SACAdminGeneric
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/sac_admin_generic_example.wasm --source-account alice --network testnet -- --sac alice --chief 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --operator 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+```
+
+## SACAdminWrapper
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/sac_admin_wrapper_example.wasm --source-account alice --network testnet -- --default_admin alice --manager bob --sac alice
+```
+
+## Upgrader
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/upgrader_example.wasm --source-account alice --network testnet -- --owner alice
+```
+
+## UpgradeableV1
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/upgradeable_v1_example.wasm --source-account alice --network testnet -- --admin alice
+```
+
+## UpgradeableV2
+
+```bash
+stellar contract deploy --wasm target/wasm32v1-none/release/upgradeable_v2_example.wasm --source-account alice --network testnet
+```
+
+---

--- a/examples/fungible-allowlist/src/contract.rs
+++ b/examples/fungible-allowlist/src/contract.rs
@@ -29,7 +29,7 @@ impl ExampleContract {
 
         access_control::set_admin(e, &admin);
 
-        // create a role "manager" and grant it to `manager`
+        // Create a role "manager" and grant it to `manager`
         access_control::grant_role_no_auth(e, &admin, &manager, &symbol_short!("manager"));
 
         // Allow the admin to transfer tokens
@@ -45,6 +45,7 @@ impl ExampleContract {
 impl FungibleToken for ExampleContract {
     type ContractType = AllowList;
 }
+
 #[contractimpl]
 impl FungibleAllowList for ExampleContract {
     fn allowed(e: &Env, account: Address) -> bool {

--- a/examples/fungible-blocklist/src/contract.rs
+++ b/examples/fungible-blocklist/src/contract.rs
@@ -35,8 +35,7 @@ impl ExampleContract {
 
         access_control::set_admin(e, &admin);
 
-        // create a role "manager" and grant it to `manager`
-
+        // Create a role "manager" and grant it to `manager`
         access_control::grant_role_no_auth(e, &admin, &manager, &symbol_short!("manager"));
 
         // Mint initial supply to the admin

--- a/examples/fungible-capped/Cargo.toml
+++ b/examples/fungible-capped/Cargo.toml
@@ -13,6 +13,8 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 stellar-tokens = { workspace = true }
+stellar-macros = { workspace = true }
+stellar-access = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-capped/src/contract.rs
+++ b/examples/fungible-capped/src/contract.rs
@@ -4,10 +4,11 @@
 //! implementing a capped mint mechanism, and setting the maximum supply
 //! at the constructor.
 //!
-//! **IMPORTANT**: this example is for demonstration purposes, and authorization
-//! is not taken into consideration
+//! **IMPORTANT**: this example is for demonstration purposes.
 
 use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use stellar_access::ownable::{set_owner, Ownable};
+use stellar_macros::{default_impl, only_owner};
 use stellar_tokens::fungible::{
     capped::{check_cap, set_cap},
     Base, FungibleToken,
@@ -18,10 +19,12 @@ pub struct ExampleContract;
 
 #[contractimpl]
 impl ExampleContract {
-    pub fn __constructor(e: &Env, cap: i128) {
+    pub fn __constructor(e: &Env, owner: Address, cap: i128) {
+        set_owner(e, &owner);
         set_cap(e, cap);
     }
 
+    #[only_owner]
     pub fn mint(e: &Env, account: Address, amount: i128) {
         check_cap(e, amount);
         Base::mint(e, &account, amount);
@@ -68,3 +71,7 @@ impl FungibleToken for ExampleContract {
         Self::ContractType::symbol(e)
     }
 }
+
+#[default_impl]
+#[contractimpl]
+impl Ownable for ExampleContract {}

--- a/examples/fungible-pausable/Cargo.toml
+++ b/examples/fungible-pausable/Cargo.toml
@@ -15,6 +15,7 @@ soroban-sdk = { workspace = true }
 stellar-contract-utils = { workspace = true }
 stellar-macros = { workspace = true }
 stellar-tokens = { workspace = true }
+stellar-access = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-vault/src/contract.rs
+++ b/examples/fungible-vault/src/contract.rs
@@ -1,6 +1,7 @@
 //! Tokenized Vault Example Contract.
 
 use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use stellar_access::ownable::{set_owner, Ownable};
 use stellar_macros::default_impl;
 use stellar_tokens::{
     fungible::{Base, FungibleToken},
@@ -12,7 +13,8 @@ pub struct ExampleContract;
 
 #[contractimpl]
 impl ExampleContract {
-    pub fn __constructor(e: &Env, asset: Address, decimals_offset: u32) {
+    pub fn __constructor(e: &Env, owner: Address, asset: Address, decimals_offset: u32) {
+        set_owner(e, &owner);
         // Asset and decimal offset should be configured once during initialization.
         Vault::set_asset(e, asset);
         Vault::set_decimals_offset(e, decimals_offset);
@@ -34,6 +36,7 @@ impl FungibleToken for ExampleContract {
 
     // Allows override of decimals and other base functions.
 
+    // Overriding decimals function for demonstration purposes:
     fn decimals(e: &Env) -> u32 {
         Vault::decimals(e)
     }
@@ -42,6 +45,8 @@ impl FungibleToken for ExampleContract {
 #[contractimpl]
 impl FungibleVault for ExampleContract {
     // Allows override of public vault functions.
+    // The `#[default_impl]` attribute can also be used, but
+    // ensure that proper authorization checks are implemented.
 
     fn query_asset(e: &Env) -> Address {
         Vault::query_asset(e)
@@ -117,3 +122,7 @@ impl FungibleVault for ExampleContract {
         Vault::redeem(e, shares, receiver, owner, operator)
     }
 }
+
+#[default_impl]
+#[contractimpl]
+impl Ownable for ExampleContract {}

--- a/examples/fungible-vault/src/test.rs
+++ b/examples/fungible-vault/src/test.rs
@@ -36,10 +36,12 @@ impl FungibleToken for MockAssetContract {
 
 fn create_vault_client<'a>(
     e: &Env,
+    owner_address: &Address,
     asset_address: &Address,
     decimals_offset: u32,
 ) -> ExampleContractClient<'a> {
-    let vault_address = e.register(ExampleContract, (asset_address, decimals_offset));
+    let vault_address =
+        e.register(ExampleContract, (owner_address, asset_address, decimals_offset));
     ExampleContractClient::new(e, &vault_address)
 }
 
@@ -64,7 +66,8 @@ fn test_vault_initialization() {
     let asset_address = asset_client.address.clone();
 
     // Create vault contract
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     // Test vault initialization
     assert_eq!(vault_client.query_asset(), asset_address);
@@ -87,7 +90,8 @@ fn test_vault_deposit() {
     let asset_address = asset_client.address.clone();
 
     // Create vault contract
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -123,7 +127,8 @@ fn test_vault_mint() {
     let asset_address = asset_client.address.clone();
 
     // Create vault contract
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -154,7 +159,8 @@ fn test_vault_withdraw() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -183,7 +189,8 @@ fn test_vault_redeem() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -217,7 +224,8 @@ fn test_conversion_functions() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -259,7 +267,8 @@ fn test_max_functions() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -293,7 +302,8 @@ fn test_multiple_users_deposit_withdraw() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -331,7 +341,8 @@ fn test_deposit_max_validation() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -359,7 +370,8 @@ fn test_withdraw_exceeds_max() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 
@@ -385,7 +397,8 @@ fn test_redeem_exceeds_max() {
     // Create contracts
     let asset_client = create_asset_client(&e, initial_supply, &admin);
     let asset_address = asset_client.address.clone();
-    let vault_client = create_vault_client(&e, &asset_address, decimals_offset);
+    let vault_admin = Address::generate(&e);
+    let vault_client = create_vault_client(&e, &vault_admin, &asset_address, decimals_offset);
 
     e.mock_all_auths();
 

--- a/examples/nft-access-control/src/contract.rs
+++ b/examples/nft-access-control/src/contract.rs
@@ -20,6 +20,9 @@ impl ExampleContract {
             String::from_str(e, "My Token"),
             String::from_str(e, "TKN"),
         );
+        // Examples of how you can create a role and grant it to an address:
+        // grant_role_no_auth(e, &admin, &minter, &symbol_short!("minter"));
+        // grant_role_no_auth(e, &admin, &burner, &symbol_short!("burner"));
     }
 
     #[only_admin]
@@ -27,14 +30,14 @@ impl ExampleContract {
         vec![&e, String::from_str(e, "seems sus")]
     }
 
-    // we want `require_auth()` provided by the macro, since there is no
+    // We want `require_auth()` provided by the macro, since there is no
     // `require_auth()` in `Base::mint`.
     #[only_role(caller, "minter")]
     pub fn mint(e: &Env, caller: Address, to: Address, token_id: u32) {
         Base::mint(e, &to, token_id)
     }
 
-    // allows either minter or burner role, does not enforce `require_auth` in the
+    // Allows either minter or burner role, does not enforce `require_auth` in the
     // macro
     #[has_any_role(caller, ["minter", "burner"])]
     pub fn multi_role_action(e: &Env, caller: Address) -> String {
@@ -42,7 +45,7 @@ impl ExampleContract {
         String::from_str(e, "multi_role_action_success")
     }
 
-    // allows either minter or burner role AND enforces `require_auth` in the macro
+    // Allows either minter or burner role AND enforces `require_auth` in the macro
     #[only_any_role(caller, ["minter", "burner"])]
     pub fn multi_role_auth_action(e: &Env, caller: Address) -> String {
         String::from_str(e, "multi_role_auth_action_success")
@@ -55,11 +58,11 @@ impl NonFungibleToken for ExampleContract {
     type ContractType = Base;
 }
 
-// for this contract, the `burn*` functions are only meant to be called by
+// For this contract, the `burn*` functions are only meant to be called by
 // specific people with the `burner` role
 #[contractimpl]
 impl NonFungibleBurnable for ExampleContract {
-    // we DON'T want `require_auth()` provided by the macro, since there is already
+    // We DON'T want `require_auth()` provided by the macro, since there is already
     // `require_auth()` in `Base::burn`
     #[has_role(from, "burner")]
     fn burn(e: &Env, from: Address, token_id: u32) {

--- a/examples/nft-consecutive/Cargo.toml
+++ b/examples/nft-consecutive/Cargo.toml
@@ -13,6 +13,8 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 stellar-tokens = { workspace = true }
+stellar-macros = { workspace = true }
+stellar-access = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/nft-enumerable/Cargo.toml
+++ b/examples/nft-enumerable/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-tokens = { workspace = true }
 stellar-macros = { workspace = true }
+stellar-access = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/nft-enumerable/src/contract.rs
+++ b/examples/nft-enumerable/src/contract.rs
@@ -4,18 +4,14 @@
 //! enumeration of all the token IDs in the contract as well as all the token
 //! IDs owned by each account.
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
-use stellar_macros::default_impl;
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use stellar_access::ownable::{set_owner, Ownable};
+use stellar_macros::{default_impl, only_owner};
 use stellar_tokens::non_fungible::{
     burnable::NonFungibleBurnable,
     enumerable::{Enumerable, NonFungibleEnumerable},
     Base, NonFungibleToken,
 };
-
-#[contracttype]
-pub enum DataKey {
-    Owner,
-}
 
 #[contract]
 pub struct ExampleContract;
@@ -23,7 +19,7 @@ pub struct ExampleContract;
 #[contractimpl]
 impl ExampleContract {
     pub fn __constructor(e: &Env, owner: Address) {
-        e.storage().instance().set(&DataKey::Owner, &owner);
+        set_owner(e, &owner);
         Base::set_metadata(
             e,
             String::from_str(e, "www.mytoken.com"),
@@ -32,10 +28,8 @@ impl ExampleContract {
         );
     }
 
+    #[only_owner]
     pub fn mint(e: &Env, to: Address) -> u32 {
-        let owner: Address =
-            e.storage().instance().get(&DataKey::Owner).expect("owner should be set");
-        owner.require_auth();
         Enumerable::sequential_mint(e, &to)
     }
 }
@@ -53,3 +47,7 @@ impl NonFungibleEnumerable for ExampleContract {}
 #[default_impl]
 #[contractimpl]
 impl NonFungibleBurnable for ExampleContract {}
+
+#[default_impl]
+#[contractimpl]
+impl Ownable for ExampleContract {}

--- a/examples/nft-royalties/src/contract.rs
+++ b/examples/nft-royalties/src/contract.rs
@@ -27,7 +27,7 @@ impl ExampleContract {
 
         access_control::set_admin(e, &admin);
 
-        // create a role "manager" and grant it to `manager`
+        // Create a role "manager" and grant it to `manager`
         access_control::grant_role_no_auth(e, &admin, &manager, &symbol_short!("manager"));
     }
 

--- a/examples/nft-sequential-minting/Cargo.toml
+++ b/examples/nft-sequential-minting/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 stellar-macros = { workspace = true }
 soroban-sdk = { workspace = true }
 stellar-tokens = { workspace = true }
+stellar-access = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/nft-sequential-minting/src/contract.rs
+++ b/examples/nft-sequential-minting/src/contract.rs
@@ -2,14 +2,10 @@
 //!
 //! Demonstrates an example usage of the NFT default base implementation.
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
-use stellar_macros::default_impl;
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use stellar_access::ownable::{set_owner, Ownable};
+use stellar_macros::{default_impl, only_owner};
 use stellar_tokens::non_fungible::{burnable::NonFungibleBurnable, Base, NonFungibleToken};
-
-#[contracttype]
-pub enum DataKey {
-    Owner,
-}
 
 #[contract]
 pub struct ExampleContract;
@@ -17,7 +13,7 @@ pub struct ExampleContract;
 #[contractimpl]
 impl ExampleContract {
     pub fn __constructor(e: &Env, owner: Address) {
-        e.storage().instance().set(&DataKey::Owner, &owner);
+        set_owner(e, &owner);
         Base::set_metadata(
             e,
             String::from_str(e, "www.mytoken.com"),
@@ -26,10 +22,8 @@ impl ExampleContract {
         );
     }
 
+    #[only_owner]
     pub fn mint(e: &Env, to: Address) -> u32 {
-        let owner: Address =
-            e.storage().instance().get(&DataKey::Owner).expect("owner should be set");
-        owner.require_auth();
         Base::sequential_mint(e, &to)
     }
 }
@@ -43,3 +37,7 @@ impl NonFungibleToken for ExampleContract {
 #[default_impl]
 #[contractimpl]
 impl NonFungibleBurnable for ExampleContract {}
+
+#[default_impl]
+#[contractimpl]
+impl Ownable for ExampleContract {}

--- a/examples/ownable/src/contract.rs
+++ b/examples/ownable/src/contract.rs
@@ -9,7 +9,6 @@ use stellar_macros::{default_impl, only_owner};
 
 #[contracttype]
 pub enum DataKey {
-    Owner,
     Counter,
 }
 

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-contract-utils = { workspace = true }
 stellar-macros = { workspace = true }
+stellar-access = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/rwa/src/contract.rs
+++ b/examples/rwa/src/contract.rs
@@ -18,7 +18,7 @@ impl ExampleContract {
 
         access_control::set_admin(e, &admin);
 
-        // create a role "manager" and grant it to `manager`
+        // Create a role "manager" and grant it to `manager`
         access_control::grant_role_no_auth(e, &admin, &manager, &symbol_short!("manager"));
 
         // Mint initial supply to the admin


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #225 <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

Added `ownable` where it made sense.

Some examples use the `access_control` module instead of `ownable`, which I think is fine.

--- 

### Notes

- Combining `ownable` with `pausable` is not very elegant in practice. For example:

```rust
fn pause(e: &Env, caller: Address) {
    let owner: Address = enforce_owner_auth(e);
    if owner != caller {
        panic_with_error!(e, ExampleContractError::Unauthorized);
    }

    pausable::pause(e);
}
```

- In the vault example, `ownable` was added, but it isn’t actually used to authorize functions, just included for demonstration purposes.

- I didn’t touch the `upgradeable` contract examples, since you may want to keep their current wasm unchanged.

- I’ve also added `examples/DEPLOY.md`, which contains sample Stellar CLI deploy commands for the example contracts.

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests - tests are passing, though no new tests have been added.
- [x] Documentation - documentation appears to have been moved to another repository.

Looking forward to your review and suggestions.

