### PR TITLE
divisionbyzero and overflow error path fix

### DIFF
--- a/packages/contract-utils/src/math/i128_fixed_point.rs
+++ b/packages/contract-utils/src/math/i128_fixed_point.rs
@@ -106,9 +106,14 @@ impl SorobanFixedPoint for i128 {
 
 /// Performs floor(x * y / z), panics on overflow or division by zero
 fn scaled_mul_div_floor(x: &i128, env: &Env, y: &i128, z: &i128) -> i128 {
+    if *z == 0 {
+        panic_with_error!(env, SorobanFixedPointError::DivisionByZero);
+    }
     match x.checked_mul(*y) {
+        // *z == 0 check is already done above, so the only possible error is overflow,
+        // where r = i128::MIN and z = -1
         Some(r) => div_floor(r, *z)
-            .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::DivisionByZero)),
+            .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::Overflow)),
         None => {
             // scale to i256 and retry
             let res = crate::math::i256_fixed_point::mul_div_floor(
@@ -125,9 +130,14 @@ fn scaled_mul_div_floor(x: &i128, env: &Env, y: &i128, z: &i128) -> i128 {
 
 /// Performs ceil(x * y / z)
 fn scaled_mul_div_ceil(x: &i128, env: &Env, y: &i128, z: &i128) -> i128 {
+    if *z == 0 {
+        panic_with_error!(env, SorobanFixedPointError::DivisionByZero);
+    }
     match x.checked_mul(*y) {
+        // *z == 0 check is already done above, so the only possible error is overflow,
+        // where r = i128::MIN and z = -1
         Some(r) => div_ceil(r, *z)
-            .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::DivisionByZero)),
+            .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::Overflow)),
         None => {
             // scale to i256 and retry
             let res = crate::math::i256_fixed_point::mul_div_ceil(

--- a/packages/contract-utils/src/math/i256_fixed_point.rs
+++ b/packages/contract-utils/src/math/i256_fixed_point.rs
@@ -25,14 +25,22 @@ impl SorobanFixedPoint for I256 {
 
 /// Performs floor(x * y / z)
 pub(crate) fn mul_div_floor(env: &Env, x: &I256, y: &I256, z: &I256) -> I256 {
+    let zero = I256::from_i32(env, 0);
+    if *z == zero {
+        panic_with_error!(env, SorobanFixedPointError::DivisionByZero);
+    }
     checked_mul_div_floor(env, x, y, z)
-        .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::DivisionByZero))
+        .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::Overflow))
 }
 
 /// Performs ceil(x * y / z)
 pub(crate) fn mul_div_ceil(env: &Env, x: &I256, y: &I256, z: &I256) -> I256 {
+    let zero = I256::from_i32(env, 0);
+    if *z == zero {
+        panic_with_error!(env, SorobanFixedPointError::DivisionByZero);
+    }
     checked_mul_div_ceil(env, x, y, z)
-        .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::DivisionByZero))
+        .unwrap_or_else(|| panic_with_error!(env, SorobanFixedPointError::Overflow))
 }
 
 /// Checked version of floor(x * y / z)

--- a/packages/contract-utils/src/math/test/i128_fixed_point.rs
+++ b/packages/contract-utils/src/math/test/i128_fixed_point.rs
@@ -18,6 +18,19 @@ fn test_fixed_mul_floor_zero_denominator() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #1500)")]
+fn test_fixed_mul_floor_overflow_on_division() {
+    let env = Env::default();
+    // i128::MIN / -1 overflows because -i128::MIN can't be represented
+    // This should panic with Overflow (#1500), not DivisionByZero (#1501)
+    let x: i128 = i128::MIN;
+    let y: i128 = 1;
+    let denominator: i128 = -1;
+
+    x.fixed_mul_floor(&env, &y, &denominator);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #1501)")]
 fn test_fixed_mul_ceil_zero_denominator() {
     let env = Env::default();


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #531 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation

Important note: the original issue was reported for `i128`, but the same issue exists also for `i256`. However, fixing this error on `i256` is not completely possible, due to:
- `checked_mul_div_floor` and `checked_mul_div_ceil` are not returning `None` for overflows, only for `DivisionByZero` case. This is because of the internal API we use for `i256` provided by `soroban_sdk` lacks the `checked` versions of `mul`, `div`, `rem_euclid`, etc. Ultimately resulting in not being able to catch the potential overflow errors there, and only panic in these cases. This is also noted by #530. This PR also changes implements the necessary fix on the `i256` code we have, similar to what we have in `i128`, so when `soroban_sdk` can expose the `checked` versions of the `mul`, `div`, etc. we can just replace them, and the fix should be complete.

