### PR TITLE
allowance bug fix

### DIFF
--- a/packages/tokens/src/fungible/extensions/burnable/test.rs
+++ b/packages/tokens/src/fungible/extensions/burnable/test.rs
@@ -66,7 +66,7 @@ fn burn_with_insufficient_balance_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #101)")]
+#[should_panic(expected = "Error(Contract, #116)")]
 fn burn_with_no_allowance_panics() {
     let e = Env::default();
     e.mock_all_auths();

--- a/packages/tokens/src/fungible/mod.rs
+++ b/packages/tokens/src/fungible/mod.rs
@@ -310,10 +310,14 @@ pub enum FungibleTokenError {
     SACMissingFnParam = 111,
     /// Indicates an invalid function parameter in the SAC contract context.
     SACInvalidFnParam = 112,
-    /// The user is not allowed to perform this operation
+    /// Indicates the user is not allowed to perform this operation.
     UserNotAllowed = 113,
-    /// The user is blocked and cannot perform this operation
+    /// Indicates the user is blocked and cannot perform this operation.
     UserBlocked = 114,
+    /// Indicates the allowance has expired.
+    ExpiredAllowance = 115,
+    /// Indicates the allowance does not exist.
+    AllowanceNotFound = 116,
 }
 
 // ################## CONSTANTS ##################

--- a/packages/tokens/src/fungible/test.rs
+++ b/packages/tokens/src/fungible/test.rs
@@ -79,6 +79,7 @@ fn approve_with_event() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #115)")]
 fn approve_handles_expiry() {
     let e = Env::default();
     e.mock_all_auths();
@@ -90,8 +91,7 @@ fn approve_handles_expiry() {
         Base::approve(&e, &owner, &spender, 50, 2);
         e.ledger().set_sequence_number(3);
 
-        let expired_allowance = Base::allowance(&e, &owner, &spender);
-        assert_eq!(expired_allowance, 0);
+        let _ = Base::allowance(&e, &owner, &spender);
     });
 }
 
@@ -187,18 +187,11 @@ fn set_allowance_with_zero_amount() {
     let e = Env::default();
     let address = e.register(MockContract, ());
     let owner = Address::generate(&e);
-    let owner2 = Address::generate(&e);
     let spender = Address::generate(&e);
 
     e.as_contract(&address, || {
         Base::set_allowance(&e, &owner, &spender, 0, 5);
         let allowance_val = Base::allowance(&e, &owner, &spender);
-        assert_eq!(allowance_val, 0);
-
-        // should pass for a past ledger
-        e.ledger().set_sequence_number(10);
-        Base::set_allowance(&e, &owner2, &spender, 0, 5);
-        let allowance_val = Base::allowance(&e, &owner2, &spender);
         assert_eq!(allowance_val, 0);
     });
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #507 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation

Notes for @brozorec :
- `allowance` has this expiry check, however, we also need to access the `live_until_ledger` info from `allowance_data` in the `spend_allowance` function. That's why, simply using `allowance` instead of `allowance_data` in `spend_allowance` wouldn't work.
- `allowance_data` is not checking for the expiry, and delegates that responsibility to the caller function. Considering that we ourselves made the mistake of using `allowance_data` but not enforcing the expiry check (and this has not been caught by the previous audits), I thought we better change the design of the `allowance_data`, and put the EXPIRY CHECK logic in it. 
- the original design of the `allowance_data` was not panicking. Even if the allowance is not found, it was returning an allowance data object with defaults (`amount: 0, live_until_ledger: 0`).
- what to return when it is expired? I first thought, (`amount: 0, live_until_ledger: allowance_data.live_until_ledger`). Because, maybe the information of when the allowance has expired will be important. But, then, the same argument can be made for the `amount`... 
- In the light of the above arguments, I've changed the behavior of `allowance_data` to include panicking. It will panic when an allowance is not found, and it will panic when an allowance has expired, which allowed me to make further simplifications across the codebase, such as:
    - `amount == 0` was both a valid allowance, and also signaling expired allowances. This resulted in hard to decipher logic in some parts of the code
    - now, `amount == 0` is a valid allowance, but not signaling expired allowances. Hence, an allowance with `amount: 0, live_until_ledger: EXPIRED_LEDGER` is not valid to set anymore. And **it was valid to set before**.

I think all these changes made the library simpler and more secure. Let me know if you want to further discuss on them! 

