### PR TITLE
Smart account: authenticate after matching signers

### DIFF
--- a/packages/accounts/src/smart_account/storage.rs
+++ b/packages/accounts/src/smart_account/storage.rs
@@ -249,29 +249,6 @@ pub fn get_policy_id(e: &Env, policy: &Address) -> u32 {
         .unwrap_or_else(|| panic_with_error!(e, SmartAccountError::PolicyNotFound))
 }
 
-/// Filters rule signers to find which ones are present in the provided signer
-/// list. Returns a vector of signers that exist in both the rule and the
-/// provided signer list.
-///
-/// # Arguments
-///
-/// * `e` - Access to the Soroban environment.
-/// * `rule_signers` - The signers required by a context rule.
-/// * `all_signers` - The signers provided for authentication.
-pub fn get_authenticated_signers(
-    e: &Env,
-    rule_signers: &Vec<Signer>,
-    all_signers: &Vec<Signer>,
-) -> Vec<Signer> {
-    let mut authenticated = Vec::new(e);
-    for rule_signer in rule_signers.iter() {
-        if all_signers.contains(&rule_signer) {
-            authenticated.push_back(rule_signer);
-        }
-    }
-    authenticated
-}
-
 /// Validates a context against a specific rule identified by `id`. Checks
 /// expiration, context type compatibility, and signer requirements.
 ///
@@ -331,50 +308,51 @@ pub fn get_validated_context_by_id(
     }
 
     let ContextRule { signers: ref rule_signers, ref policies, .. } = context_rule;
-    let authenticated_signers = get_authenticated_signers(e, rule_signers, all_signers);
+    // Filters rule signers to find which ones are present in the provided signer
+    // list.
+    let matched_signers =
+        Vec::from_iter(e, rule_signers.iter().filter(|s| all_signers.contains(s)));
 
     if policies.is_empty() {
-        // Without policies, all rule signers must be authenticated.
-        if rule_signers.len() != authenticated_signers.len() {
+        // Without policies, all rule signers must be matched.
+        if rule_signers.len() != matched_signers.len() {
             panic_with_error!(e, SmartAccountError::UnvalidatedContext);
         }
     }
     // With policies, defer full validation to enforce().
 
-    (context_rule, context.clone(), authenticated_signers)
+    (context_rule, context.clone(), matched_signers)
 }
 
-/// Authenticates all provided signatures against their respective signers.
-/// Verifies both `Address` authorizations and delegated signatures through
-/// external verifier contracts.
+/// Verifies an `Address` authorization or a cryptographic signature through an
+/// external verifier contract.
 ///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.
 /// * `signature_payload` - The hash of the data that was signed.
-/// * `signers` - The signers mapped to their signature data.
+/// * `signer` - The signer who signed the payload.
+/// * `sig_data` - The signature to verify for an external signer.
 ///
 /// # Errors
 ///
 /// * [`SmartAccountError::ExternalVerificationFailed`] - When an external
 ///   signature fails verification through its verifier contract.
