### PR TITLE
Add Cargo feature flags to prevent unused types leaking into contract specs

### DIFF
--- a/examples/fungible-allowlist/Cargo.toml
+++ b/examples/fungible-allowlist/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["allowlist"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-blocklist/Cargo.toml
+++ b/examples/fungible-blocklist/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["blocklist"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-capped/Cargo.toml
+++ b/examples/fungible-capped/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["capped"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-merkle-airdrop/Cargo.toml
+++ b/examples/fungible-merkle-airdrop/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-tokens = { workspace = true }
 stellar-access = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["merkle-distributor"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-pausable/Cargo.toml
+++ b/examples/fungible-pausable/Cargo.toml
@@ -12,9 +12,9 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["pausable"] }
 stellar-macros = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["fungible", "burnable"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-vault/Cargo.toml
+++ b/examples/fungible-vault/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["vault"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/fungible-votes/Cargo.toml
+++ b/examples/fungible-votes/Cargo.toml
@@ -15,7 +15,7 @@ soroban-sdk = { workspace = true }
 stellar-access = { workspace = true }
 stellar-governance = { workspace = true }
 stellar-macros = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["fungible", "burnable", "votes"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/merkle-voting/Cargo.toml
+++ b/examples/merkle-voting/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["merkle-distributor"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/multisig-smart-account/account/Cargo.toml
+++ b/examples/multisig-smart-account/account/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 stellar-accounts = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["upgradeable"] }
 stellar-macros = { workspace = true }
 
 

--- a/examples/nft-access-control/Cargo.toml
+++ b/examples/nft-access-control/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["non-fungible", "burnable"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/nft-consecutive/Cargo.toml
+++ b/examples/nft-consecutive/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["consecutive"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/nft-enumerable/Cargo.toml
+++ b/examples/nft-enumerable/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["enumerable"] }
 stellar-macros = { workspace = true }
 
 [dev-dependencies]

--- a/examples/nft-royalties/Cargo.toml
+++ b/examples/nft-royalties/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["royalties"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/nft-sequential-minting/Cargo.toml
+++ b/examples/nft-sequential-minting/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 stellar-macros = { workspace = true }
 soroban-sdk = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["non-fungible", "burnable"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["pausable"] }
 stellar-macros = { workspace = true }
 
 [dev-dependencies]

--- a/examples/sac-admin-generic/Cargo.toml
+++ b/examples/sac-admin-generic/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["sac"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/sac-admin-wrapper/Cargo.toml
+++ b/examples/sac-admin-wrapper/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-tokens = { workspace = true }
+stellar-tokens = { workspace = true, features = ["sac"] }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
 

--- a/examples/upgradeable/upgrader/Cargo.toml
+++ b/examples/upgradeable/upgrader/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["upgradeable"] }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
 

--- a/examples/upgradeable/v1/Cargo.toml
+++ b/examples/upgradeable/v1/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["upgradeable"] }
 stellar-macros = { workspace = true }
 
 [dev-dependencies]

--- a/examples/upgradeable/v2/Cargo.toml
+++ b/examples/upgradeable/v2/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-contract-utils = { workspace = true }
+stellar-contract-utils = { workspace = true, features = ["upgradeable"] }
 stellar-macros = { workspace = true }
 
 [dev-dependencies]

--- a/packages/contract-utils/Cargo.toml
+++ b/packages/contract-utils/Cargo.toml
@@ -12,6 +12,14 @@ description = "Utilities for Stellar contracts."
 crate-type = ["lib", "cdylib"]
 doctest = false
 
+[features]
+default = []
+crypto = []
+math = []
+merkle-distributor = ["crypto"]
+pausable = []
+upgradeable = []
+
 [dependencies]
 soroban-sdk = { workspace = true }
 

--- a/packages/contract-utils/src/lib.rs
+++ b/packages/contract-utils/src/lib.rs
@@ -1,7 +1,15 @@
 #![no_std]
 
+// Ensure soroban-sdk's panic handler is linked for cdylib builds.
+extern crate soroban_sdk;
+
+#[cfg(feature = "crypto")]
 pub mod crypto;
+#[cfg(feature = "math")]
 pub mod math;
+#[cfg(feature = "merkle-distributor")]
 pub mod merkle_distributor;
+#[cfg(feature = "pausable")]
 pub mod pausable;
+#[cfg(feature = "upgradeable")]
 pub mod upgradeable;

--- a/packages/contract-utils/src/merkle_distributor/mod.rs
+++ b/packages/contract-utils/src/merkle_distributor/mod.rs
@@ -53,7 +53,7 @@ mod test;
 
 use core::marker::PhantomData;
 
-use soroban_sdk::{contracterror, contractevent, Bytes, Env, Val};
+use soroban_sdk::{contracterror, contractevent, Bytes, Env};
 
 use crate::crypto::hasher::Hasher;
 pub use crate::merkle_distributor::storage::MerkleDistributorStorageKey;
@@ -97,7 +97,7 @@ pub struct SetRoot {
 #[contractevent]
 #[derive(Clone, Debug)]
 pub struct SetClaimed {
-    pub index: Val,
+    pub index: u32,
 }
 
 /// Emits an event when the merkle root is set.
@@ -116,6 +116,6 @@ pub fn emit_set_root(e: &Env, root: Bytes) {
 ///
 /// * `e` - The Soroban environment.
 /// * `index` - The index that was claimed.
-pub fn emit_set_claimed(e: &Env, index: Val) {
+pub fn emit_set_claimed(e: &Env, index: u32) {
     SetClaimed { index }.publish(e);
 }

--- a/packages/contract-utils/src/merkle_distributor/storage.rs
+++ b/packages/contract-utils/src/merkle_distributor/storage.rs
@@ -101,7 +101,7 @@ where
     pub fn set_claimed(e: &Env, index: u32) {
         let key = MerkleDistributorStorageKey::Claimed(index);
         e.storage().persistent().set(&key, &true);
-        emit_set_claimed(e, index.into());
+        emit_set_claimed(e, index);
     }
 
     /// Verifies a Merkle proof for a leaf and marks its index as claimed if the

--- a/packages/tokens/Cargo.toml
+++ b/packages/tokens/Cargo.toml
@@ -11,10 +11,27 @@ description = "Fungible and NonFungible Tokens for the Stellar contracts."
 crate-type = ["lib", "cdylib"]
 doctest = false
 
+[features]
+default = []
+fungible = []
+non-fungible = []
+burnable = []
+sac = ["fungible"]
+pausable = ["stellar-contract-utils/pausable"]
+rwa = ["fungible", "pausable"]
+vault = ["fungible", "stellar-contract-utils/math"]
+allowlist = ["fungible", "burnable"]
+blocklist = ["fungible", "burnable"]
+capped = ["fungible"]
+votes = ["dep:stellar-governance", "burnable"]
+enumerable = ["non-fungible", "burnable"]
+consecutive = ["non-fungible", "burnable"]
+royalties = ["non-fungible"]
+
 [dependencies]
 soroban-sdk = { workspace = true }
 stellar-contract-utils = { workspace = true }
-stellar-governance = { workspace = true }
+stellar-governance = { workspace = true, optional = true }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }

--- a/packages/tokens/src/fungible/extensions/mod.rs
+++ b/packages/tokens/src/fungible/extensions/mod.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "allowlist")]
 pub mod allowlist;
+#[cfg(feature = "blocklist")]
 pub mod blocklist;
+#[cfg(feature = "burnable")]
 pub mod burnable;
+#[cfg(feature = "capped")]
 pub mod capped;
+#[cfg(feature = "votes")]
 pub mod votes;

--- a/packages/tokens/src/fungible/mod.rs
+++ b/packages/tokens/src/fungible/mod.rs
@@ -75,12 +75,22 @@ mod utils;
 #[cfg(test)]
 mod test;
 
-pub use extensions::{allowlist, blocklist, burnable, capped, votes};
+#[cfg(feature = "allowlist")]
+pub use extensions::allowlist;
+#[cfg(feature = "blocklist")]
+pub use extensions::blocklist;
+#[cfg(feature = "burnable")]
+pub use extensions::burnable;
+#[cfg(feature = "capped")]
+pub use extensions::capped;
+#[cfg(feature = "votes")]
+pub use extensions::votes;
 pub use overrides::{Base, ContractOverrides};
 use soroban_sdk::{
     contracterror, contractevent, contracttrait, Address, Env, MuxedAddress, String,
 };
 pub use storage::{AllowanceData, AllowanceKey, FungibleStorageKey};
+#[cfg(feature = "sac")]
 pub use utils::{sac_admin_generic, sac_admin_wrapper};
 
 /// Vanilla Fungible Token Trait

--- a/packages/tokens/src/fungible/utils/mod.rs
+++ b/packages/tokens/src/fungible/utils/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "sac")]
 pub mod sac_admin_generic;
+#[cfg(feature = "sac")]
 pub mod sac_admin_wrapper;

--- a/packages/tokens/src/lib.rs
+++ b/packages/tokens/src/lib.rs
@@ -13,7 +13,14 @@
 
 #![no_std]
 
+// Ensure soroban-sdk's panic handler is linked for cdylib builds.
+extern crate soroban_sdk;
+
+#[cfg(feature = "fungible")]
 pub mod fungible;
+#[cfg(feature = "non-fungible")]
 pub mod non_fungible;
+#[cfg(feature = "rwa")]
 pub mod rwa;
+#[cfg(feature = "vault")]
 pub mod vault;

--- a/packages/tokens/src/non_fungible/extensions/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/mod.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "burnable")]
 pub mod burnable;
+#[cfg(feature = "consecutive")]
 pub mod consecutive;
+#[cfg(feature = "enumerable")]
 pub mod enumerable;
+#[cfg(feature = "royalties")]
 pub mod royalties;
+#[cfg(feature = "votes")]
 pub mod votes;

--- a/packages/tokens/src/non_fungible/mod.rs
+++ b/packages/tokens/src/non_fungible/mod.rs
@@ -72,7 +72,16 @@ mod utils;
 #[cfg(test)]
 mod test;
 
-pub use extensions::{burnable, consecutive, enumerable, royalties, votes};
+#[cfg(feature = "burnable")]
+pub use extensions::burnable;
+#[cfg(feature = "consecutive")]
+pub use extensions::consecutive;
+#[cfg(feature = "enumerable")]
+pub use extensions::enumerable;
+#[cfg(feature = "royalties")]
+pub use extensions::royalties;
+#[cfg(feature = "votes")]
+pub use extensions::votes;
 pub use overrides::{Base, ContractOverrides};
 // ################## TRAIT ##################
 use soroban_sdk::{contracterror, contractevent, contracttrait, Address, Env, String};

--- a/packages/tokens/src/non_fungible/overrides.rs
+++ b/packages/tokens/src/non_fungible/overrides.rs
@@ -138,6 +138,7 @@ impl ContractOverrides for Base {}
 /// Trait for overriding `burn` and `burn_from` functions.
 /// The behavior of `burn` and `burn_from` changes across implementations,
 /// i.e. enumerable, consecutive, hence the need for an abstraction
+#[cfg(feature = "burnable")]
 pub trait BurnableOverrides {
     fn burn(e: &Env, from: &Address, token_id: u32) {
         Base::burn(e, from, token_id);
@@ -148,4 +149,5 @@ pub trait BurnableOverrides {
     }
 }
 
+#[cfg(feature = "burnable")]
 impl BurnableOverrides for Base {}


### PR DESCRIPTION
## Problem

fixes #573

Soroban SDK spec macros (`#[contracterror]`, `#[contractevent]`, `#[contracttype]`)
generate `#[link_section = "contractspecv0"]` entries in library crates that survive
into the final WASM binary regardless of whether the contract uses them. This means
a simple fungible-capped contract ends up with ~22 spec types including NFT types,
pausable types, SAC admin types, crypto/math types, and other unrelated entries.

## Solution

Introduce Cargo feature flags on `stellar-contract-utils` and `stellar-tokens` to
gate module compilation. When a contract only enables the features it needs, unused
modules are never compiled, and their types never enter the WASM spec.

### `stellar-contract-utils` features

- `crypto` — cryptographic utilities
- `math` — fixed-point math
- `merkle-distributor` — merkle tree distributor (implies `crypto`)
- `pausable` — pause/unpause functionality
- `upgradeable` — contract upgrade support

### `stellar-tokens` features

- `fungible` — base fungible token (SEP-41)
- `non-fungible` — base non-fungible token
- `burnable` — burn extensions for both token types
- `sac` — SAC admin utilities (implies `fungible`)
- `pausable` — pausable support (forwards to `stellar-contract-utils/pausable`)
- `rwa` — real-world asset token (implies `fungible`, `pausable`)
- `vault` — vault token (implies `fungible`, `stellar-contract-utils/math`)
- `allowlist` — allowlist extension (implies `fungible`, `burnable`)
- `blocklist` — blocklist extension (implies `fungible`, `burnable`)
- `capped` — capped supply extension (implies `fungible`)
- `votes` — voting extension (implies `burnable`, enables `stellar-governance`)
- `enumerable` — enumerable NFT (implies `non-fungible`, `burnable`)
- `consecutive` — consecutive NFT (implies `non-fungible`, `burnable`)
- `royalties` — NFT royalties (implies `non-fungible`)

### Additional changes

- Gate all module declarations with `#[cfg(feature = "...")]` in both library crates
- Gate extension re-exports in `fungible/mod.rs` and `non_fungible/mod.rs`
- Gate `BurnableOverrides` trait behind `#[cfg(feature = "burnable")]`
- Gate SAC admin utilities behind `#[cfg(feature = "sac")]`
- Make `stellar-governance` an optional dependency of `stellar-tokens`
- Add `extern crate soroban_sdk;` to both library crate roots to ensure the
  panic handler is linked for cdylib builds when no features are enabled
- Fix `merkle_distributor` event `SetClaimed::index` type from `Val` to `u32`
- Update all 20 example contracts to declare the specific features they need

### Optimized WASM size comparison (`stellar contract build --optimize`)

| Contract              | Before (B) | After (B) |   Diff (B) | Change |
|-----------------------|-----------:|----------:|-----------:|-------:|
| fungible-allowlist    |     61,131 |    28,847 |    -32,284 | -52.8% |
| fungible-blocklist    |     59,325 |    27,053 |    -32,272 | -54.4% |
| fungible-capped       |     44,191 |    11,406 |    -32,785 | -74.2% |
| fungible-merkle-airdrop |   5,265 |     4,157 |     -1,108 | -21.0% |
| fungible-pausable     |     42,525 |    10,312 |    -32,213 | -75.8% |
| fungible-vault        |     61,011 |    30,315 |    -30,696 | -50.3% |
| fungible-votes        |     56,579 |    29,135 |    -27,444 | -48.5% |
| merkle-voting         |      5,723 |     4,615 |     -1,108 | -19.4% |
| multisig-account      |     35,186 |    33,361 |     -1,825 |  -5.2% |
| nft-access-control    |     62,320 |    29,751 |    -32,569 | -52.3% |
| nft-consecutive       |     45,637 |    13,528 |    -32,109 | -70.4% |
| nft-enumerable        |     51,887 |    19,702 |    -32,185 | -62.0% |
| nft-royalties         |     64,408 |    32,463 |    -31,945 | -49.6% |
| nft-sequential-minting |    48,795 |    16,221 |    -32,574 | -66.8% |
| pausable              |      4,171 |     2,675 |     -1,496 | -35.9% |
| sac-admin-generic     |     41,684 |     9,023 |    -32,661 | -78.4% |
| sac-admin-wrapper     |     52,584 |    19,923 |    -32,661 | -62.1% |
| upgradeable-v1        |      3,153 |     1,329 |     -1,824 | -57.8% |
| upgradeable-v2        |      3,582 |     1,758 |     -1,824 | -50.9% |
| upgrader              |      6,454 |     4,630 |     -1,824 | -28.3% |
| **Total (changed)**   | **755,611** | **330,204** | **-425,407** | **-56.3%** |
| **Total (all 28)**    | **892,618** | **467,211** | **-425,407** | **-47.7%** |

8 contracts (fee-forwarder, ownable, multisig verifiers/policies, timelock)
were unaffected as they don't depend on `stellar-tokens` or `stellar-contract-utils`.

## PR Checklist

- [x] Tests
- [x] Documentation

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example projects to explicitly configure features for token and contract utilities.
  * Restructured modules with conditional feature-based compilation for improved modularity.

* **Refactor**
  * Reorganized token and contract utility libraries to optimize dependency management.
  * Enhanced merkle distributor implementation with improved type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->