### PR TITLE
muxed address event fix

### DIFF
--- a/packages/test-utils/event-assertion/src/lib.rs
+++ b/packages/test-utils/event-assertion/src/lib.rs
@@ -109,7 +109,32 @@ mod implementation {
             None
         }
 
-        pub fn assert_fungible_transfer(
+        /// Asserts a SEP-41 transfer event with a bare `i128` data field
+        /// (no muxed ID). This is the standard shape for `transfer` to a
+        /// non-muxed address, `transfer_from`, and RWA transfers.
+        pub fn assert_fungible_transfer(&mut self, from: &Address, to: &Address, amount: i128) {
+            let event = self.expect_event("transfer", "Transfer event not found in event log");
+            self.assert_event_contract(&event);
+
+            let (topics, data) = self.event_topics_data(&event);
+            assert_eq!(topics.len(), 3, "Transfer event should have 3 topics");
+
+            self.assert_topic_symbol(topics, 0, symbol_short!("transfer"));
+
+            let event_from: Address = self.topic_as(topics, 1);
+            let event_to: Address = self.topic_as(topics, 2);
+
+            let val = Val::try_from_val(self.env, data).unwrap();
+            let event_amount: i128 = i128::from_val(self.env, &val);
+
+            assert_eq!(&event_from, from, "Transfer event has wrong from address");
+            assert_eq!(&event_to, to, "Transfer event has wrong to address");
+            assert_eq!(event_amount, amount, "Transfer event has wrong amount");
+        }
+
+        /// Asserts a SEP-41 muxed transfer event whose data field is
+        /// `{to_muxed_id: Option<u64>, amount: i128}`.
+        pub fn assert_fungible_muxed_transfer(
             &mut self,
             from: &Address,
             to: &Address,

--- a/packages/tokens/src/fungible/mod.rs
+++ b/packages/tokens/src/fungible/mod.rs
@@ -327,10 +327,34 @@ pub const INSTANCE_TTL_THRESHOLD: u32 = INSTANCE_EXTEND_AMOUNT - DAY_IN_LEDGERS;
 
 // ################## EVENTS ##################
 
-/// Event emitted when tokens are transferred between addresses.
-#[contractevent]
+/// Event emitted when tokens are transferred between addresses without a
+/// muxed destination.
+///
+/// Per SEP-41, the event data is a bare `i128` when no muxed address is
+/// involved. The `data_format = "single-value"` attribute ensures the
+/// `amount` field is serialized as a bare value rather than a map.
+#[contractevent(data_format = "single-value")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Transfer {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub to: Address,
+    pub amount: i128,
+}
+
+/// Event emitted when tokens are transferred to a muxed address.
+///
+/// Per SEP-41, when the destination is a [`MuxedAddress`] the event data
+/// carries both the amount and the muxed identifier so that off-chain
+/// consumers can attribute the transfer to the correct sub-account.
+///
+/// Uses `topics = ["transfer"]` so that both [`Transfer`] and
+/// [`MuxedTransfer`] share the same `"transfer"` event symbol, as required
+/// by SEP-41.
+#[contractevent(topics = ["transfer"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MuxedTransfer {
     #[topic]
     pub from: Address,
     #[topic]
@@ -340,6 +364,14 @@ pub struct Transfer {
 }
 
 /// Emits an event indicating a transfer of tokens.
+///
+/// When `to_muxed_id` is `Some`, a [`MuxedTransfer`] event is published
+/// whose data field is `{to_muxed_id: Option<u64>, amount: i128}`. When it
+/// is `None`, a [`Transfer`] event is published whose data field is a bare
+/// `i128`, conforming to the SEP-41 standard.
+///
+/// Both variants share the same topic structure:
+/// `["transfer", from: Address, to: Address]`.
 ///
 /// # Arguments
 ///
@@ -355,7 +387,14 @@ pub fn emit_transfer(
     to_muxed_id: Option<u64>,
     amount: i128,
 ) {
-    Transfer { from: from.clone(), to: to.clone(), to_muxed_id, amount }.publish(e);
+    match to_muxed_id {
+        Some(_) => {
+            MuxedTransfer { from: from.clone(), to: to.clone(), to_muxed_id, amount }.publish(e);
+        }
+        None => {
+            Transfer { from: from.clone(), to: to.clone(), amount }.publish(e);
+        }
+    }
 }
 
 /// Event emitted when an allowance is approved.

--- a/packages/tokens/src/fungible/storage.rs
+++ b/packages/tokens/src/fungible/storage.rs
@@ -336,7 +336,9 @@ impl Base {
     /// # Events
     ///
     /// * topics - `["transfer", from: Address, to: Address]`
-    /// * data - `[to_muxed_id: Option<u64>, amount: i128]`
+    /// * data - `amount: i128` (when `to` has no muxed ID)
+    /// * data - `{to_muxed_id: Option<u64>, amount: i128}` (when `to` has a
+    ///   muxed ID)
     ///
     /// # Notes
     ///

--- a/packages/tokens/src/fungible/test.rs
+++ b/packages/tokens/src/fungible/test.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
         storage::{Instance, Persistent},
         Address as _, AuthorizedFunction, Events, Ledger, MuxedAddress as _,
     },
-    vec, Address, Env, Event, IntoVal, MuxedAddress, String,
+    vec, Address, Env, Event, FromVal, IntoVal, Map, MuxedAddress, String, Symbol, TryFromVal, Val,
 };
 use stellar_event_assertion::EventAssertion;
 