-pub fn authenticate(e: &Env, signature_payload: &Hash<32>, signers: &Map<Signer, Bytes>) {
-    for (signer, sig_data) in signers.iter() {
-        match signer {
-            Signer::External(verifier, key_data) => {
-                let sig_payload = Bytes::from_array(e, &signature_payload.to_bytes().to_array());
-                if !VerifierClient::new(e, &verifier).verify(
-                    &sig_payload,
-                    &key_data.into_val(e),
-                    &sig_data.into_val(e),
-                ) {
-                    panic_with_error!(e, SmartAccountError::ExternalVerificationFailed)
-                }
+pub fn authenticate(e: &Env, signature_payload: &Hash<32>, signer: &Signer, sig_data: &Bytes) {
+    match signer {
+        Signer::External(verifier, key_data) => {
+            let sig_payload = signature_payload.to_bytes().to_bytes();
+            if !VerifierClient::new(e, verifier).verify(
+                &sig_payload,
+                &key_data.into_val(e),
+                &sig_data.into_val(e),
+            ) {
+                panic_with_error!(e, SmartAccountError::ExternalVerificationFailed)
             }
-            Signer::Delegated(addr) => {
-                let args = (signature_payload.clone(),).into_val(e);
-                addr.require_auth_for_args(args)
-            }
+        }
+        Signer::Delegated(addr) => {
+            let args = (signature_payload.clone(),).into_val(e);
+            addr.require_auth_for_args(args)
         }
     }
 }
@@ -491,13 +469,6 @@ pub fn do_check_auth(
         panic_with_error!(e, SmartAccountError::ContextRuleIdsLengthMismatch);
     }
 
-    // Bind context_rule_ids into the signed digest.
-    let mut preimage = signature_payload.to_bytes().to_bytes();
-    preimage.append(&signatures.context_rule_ids.clone().to_xdr(e));
-    let auth_digest = e.crypto().sha256(&preimage);
-
-    authenticate(e, &auth_digest, &signatures.signers);
-
     // Validate all contexts against their specified rules.
     let validated_contexts = Vec::from_iter(
         e,
@@ -510,30 +481,38 @@ pub fn do_check_auth(
     );
 
     let mut allowed_signers = Map::new(e);
-    for (rule, context, authenticated_signers) in validated_contexts.iter() {
+    for (rule, _, _) in validated_contexts.iter() {
         // Collect all signers from the validated rules to check below for signers that
         // do not belong to any rule.
         for signer in rule.signers.iter() {
             allowed_signers.set(signer, ());
         }
+    }
 
-        // Enforce all policies.
+    // Bind context_rule_ids into the signed digest.
+    let mut preimage = signature_payload.to_bytes().to_bytes();
+    preimage.append(&signatures.context_rule_ids.clone().to_xdr(e));
+    let auth_digest = e.crypto().sha256(&preimage);
+
+    // Authenticate and reject any signer that is not part of any
+    // selected rule, preventing arbitrary external calls via
+    // attacker-controlled verifier contracts.
+    for (signer, sig_data) in signatures.signers.iter() {
+        if !allowed_signers.contains_key(signer.clone()) {
+            panic_with_error!(e, SmartAccountError::UnauthorizedSigner);
+        }
+        authenticate(e, &auth_digest, &signer, &sig_data);
+    }
+
+    // Enforce all policies.
+    for (rule, context, matched_signers) in validated_contexts.iter() {
         for policy in rule.policies.iter() {
             PolicyClient::new(e, &policy).enforce(
                 &context,
-                &authenticated_signers,
+                &matched_signers,
                 &rule,
                 &e.current_contract_address(),
             );
-        }
-    }
-
-    // Reject any signer in AuthPayload that is not part of any selected
-    // rule, preventing arbitrary external calls via attacker-controlled
-    // verifier contracts.
-    for signer in signatures.signers.keys().iter() {
-        if !allowed_signers.contains_key(signer) {
-            panic_with_error!(e, SmartAccountError::UnauthorizedSigner);
         }
     }
 

--- a/packages/accounts/src/smart_account/storage.rs
+++ b/packages/accounts/src/smart_account/storage.rs
@@ -330,7 +330,7 @@ pub fn get_validated_context_by_id(
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.
-/// * `signature_payload` - The hash of the data that was signed.
+/// * `auth_digest` - The hash of the data that was signed.
 /// * `signer` - The signer who signed the payload.
 /// * `sig_data` - The signature to verify for an external signer.
 ///
@@ -338,10 +338,10 @@ pub fn get_validated_context_by_id(
 ///
 /// * [`SmartAccountError::ExternalVerificationFailed`] - When an external
 ///   signature fails verification through its verifier contract.
-pub fn authenticate(e: &Env, signature_payload: &Hash<32>, signer: &Signer, sig_data: &Bytes) {
+pub fn authenticate(e: &Env, auth_digest: &Hash<32>, signer: &Signer, sig_data: &Bytes) {
     match signer {
         Signer::External(verifier, key_data) => {
-            let sig_payload = signature_payload.to_bytes().to_bytes();
+            let sig_payload = auth_digest.to_bytes().to_bytes();
             if !VerifierClient::new(e, verifier).verify(
                 &sig_payload,
                 &key_data.into_val(e),
@@ -351,7 +351,7 @@ pub fn authenticate(e: &Env, signature_payload: &Hash<32>, signer: &Signer, sig_
             }
         }
         Signer::Delegated(addr) => {
-            let args = (signature_payload.clone(),).into_val(e);
+            let args = (auth_digest.clone(),).into_val(e);
             addr.require_auth_for_args(args)
         }
     }

--- a/packages/accounts/src/smart_account/test/context_rules.rs
+++ b/packages/accounts/src/smart_account/test/context_rules.rs
@@ -16,9 +16,9 @@ use crate::{
     policies::Policy,
     smart_account::{
         storage::{
-            add_context_rule, authenticate, do_check_auth, get_authenticated_signers,
-            get_context_rule, get_context_rules_count, get_validated_context_by_id,
-            remove_context_rule, update_context_rule_name, update_context_rule_valid_until,
+            add_context_rule, authenticate, do_check_auth, get_context_rule,
+            get_context_rules_count, get_validated_context_by_id, remove_context_rule,
+            update_context_rule_name, update_context_rule_valid_until,
             validate_no_canonical_duplicates, AuthPayload, ContextRule, ContextRuleType, Signer,
             SmartAccountStorageKey,
         },
@@ -713,12 +713,9 @@ fn authenticate_external_signer_verification_fails() {
             e.storage().persistent().set(&symbol_short!("verify"), &false);
         });
 
-        let mut signature_map = Map::new(&e);
-        signature_map.set(signer, sig_data);
+        let payload = e.crypto().sha256(&Bytes::from_array(&e, &[1u8; 32]));
 
-        let payload = Bytes::from_array(&e, &[1u8; 32]);
-
-        authenticate(&e, &e.crypto().sha256(&payload), &signature_map);
+        authenticate(&e, &payload, &signer, &sig_data);
     });
 }
 
@@ -742,62 +739,10 @@ fn authenticate_mixed_signers_success() {
             e.storage().persistent().set(&symbol_short!("verify"), &true);
         });
 
-        let mut signature_map = Map::new(&e);
-        signature_map.set(native_signer, Bytes::new(&e));
-        signature_map.set(external_signer, Bytes::from_array(&e, &[5, 6, 7, 8]));
+        let payload = e.crypto().sha256(&Bytes::from_array(&e, &[1u8; 32]));
 
-        let payload = Bytes::from_array(&e, &[1u8; 32]);
-
-        authenticate(&e, &e.crypto().sha256(&payload), &signature_map);
-    });
-}
-
-#[test]
-fn get_authenticated_signers_combos() {
-    let e = Env::default();
-    let address = e.register(MockContract, ());
-
-    e.as_contract(&address, || {
-        // all match
-        let rule_signers = create_test_signers(&e);
-        let all_signers = rule_signers.clone();
-        let authenticated = get_authenticated_signers(&e, &rule_signers, &all_signers);
-        assert_eq!(authenticated.len(), 2);
-        assert_eq!(authenticated, rule_signers);
-
-        // empty all_signers
-        let authenticated = get_authenticated_signers(&e, &rule_signers, &Vec::new(&e));
-        assert_eq!(authenticated.len(), 0);
-
-        // empty rule_signers
-        let authenticated = get_authenticated_signers(&e, &Vec::new(&e), &create_test_signers(&e));
-        assert_eq!(authenticated.len(), 0);
-
-        // partial match
-        let addr1 = Address::generate(&e);
-        let addr2 = Address::generate(&e);
-        let addr3 = Address::generate(&e);
-        let rule_signers = Vec::from_array(
-            &e,
-            [Signer::Delegated(addr1.clone()), Signer::Delegated(addr2.clone())],
-        );
-        let all_signers = Vec::from_array(
-            &e,
-            [
-                Signer::Delegated(addr1.clone()),
-                Signer::Delegated(addr3.clone()), // addr2 is missing, addr3 is extra
-            ],
-        );
-        let authenticated = get_authenticated_signers(&e, &rule_signers, &all_signers);
-        assert_eq!(authenticated.len(), 1); // Only addr1 matches
-        assert_eq!(authenticated.get(0).unwrap(), Signer::Delegated(addr1.clone()));
-
-        // no match
-        let rule_signers =
-            Vec::from_array(&e, [Signer::Delegated(addr1), Signer::Delegated(addr2)]);
-        let all_signers = Vec::from_array(&e, [Signer::Delegated(addr3)]);
-        let authenticated = get_authenticated_signers(&e, &rule_signers, &all_signers);
-        assert_eq!(authenticated.len(), 0);
+        authenticate(&e, &payload, &native_signer, &Bytes::new(&e));
+        authenticate(&e, &payload, &external_signer, &Bytes::from_array(&e, &[5, 6, 7, 8]));
     });
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated smart account authentication API to verify individual signature pairs instead of batch verification.
  * Streamlined authentication validation flow for improved performance.
  * Removed `get_authenticated_signers` helper function; use inline validation instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->