@@ -246,7 +246,7 @@ fn transfer_works() {
         let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_fungible_mint(&from, 100);
-        event_assert.assert_fungible_transfer(&from, &recipient, None, 50);
+        event_assert.assert_fungible_transfer(&from, &recipient, 50);
     });
 }
 
@@ -285,7 +285,104 @@ fn transfer_muxed_address_works() {
         let mut event_assert = EventAssertion::new(&e, address.clone());
         event_assert.assert_event_count(2);
         event_assert.assert_fungible_mint(&from, 100);
-        event_assert.assert_fungible_transfer(&from, &recipient.address(), recipient.id(), 50);
+        event_assert.assert_fungible_muxed_transfer(
+            &from,
+            &recipient.address(),
+            recipient.id(),
+            50,
+        );
+    });
+}
+
+/// Verifies that `transfer` to a non-muxed address emits a SEP-41
+/// compliant event whose data is a bare `i128` (not a struct).
+#[test]
+fn transfer_non_muxed_emits_bare_i128_event_data() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+    let from = Address::generate(&e);
+    let to = Address::generate(&e);
+
+    e.as_contract(&address, || {
+        Base::mint(&e, &from, 100);
+        Base::transfer(&e, &from, &MuxedAddress::from(to.clone()), 50);
+
+        // Grab the raw transfer event (skip mint at index 0).
+        let events = e.events().all();
+        let transfer_event = events.events().get(1).unwrap();
+
+        // The data field must decode as a bare i128, proving it is NOT
+        // wrapped in a map/struct.
+        let data = match &transfer_event.body {
+            soroban_sdk::xdr::ContractEventBody::V0(ref body) => &body.data,
+        };
+        let val = Val::try_from_val(&e, data).unwrap();
+        let amount: i128 = FromVal::from_val(&e, &val);
+        assert_eq!(amount, 50);
+    });
+}
+
+/// Verifies that `transfer_from` emits a SEP-41 compliant event whose data
+/// is a bare `i128`.
+#[test]
+fn transfer_from_emits_bare_i128_event_data() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+    let owner = Address::generate(&e);
+    let spender = Address::generate(&e);
+    let to = Address::generate(&e);
+
+    e.as_contract(&address, || {
+        Base::mint(&e, &owner, 100);
+        Base::approve(&e, &owner, &spender, 50, 1000);
+        Base::transfer_from(&e, &spender, &owner, &to, 30);
+
+        // Grab the raw transfer event (skip mint at 0, approve at 1).
+        let events = e.events().all();
+        let transfer_event = events.events().get(2).unwrap();
+
+        let data = match &transfer_event.body {
+            soroban_sdk::xdr::ContractEventBody::V0(ref body) => &body.data,
+        };
+        let val = Val::try_from_val(&e, data).unwrap();
+        let amount: i128 = FromVal::from_val(&e, &val);
+        assert_eq!(amount, 30);
+    });
+}
+
+/// Verifies that `transfer` to a muxed address emits event data as a
+/// struct containing both `to_muxed_id` and `amount`, distinct from the
+/// bare `i128` emitted for non-muxed transfers.
+#[test]
+fn transfer_muxed_emits_struct_event_data() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+    let from = Address::generate(&e);
+    let recipient = MuxedAddress::generate(&e);
+
+    e.as_contract(&address, || {
+        Base::mint(&e, &from, 100);
+        Base::transfer(&e, &from, &recipient, 50);
+
+        // Grab the raw transfer event (skip mint at index 0).
+        let events = e.events().all();
+        let transfer_event = events.events().get(1).unwrap();
+
+        let data = match &transfer_event.body {
+            soroban_sdk::xdr::ContractEventBody::V0(ref body) => &body.data,
+        };
+
+        // The data must be a map with both `to_muxed_id` and `amount` keys.
+        let data_map: Map<Symbol, Val> = Map::from_val(&e, data);
+        let event_amount: i128 = data_map.get(symbol_short!("amount")).unwrap().into_val(&e);
+        let event_muxed_id: Option<u64> =
+            data_map.get(Symbol::new(&e, "to_muxed_id")).unwrap().into_val(&e);
+
+        assert_eq!(event_amount, 50);
+        assert_eq!(event_muxed_id, recipient.id());
     });
 }
 
@@ -339,7 +436,7 @@ fn approve_and_transfer_from() {
         event_assert.assert_event_count(3);
         event_assert.assert_fungible_mint(&owner, 100);
         event_assert.assert_fungible_approve(&owner, &spender, 50, 1000);
-        event_assert.assert_fungible_transfer(&owner, &recipient, None, 30);
+        event_assert.assert_fungible_transfer(&owner, &recipient, 30);
     });
 }
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #633 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Fungible token transfers now support muxed recipient addresses with conditional event data formatting based on recipient type
  - New assertion methods available for validating muxed transfer events in test suites

* **Tests**
  - Expanded event assertion toolkit with enhanced validation capabilities for transfer events
  - Added comprehensive test coverage to verify correct event payload structures for both standard and muxed recipient address transfers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->