### PR TITLE
feat(crypto): Grumpkin affine point arithmetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,132 +46,277 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
 name = "ark-bn254"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-ec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
- "itertools",
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
- "derivative",
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
  "digest",
- "itertools",
+ "educe",
+ "itertools 0.13.0",
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest",
+ "educe",
+ "num-bigint",
+ "num-traits",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-grumpkin"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c969a12ceed8881e5c66277dabd3e7a5aa2c72c9370f3f42eca3f2dd33a21a"
+dependencies = [
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-poly"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
  "digest",
  "num-bigint",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "ark-std"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
 ]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
@@ -242,7 +393,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -269,7 +420,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -378,7 +529,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -412,7 +563,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -425,7 +576,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -436,7 +587,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -447,7 +598,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -478,17 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,7 +636,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -578,6 +718,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +753,26 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -905,19 +1077,11 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
  "foldhash",
 ]
 
@@ -926,6 +1090,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heapless"
@@ -1040,9 +1207,18 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1126,7 +1302,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1264,7 +1440,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1374,7 +1550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1526,7 +1702,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1774,7 +1950,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1819,7 +1995,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1873,21 +2049,21 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "25.0.1"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7192e3a5551a7aeee90d2110b11b615798e81951fd8c8293c87ea7f88b0168f5"
+checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-env-common"
-version = "25.0.1"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc49a80a68fc1005847308e63b9fce39874de731940b1807b721d472de3ff01"
+checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1904,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "25.0.1"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2334ba1cfe0a170ab744d96db0b4ca86934de9ff68187ceebc09dc342def55"
+checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1914,15 +2090,15 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "25.0.1"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43af5d53c57bc2f546e122adc0b1cca6f93942c718977379aa19ddd04f06fcec"
+checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
  "curve25519-dalek",
  "ecdsa",
  "ed25519-dalek",
@@ -1951,24 +2127,24 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "25.0.1"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a989167512e3592d455b1e204d703cfe578a36672a77ed2f9e6f7e1bbfd9cc5c"
+checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "25.3.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca06e6c5029d1285e66219cb387a234224e26969ce8ad2bc2d5017e9395d63b"
+checksum = "0d519682f5cf750a769f2c89f32ee089f48b9e645e01af34fc3b98a78e9a4ede"
 dependencies = [
  "serde",
  "serde_json",
@@ -1980,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.3.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4502f2e018f238a4c5d3212d7d20ea6abcdc6e58babd63b642b693739db30fd1"
+checksum = "d03acd78bf4c80d5cacc8ee149966a49aaf8873b9936315af09f820887085c5e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -2004,13 +2180,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "25.3.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca03e9cf61d241cb9afdd6ddf41f6c25698b3f566a875e7009ea799b89e2bf0a"
+checksum = "9751225bd51b04257eb4aca60fcc996a3b6d69c81ac39ca24e68e9bf97aabe83"
 dependencies = [
  "darling 0.20.11",
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -2019,14 +2195,14 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "25.3.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa02e07f507cc27406ae0834db4dcf309b78c4cc8776eb3b2d662d66e8859d25"
+checksum = "867c8b583180e7398af6c43134202dc1324e42c32b32d859aa921ce61de6c9ca"
 dependencies = [
  "base64",
  "sha2",
@@ -2037,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "25.3.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6835bb510763ef3fa5405e89036e3c8ea6ef5abe55fc52cfe9ac0e38be9d531c"
+checksum = "f41517bf9490f66cf0403d1048bdf1b9560c4f88b2e067b7f8ec73241b4c4514"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2047,7 +2223,7 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.117",
+ "syn",
  "thiserror",
 ]
 
@@ -2059,7 +2235,7 @@ checksum = "f7d51ae9c644ccd8dd2c41148ee31a037641b1aeb85b76d519c7f6e9a4cd55b0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2129,6 +2305,10 @@ dependencies = [
 name = "stellar-contract-utils"
 version = "0.7.1"
 dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-grumpkin",
+ "ark-serialize 0.6.0",
  "hex-literal 1.1.0",
  "proptest",
  "soroban-sdk",
@@ -2165,7 +2345,7 @@ version = "0.7.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2205,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "25.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d20dafed80076b227d4b17c0c508a4bbc4d5e4c3d4c1de7cd42242df4b1eaf"
+checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
 dependencies = [
  "arbitrary",
  "base64",
@@ -2240,17 +2420,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2293,7 +2462,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2425,7 +2594,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2493,7 +2662,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2598,7 +2767,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2609,7 +2778,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2681,7 +2850,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2697,7 +2866,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2756,7 +2925,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2776,7 +2945,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ categories = ["no-std", "wasm"]
 version = "0.7.1"
 
 [workspace.dependencies]
-soroban-sdk = { version = "25.3.0", features = [
+soroban-sdk = { version = "26.0.0", features = [
     "experimental_spec_shaking_v2",
 ] }
 proc-macro2 = "1.0"

--- a/packages/contract-utils/Cargo.toml
+++ b/packages/contract-utils/Cargo.toml
@@ -23,3 +23,7 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 proptest = { workspace = true }
 hex-literal = { workspace = true }
 stellar-event-assertion = { workspace = true }
+ark-grumpkin = { version = "0.6", default-features = false }
+ark-ec = { version = "0.6", default-features = false }
+ark-ff = { version = "0.6", default-features = false }
+ark-serialize = { version = "0.6", default-features = false }

--- a/packages/contract-utils/src/crypto/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/grumpkin.rs
@@ -42,16 +42,28 @@ pub struct Grumpkin;
 
 impl Grumpkin {
     /// Returns the encoded identity element (the point at infinity).
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
     pub fn identity(e: &Env) -> Point {
         BytesN::from_array(e, &[0u8; 64])
     }
 
     /// Returns `true` iff `p` is the identity (all-zero 64-byte encoding).
+    ///
+    /// # Arguments
+    ///
+    /// * `p` - The point to check.
     pub fn is_identity(p: &Point) -> bool {
         p.to_array() == [0u8; 64]
     }
 
     /// Returns `true` iff `p` is not the identity.
+    ///
+    /// # Arguments
+    ///
+    /// * `p` - The point to check.
     pub fn is_not_identity(p: &Point) -> bool {
         !Self::is_identity(p)
     }
@@ -69,6 +81,11 @@ impl Grumpkin {
     /// The identity encoding `(0, 0)` returns `false`: `0² ≠ -17 (mod r)`. To
     /// admit `O` as a valid group element, combine this with
     /// [`Self::is_identity`] at the call site.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p` - The point to validate.
     pub fn is_on_curve(e: &Env, p: &Point) -> bool {
         let bytes = p.to_array();
         if !is_canonical_coord(&bytes[..32]) || !is_canonical_coord(&bytes[32..]) {
@@ -82,6 +99,11 @@ impl Grumpkin {
 
     /// Returns `-p`. For non-identity `p = (x, y)`, this is `(x, -y mod r)`;
     /// `-O = O`.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p` - The point to negate.
     pub fn neg(e: &Env, p: &Point) -> Point {
         if Self::is_identity(p) {
             return p.clone();
@@ -103,6 +125,12 @@ impl Grumpkin {
     ///    two-torsion edge case `y = 0`, since then `y = -y` and `p = -p`.
     /// 4. `p1 = p2` → doubling with slope `λ_dbl = 3·x1² / (2·y1)`.
     /// 5. Otherwise (generic) → slope `λ_add = (y2 - y1) / (x2 - x1)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p1` - The first summand.
+    /// * `p2` - The second summand.
     pub fn add(e: &Env, p1: &Point, p2: &Point) -> Point {
         if Self::is_identity(p1) {
             return p2.clone();
@@ -142,11 +170,23 @@ impl Grumpkin {
 
     /// Returns `p1 - p2 = p1 + (-p2)`. Subtraction of a point from itself
     /// returns `O` via the inverse case in [`Self::add`].
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p1` - The minuend.
+    /// * `p2` - The subtrahend.
     pub fn sub(e: &Env, p1: &Point, p2: &Point) -> Point {
         Self::add(e, p1, &Self::neg(e, p2))
     }
 
     /// Encodes `(x, y)` as a 64-byte [`Point`].
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `x` - The x-coordinate as a `Bn254Fr` element.
+    /// * `y` - The y-coordinate as a `Bn254Fr` element.
     pub fn from_xy(e: &Env, x: &Bn254Fr, y: &Bn254Fr) -> Point {
         let mut bytes = [0u8; 64];
         bytes[..32].copy_from_slice(&x.to_bytes().to_array());
@@ -155,6 +195,11 @@ impl Grumpkin {
     }
 
     /// Decodes `(x, y)` from a 64-byte [`Point`].
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p` - The encoded point to decode.
     pub fn coordinates(e: &Env, p: &Point) -> (Bn254Fr, Bn254Fr) {
         let bytes = p.to_array();
         let mut x = [0u8; 32];

--- a/packages/contract-utils/src/crypto/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/grumpkin.rs
@@ -31,6 +31,16 @@ use soroban_sdk::{crypto::bn254::Bn254Fr, BytesN, Env, U256};
 /// infinity).
 pub type Point = BytesN<64>;
 
+/// Canonical byte encoding of the identity element (point at infinity).
+const IDENTITY_BYTES: [u8; 64] = [0u8; 64];
+
+/// BN254 scalar field order `r` in big-endian bytes — the canonical upper
+/// bound on a coordinate's 32-byte representative.
+const BN254_FR_MODULUS_BE: [u8; 32] = [
+    0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58, 0x5d,
+    0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00, 0x00, 0x01,
+];
+
 /// Grumpkin point arithmetic over `Bn254Fr`.
 ///
 /// The implementation performs no on-curve check on its inputs: callers must
@@ -47,7 +57,7 @@ impl Grumpkin {
     ///
     /// * `e` - Access to the Soroban environment.
     pub fn identity(e: &Env) -> Point {
-        BytesN::from_array(e, &[0u8; 64])
+        BytesN::from_array(e, &IDENTITY_BYTES)
     }
 
     /// Returns `true` iff `p` is the identity (all-zero 64-byte encoding).
@@ -56,7 +66,7 @@ impl Grumpkin {
     ///
     /// * `p` - The point to check.
     pub fn is_identity(p: &Point) -> bool {
-        p.to_array() == [0u8; 64]
+        p.to_array() == IDENTITY_BYTES
     }
 
     /// Returns `true` iff `p` is not the identity.
@@ -220,13 +230,6 @@ fn fr_zero(e: &Env) -> Bn254Fr {
 fn fr_from_u32(e: &Env, v: u32) -> Bn254Fr {
     Bn254Fr::from_u256(U256::from_u32(e, v))
 }
-
-/// BN254 scalar field order `r` in big-endian bytes — the canonical upper
-/// bound on a coordinate's 32-byte representative.
-const BN254_FR_MODULUS_BE: [u8; 32] = [
-    0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58, 0x5d,
-    0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00, 0x00, 0x01,
-];
 
 /// Returns `true` iff `coord` is a canonical 32-byte big-endian `Bn254Fr`
 /// representative, i.e. lexicographically less than the field modulus `r`.

--- a/packages/contract-utils/src/crypto/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/grumpkin.rs
@@ -57,12 +57,23 @@ impl Grumpkin {
     }
 
     /// Returns `true` iff `(x, y)` satisfies Grumpkin's curve equation
-    /// `y² ≡ x³ - 17 (mod r)`.
+    /// `y² ≡ x³ - 17 (mod r)` **and** each coordinate is a canonical
+    /// `Bn254Fr` representative (`< r` as a 32-byte big-endian integer).
+    ///
+    /// The canonical-range check is required for byte equality on validated
+    /// points to be sound: without it, the same logical point `(x, y)` has
+    /// multiple distinct encodings (e.g. `be(x) || be(y)` and
+    /// `be(x + r) || be(y)`), all of which `Bn254Fr::from_bytes` reduces to
+    /// the same value, breaking uniqueness checks keyed on the raw bytes.
     ///
     /// The identity encoding `(0, 0)` returns `false`: `0² ≠ -17 (mod r)`. To
     /// admit `O` as a valid group element, combine this with
     /// [`Self::is_identity`] at the call site.
     pub fn is_on_curve(e: &Env, p: &Point) -> bool {
+        let bytes = p.to_array();
+        if !is_canonical_coord(&bytes[..32]) || !is_canonical_coord(&bytes[32..]) {
+            return false;
+        }
         let (x, y) = Self::coordinates(e, p);
         let lhs = y.clone() * y;
         let rhs = x.clone() * x.clone() * x - fr_from_u32(e, 17);
@@ -163,4 +174,19 @@ fn fr_zero(e: &Env) -> Bn254Fr {
 
 fn fr_from_u32(e: &Env, v: u32) -> Bn254Fr {
     Bn254Fr::from_u256(U256::from_u32(e, v))
+}
+
+/// BN254 scalar field order `r` in big-endian bytes — the canonical upper
+/// bound on a coordinate's 32-byte representative.
+const BN254_FR_MODULUS_BE: [u8; 32] = [
+    0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58, 0x5d,
+    0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00, 0x00, 0x01,
+];
+
+/// Returns `true` iff `coord` is a canonical 32-byte big-endian `Bn254Fr`
+/// representative, i.e. lexicographically less than the field modulus `r`.
+/// Lexicographic byte comparison on fixed-width 32-byte big-endian arrays
+/// coincides with numeric comparison.
+fn is_canonical_coord(coord: &[u8]) -> bool {
+    coord < &BN254_FR_MODULUS_BE[..]
 }

--- a/packages/contract-utils/src/crypto/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/grumpkin.rs
@@ -1,0 +1,166 @@
+//! Grumpkin affine point arithmetic over Soroban's BN254 scalar field.
+//!
+//! Grumpkin is the prime-order elliptic curve `y² = x³ - 17` defined over
+//! `F_r`, the scalar field of BN254. Because Grumpkin's base field equals
+//! BN254's scalar field, every coordinate operation reduces to a `Bn254Fr`
+//! host call (CAP-80: `bn254_fr_{add, sub, mul, inv}`).
+//!
+//! This module exposes:
+//!
+//! * [`Grumpkin::add`], [`Grumpkin::sub`], [`Grumpkin::neg`] — affine point
+//!   arithmetic with full identity handling.
+//! * [`Grumpkin::is_on_curve`], [`Grumpkin::is_not_identity`] — validation
+//!   helpers for points that enter the system without a soundness proof.
+//! * [`Grumpkin::identity`] — the encoded point at infinity, `(0, 0)` over 64
+//!   bytes.
+//!
+//! # Encoding
+//!
+//! A [`Point`] is a `BytesN<64>` laid out as `be_bytes(x) || be_bytes(y)`, each
+//! coordinate a canonical 32-byte big-endian `Bn254Fr` representative. The
+//! identity is the all-zero encoding `(0, 0)` and is handled as a special case
+//! in arithmetic. Real curve points cannot share this encoding because
+//! `0² ≠ 0³ - 17 (mod r)`.
+
+use soroban_sdk::{crypto::bn254::Bn254Fr, BytesN, Env, U256};
+
+/// Affine encoding of a Grumpkin point as a 64-byte value.
+///
+/// Layout: `be_bytes(x) || be_bytes(y)`, each a canonical 32-byte `Bn254Fr`
+/// representative. The all-zero encoding represents the identity (point at
+/// infinity).
+pub type Point = BytesN<64>;
+
+/// Grumpkin point arithmetic over `Bn254Fr`.
+///
+/// The implementation performs no on-curve check on its inputs: callers must
+/// ensure inputs are valid curve points before calling [`Self::add`],
+/// [`Self::sub`], or [`Self::neg`]. Use [`Self::is_on_curve`] and
+/// [`Self::is_not_identity`] at trust boundaries (e.g. user-supplied points
+/// without an accompanying soundness proof).
+pub struct Grumpkin;
+
+impl Grumpkin {
+    /// Returns the encoded identity element (the point at infinity).
+    pub fn identity(e: &Env) -> Point {
+        BytesN::from_array(e, &[0u8; 64])
+    }
+
+    /// Returns `true` iff `p` is the identity (all-zero 64-byte encoding).
+    pub fn is_identity(p: &Point) -> bool {
+        p.to_array() == [0u8; 64]
+    }
+
+    /// Returns `true` iff `p` is not the identity.
+    pub fn is_not_identity(p: &Point) -> bool {
+        !Self::is_identity(p)
+    }
+
+    /// Returns `true` iff `(x, y)` satisfies Grumpkin's curve equation
+    /// `y² ≡ x³ - 17 (mod r)`.
+    ///
+    /// The identity encoding `(0, 0)` returns `false`: `0² ≠ -17 (mod r)`. To
+    /// admit `O` as a valid group element, combine this with
+    /// [`Self::is_identity`] at the call site.
+    pub fn is_on_curve(e: &Env, p: &Point) -> bool {
+        let (x, y) = Self::coordinates(e, p);
+        let lhs = y.clone() * y;
+        let rhs = x.clone() * x.clone() * x - fr_from_u32(e, 17);
+        lhs == rhs
+    }
+
+    /// Returns `-p`. For non-identity `p = (x, y)`, this is `(x, -y mod r)`;
+    /// `-O = O`.
+    pub fn neg(e: &Env, p: &Point) -> Point {
+        if Self::is_identity(p) {
+            return p.clone();
+        }
+        let (x, y) = Self::coordinates(e, p);
+        let neg_y = fr_zero(e) - y;
+        Self::from_xy(e, &x, &neg_y)
+    }
+
+    /// Returns `p1 + p2` on Grumpkin.
+    ///
+    /// Distinguishes the five cases of affine short-Weierstrass addition:
+    ///
+    /// 1. `p1 = O` → `p2`.
+    /// 2. `p2 = O` → `p1`.
+    /// 3. `x1 = x2` and `y1 = -y2 (mod r)` → `O` (inverse case). This must be
+    ///    detected before the generic case, otherwise `x1 - x2 = 0` forces a
+    ///    division by zero in the slope formula. It also subsumes the
+    ///    two-torsion edge case `y = 0`, since then `y = -y` and `p = -p`.
+    /// 4. `p1 = p2` → doubling with slope `λ_dbl = 3·x1² / (2·y1)`.
+    /// 5. Otherwise (generic) → slope `λ_add = (y2 - y1) / (x2 - x1)`.
+    pub fn add(e: &Env, p1: &Point, p2: &Point) -> Point {
+        if Self::is_identity(p1) {
+            return p2.clone();
+        }
+        if Self::is_identity(p2) {
+            return p1.clone();
+        }
+
+        let (x1, y1) = Self::coordinates(e, p1);
+        let (x2, y2) = Self::coordinates(e, p2);
+
+        if x1 == x2 {
+            let neg_y2 = fr_zero(e) - y2.clone();
+            if y1 == neg_y2 {
+                return Self::identity(e);
+            }
+            // Doubling: y1 = y2 (and y1 ≠ 0, since y1 = -y1 ⇒ y1 = 0 is caught
+            // above as the inverse case).
+            let three = fr_from_u32(e, 3);
+            let two = fr_from_u32(e, 2);
+            let num = three * (x1.clone() * x1.clone());
+            let denom = two * y1.clone();
+            let lambda = num * denom.inv();
+            // x3 = λ² - 2·x1
+            let x3 = lambda.clone() * lambda.clone() - x1.clone() - x1.clone();
+            // y3 = λ·(x1 - x3) - y1
+            let y3 = lambda * (x1 - x3.clone()) - y1;
+            return Self::from_xy(e, &x3, &y3);
+        }
+
+        // Generic case: distinct x-coordinates.
+        let lambda = (y2 - y1.clone()) * (x2.clone() - x1.clone()).inv();
+        let x3 = lambda.clone() * lambda.clone() - x1.clone() - x2;
+        let y3 = lambda * (x1 - x3.clone()) - y1;
+        Self::from_xy(e, &x3, &y3)
+    }
+
+    /// Returns `p1 - p2 = p1 + (-p2)`. Subtraction of a point from itself
+    /// returns `O` via the inverse case in [`Self::add`].
+    pub fn sub(e: &Env, p1: &Point, p2: &Point) -> Point {
+        Self::add(e, p1, &Self::neg(e, p2))
+    }
+
+    /// Encodes `(x, y)` as a 64-byte [`Point`].
+    pub fn from_xy(e: &Env, x: &Bn254Fr, y: &Bn254Fr) -> Point {
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&x.to_bytes().to_array());
+        bytes[32..].copy_from_slice(&y.to_bytes().to_array());
+        BytesN::from_array(e, &bytes)
+    }
+
+    /// Decodes `(x, y)` from a 64-byte [`Point`].
+    pub fn coordinates(e: &Env, p: &Point) -> (Bn254Fr, Bn254Fr) {
+        let bytes = p.to_array();
+        let mut x = [0u8; 32];
+        let mut y = [0u8; 32];
+        x.copy_from_slice(&bytes[..32]);
+        y.copy_from_slice(&bytes[32..]);
+        (
+            Bn254Fr::from_bytes(BytesN::from_array(e, &x)),
+            Bn254Fr::from_bytes(BytesN::from_array(e, &y)),
+        )
+    }
+}
+
+fn fr_zero(e: &Env) -> Bn254Fr {
+    Bn254Fr::from_u256(U256::from_u32(e, 0))
+}
+
+fn fr_from_u32(e: &Env, v: u32) -> Bn254Fr {
+    Bn254Fr::from_u256(U256::from_u32(e, v))
+}

--- a/packages/contract-utils/src/crypto/mod.rs
+++ b/packages/contract-utils/src/crypto/mod.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod grumpkin;
 pub mod hashable;
 pub mod hasher;
 pub mod keccak;

--- a/packages/contract-utils/src/crypto/test/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/test/grumpkin.rs
@@ -1,0 +1,355 @@
+//! Tests for the Grumpkin point arithmetic module.
+//!
+//! Ground-truth point values are produced by `ark-grumpkin` (off-host) and
+//! piped through the 64-byte `(be(x) || be(y))` encoding into the on-host
+//! arithmetic. The property tests cover the algebraic identities of an
+//! abelian group — associativity, commutativity, identity, inversion — plus
+//! Pedersen homomorphism, and exercise the case-by-case branches of `add`
+//! (left/right identity, inverse, doubling, generic).
+
+extern crate std;
+
+use ark_ec::{AffineRepr, CurveGroup, PrimeGroup};
+use ark_ff::{BigInteger, PrimeField, Zero};
+use ark_grumpkin::{Affine as ArkPoint, Fr as ArkScalar, Projective as ArkProj};
+use proptest::prelude::*;
+use soroban_sdk::{BytesN, Env};
+
+use crate::crypto::grumpkin::{Grumpkin, Point};
+
+// ################## HELPERS ##################
+
+/// Encodes an `ark-grumpkin` affine point as the 64-byte on-chain `Point`
+/// (`be(x) || be(y)`, identity = 64 zero bytes).
+fn to_point(e: &Env, p: &ArkPoint) -> Point {
+    if p.is_zero() {
+        return Grumpkin::identity(e);
+    }
+    let mut bytes = [0u8; 64];
+    let x = p.x().expect("non-identity has x").into_bigint().to_bytes_be();
+    let y = p.y().expect("non-identity has y").into_bigint().to_bytes_be();
+    // ark BigInt::to_bytes_be() returns a fixed N*8-byte buffer; for Grumpkin's
+    // 254-bit base field N = 4 so the output is always 32 bytes.
+    bytes[..32].copy_from_slice(&x);
+    bytes[32..].copy_from_slice(&y);
+    BytesN::from_array(e, &bytes)
+}
+
+fn scalar_mul_g(k: ArkScalar) -> ArkPoint {
+    (ArkProj::generator() * k).into_affine()
+}
+
+fn scalar_from_bytes(seed: &[u8]) -> ArkScalar {
+    ArkScalar::from_le_bytes_mod_order(seed)
+}
+
+fn rand_point(e: &Env, seed: &[u8; 32]) -> Point {
+    to_point(e, &scalar_mul_g(scalar_from_bytes(seed)))
+}
+
+/// A second Grumpkin generator `H`, distinct from `G`, used for Pedersen
+/// commitments in the homomorphism test. Independence from `G` is not required
+/// for the algebraic identity `commit(v1, r1) + commit(v2, r2) =
+/// commit(v1+v2, r1+r2)`; any non-identity point works.
+fn h_generator() -> ArkPoint {
+    // H = 2 * G — fixed, deterministic, non-identity.
+    scalar_mul_g(ArkScalar::from(2u64))
+}
+
+fn pedersen_commit(v: ArkScalar, r: ArkScalar) -> ArkPoint {
+    (ArkProj::generator() * v + h_generator() * r).into_affine()
+}
+
+// ################## UNIT TESTS — case-by-case branches ##################
+
+#[test]
+fn identity_is_all_zero_encoding() {
+    let e = Env::default();
+    let o = Grumpkin::identity(&e);
+    assert_eq!(o.to_array(), [0u8; 64]);
+    assert!(Grumpkin::is_identity(&o));
+    assert!(!Grumpkin::is_not_identity(&o));
+}
+
+#[test]
+fn left_identity_returns_other_operand() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x11; 32]);
+    let o = Grumpkin::identity(&e);
+    assert_eq!(Grumpkin::add(&e, &o, &p).to_array(), p.to_array());
+}
+
+#[test]
+fn right_identity_returns_other_operand() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x22; 32]);
+    let o = Grumpkin::identity(&e);
+    assert_eq!(Grumpkin::add(&e, &p, &o).to_array(), p.to_array());
+}
+
+#[test]
+fn inverse_branch_returns_identity() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x33; 32]);
+    let neg_p = Grumpkin::neg(&e, &p);
+    assert_eq!(Grumpkin::add(&e, &p, &neg_p).to_array(), [0u8; 64]);
+    assert_eq!(Grumpkin::add(&e, &neg_p, &p).to_array(), [0u8; 64]);
+}
+
+#[test]
+fn doubling_branch_matches_reference() {
+    let e = Env::default();
+    let k = ArkScalar::from(7u64);
+    let p_ark = scalar_mul_g(k);
+    let two_p_ark = scalar_mul_g(k + k);
+
+    let p = to_point(&e, &p_ark);
+    let two_p = to_point(&e, &two_p_ark);
+
+    assert_eq!(Grumpkin::add(&e, &p, &p).to_array(), two_p.to_array());
+}
+
+#[test]
+fn generic_branch_matches_reference() {
+    let e = Env::default();
+    let k1 = ArkScalar::from(3u64);
+    let k2 = ArkScalar::from(11u64);
+
+    let p1 = to_point(&e, &scalar_mul_g(k1));
+    let p2 = to_point(&e, &scalar_mul_g(k2));
+    let expected = to_point(&e, &scalar_mul_g(k1 + k2));
+
+    assert_eq!(Grumpkin::add(&e, &p1, &p2).to_array(), expected.to_array());
+}
+
+#[test]
+fn neg_identity_is_identity() {
+    let e = Env::default();
+    let o = Grumpkin::identity(&e);
+    assert_eq!(Grumpkin::neg(&e, &o).to_array(), [0u8; 64]);
+}
+
+#[test]
+fn neg_matches_reference() {
+    let e = Env::default();
+    let k = ArkScalar::from(5u64);
+    let p_ark = scalar_mul_g(k);
+    let neg_p_ark = (-p_ark.into_group()).into_affine();
+
+    let p = to_point(&e, &p_ark);
+    let expected = to_point(&e, &neg_p_ark);
+
+    assert_eq!(Grumpkin::neg(&e, &p).to_array(), expected.to_array());
+}
+
+#[test]
+fn sub_self_is_identity() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x55; 32]);
+    assert_eq!(Grumpkin::sub(&e, &p, &p).to_array(), [0u8; 64]);
+}
+
+#[test]
+fn sub_matches_add_with_neg() {
+    let e = Env::default();
+    let p1 = rand_point(&e, &[0x66; 32]);
+    let p2 = rand_point(&e, &[0x77; 32]);
+    let lhs = Grumpkin::sub(&e, &p1, &p2);
+    let rhs = Grumpkin::add(&e, &p1, &Grumpkin::neg(&e, &p2));
+    assert_eq!(lhs.to_array(), rhs.to_array());
+}
+
+// ################## UNIT TESTS — on-curve / identity validation
+// ##################
+
+#[test]
+fn is_on_curve_accepts_real_points() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x99; 32]);
+    assert!(Grumpkin::is_on_curve(&e, &p));
+}
+
+#[test]
+fn is_on_curve_rejects_identity() {
+    let e = Env::default();
+    // (0, 0) is the identity encoding; it does not satisfy y² = x³ − 17.
+    let o = Grumpkin::identity(&e);
+    assert!(!Grumpkin::is_on_curve(&e, &o));
+}
+
+#[test]
+fn is_on_curve_rejects_off_curve_point() {
+    let e = Env::default();
+    // (1, 1) — 1 ≠ 1 - 17 (mod r), so not on the curve.
+    let mut bytes = [0u8; 64];
+    bytes[31] = 1;
+    bytes[63] = 1;
+    let p = BytesN::from_array(&e, &bytes);
+    assert!(!Grumpkin::is_on_curve(&e, &p));
+}
+
+#[test]
+fn is_on_curve_rejects_corrupted_y() {
+    let e = Env::default();
+    let mut p = rand_point(&e, &[0xAA; 32]).to_array();
+    // Flip a bit in y.
+    p[40] ^= 0x01;
+    let p = BytesN::from_array(&e, &p);
+    assert!(!Grumpkin::is_on_curve(&e, &p));
+}
+
+#[test]
+fn is_not_identity_distinguishes_zero_from_real() {
+    let e = Env::default();
+    let o = Grumpkin::identity(&e);
+    let p = rand_point(&e, &[0xBB; 32]);
+    assert!(!Grumpkin::is_not_identity(&o));
+    assert!(Grumpkin::is_not_identity(&p));
+}
+
+#[test]
+fn from_xy_and_coordinates_roundtrip() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0xCC; 32]);
+    let (x, y) = Grumpkin::coordinates(&e, &p);
+    let rebuilt = Grumpkin::from_xy(&e, &x, &y);
+    assert_eq!(rebuilt.to_array(), p.to_array());
+}
+
+// ################## PROPERTY TESTS ##################
+
+fn nonzero_scalar(seed: &[u8; 32]) -> ArkScalar {
+    let mut s = scalar_from_bytes(seed);
+    // Avoid scalar = 0 because then k * G = O and many identities collapse;
+    // we cover the identity case explicitly in unit tests.
+    if s.is_zero() {
+        s = ArkScalar::from(1u64);
+    }
+    s
+}
+
+#[test]
+fn prop_commutativity() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k1: [u8; 32], k2: [u8; 32])| {
+        let s1 = nonzero_scalar(&k1);
+        let s2 = nonzero_scalar(&k2);
+        let p1 = to_point(&e, &scalar_mul_g(s1));
+        let p2 = to_point(&e, &scalar_mul_g(s2));
+
+        let lhs = Grumpkin::add(&e, &p1, &p2);
+        let rhs = Grumpkin::add(&e, &p2, &p1);
+        prop_assert_eq!(lhs.to_array(), rhs.to_array());
+    })
+}
+
+#[test]
+fn prop_associativity() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k1: [u8; 32], k2: [u8; 32], k3: [u8; 32])| {
+        let s1 = nonzero_scalar(&k1);
+        let s2 = nonzero_scalar(&k2);
+        let s3 = nonzero_scalar(&k3);
+        let p1 = to_point(&e, &scalar_mul_g(s1));
+        let p2 = to_point(&e, &scalar_mul_g(s2));
+        let p3 = to_point(&e, &scalar_mul_g(s3));
+
+        let left = Grumpkin::add(&e, &Grumpkin::add(&e, &p1, &p2), &p3);
+        let right = Grumpkin::add(&e, &p1, &Grumpkin::add(&e, &p2, &p3));
+        prop_assert_eq!(left.to_array(), right.to_array());
+    })
+}
+
+#[test]
+fn prop_identity_law() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let o = Grumpkin::identity(&e);
+    proptest!(|(k: [u8; 32])| {
+        let p = to_point(&e, &scalar_mul_g(nonzero_scalar(&k)));
+        prop_assert_eq!(Grumpkin::add(&e, &p, &o).to_array(), p.to_array());
+        prop_assert_eq!(Grumpkin::add(&e, &o, &p).to_array(), p.to_array());
+    })
+}
+
+#[test]
+fn prop_inversion() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k: [u8; 32])| {
+        let p = to_point(&e, &scalar_mul_g(nonzero_scalar(&k)));
+        let neg_p = Grumpkin::neg(&e, &p);
+        prop_assert_eq!(Grumpkin::add(&e, &p, &neg_p).to_array(), [0u8; 64]);
+    })
+}
+
+#[test]
+fn prop_pedersen_homomorphism() {
+    // commit(v1, r1) + commit(v2, r2) == commit(v1 + v2, r1 + r2)
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(
+        v1: [u8; 32], r1: [u8; 32],
+        v2: [u8; 32], r2: [u8; 32],
+    )| {
+        let v1 = scalar_from_bytes(&v1);
+        let r1 = scalar_from_bytes(&r1);
+        let v2 = scalar_from_bytes(&v2);
+        let r2 = scalar_from_bytes(&r2);
+
+        let c1 = to_point(&e, &pedersen_commit(v1, r1));
+        let c2 = to_point(&e, &pedersen_commit(v2, r2));
+        let expected = to_point(&e, &pedersen_commit(v1 + v2, r1 + r2));
+
+        prop_assert_eq!(Grumpkin::add(&e, &c1, &c2).to_array(), expected.to_array());
+    })
+}
+
+#[test]
+fn prop_doubling_equals_self_add() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k: [u8; 32])| {
+        let s = nonzero_scalar(&k);
+        let p = to_point(&e, &scalar_mul_g(s));
+        let two_p_via_add = Grumpkin::add(&e, &p, &p);
+        let two_p_ref = to_point(&e, &scalar_mul_g(s + s));
+        prop_assert_eq!(two_p_via_add.to_array(), two_p_ref.to_array());
+    })
+}
+
+#[test]
+fn prop_is_on_curve_holds_for_real_points() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k: [u8; 32])| {
+        let p = to_point(&e, &scalar_mul_g(nonzero_scalar(&k)));
+        prop_assert!(Grumpkin::is_on_curve(&e, &p));
+        prop_assert!(Grumpkin::is_not_identity(&p));
+    })
+}
+
+#[test]
+fn prop_is_on_curve_rejects_corrupted_y() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k: [u8; 32], byte_idx in 32usize..64, bit in 0u32..8)| {
+        let mut p = to_point(&e, &scalar_mul_g(nonzero_scalar(&k))).to_array();
+        p[byte_idx] ^= 1u8 << bit;
+        let corrupted = BytesN::from_array(&e, &p);
+        // Off-curve corruption flips y; for a random base-field element y',
+        // (y')² == x³ − 17 holds with probability ≈ 1/r, so this fails with
+        // overwhelming probability.
+        prop_assert!(!Grumpkin::is_on_curve(&e, &corrupted));
+    })
+}

--- a/packages/contract-utils/src/crypto/test/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/test/grumpkin.rs
@@ -353,3 +353,78 @@ fn prop_is_on_curve_rejects_corrupted_y() {
         prop_assert!(!Grumpkin::is_on_curve(&e, &corrupted));
     })
 }
+
+/// BN254 scalar field modulus r in big-endian bytes — duplicated here so the
+/// test exercises a value independent of the production constant.
+const FR_MODULUS_BE: [u8; 32] = [
+    0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58, 0x5d,
+    0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00, 0x00, 0x01,
+];
+
+/// Adds the BN254 scalar field modulus `r` to a canonical 32-byte big-endian
+/// coordinate, producing a non-canonical encoding that reduces to the same
+/// field element under `Bn254Fr::from_bytes`. Returns `None` if the sum
+/// overflows 32 bytes (only happens for `coord` very close to `r`, which is
+/// extremely unlikely for randomly generated points).
+fn add_modulus_be(coord: &[u8; 32]) -> Option<[u8; 32]> {
+    let mut out = [0u8; 32];
+    let mut carry: u16 = 0;
+    for i in (0..32).rev() {
+        let sum = coord[i] as u16 + FR_MODULUS_BE[i] as u16 + carry;
+        out[i] = sum as u8;
+        carry = sum >> 8;
+    }
+    if carry != 0 {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+#[test]
+fn prop_is_on_curve_rejects_non_canonical_x() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k: [u8; 32])| {
+        let canonical = to_point(&e, &scalar_mul_g(nonzero_scalar(&k))).to_array();
+        let mut x = [0u8; 32];
+        x.copy_from_slice(&canonical[..32]);
+        let Some(x_plus_r) = add_modulus_be(&x) else { return Ok(()); };
+        let mut malleated = canonical;
+        malleated[..32].copy_from_slice(&x_plus_r);
+        let mutated = BytesN::from_array(&e, &malleated);
+        // Same logical point under mod-r reduction; distinct bytes.
+        prop_assert_ne!(malleated, canonical);
+        prop_assert!(!Grumpkin::is_on_curve(&e, &mutated));
+    })
+}
+
+#[test]
+fn prop_is_on_curve_rejects_non_canonical_y() {
+    let e = Env::default();
+    e.cost_estimate().budget().reset_unlimited();
+
+    proptest!(|(k: [u8; 32])| {
+        let canonical = to_point(&e, &scalar_mul_g(nonzero_scalar(&k))).to_array();
+        let mut y = [0u8; 32];
+        y.copy_from_slice(&canonical[32..]);
+        let Some(y_plus_r) = add_modulus_be(&y) else { return Ok(()); };
+        let mut malleated = canonical;
+        malleated[32..].copy_from_slice(&y_plus_r);
+        let mutated = BytesN::from_array(&e, &malleated);
+        prop_assert_ne!(malleated, canonical);
+        prop_assert!(!Grumpkin::is_on_curve(&e, &mutated));
+    })
+}
+
+#[test]
+fn is_on_curve_rejects_x_equal_to_modulus() {
+    // x = r is the smallest non-canonical value that reduces to 0; check
+    // exactly that boundary.
+    let e = Env::default();
+    let mut bytes = [0u8; 64];
+    bytes[..32].copy_from_slice(&FR_MODULUS_BE);
+    let p = BytesN::from_array(&e, &bytes);
+    assert!(!Grumpkin::is_on_curve(&e, &p));
+}

--- a/packages/contract-utils/src/crypto/test/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/test/grumpkin.rs
@@ -361,11 +361,15 @@ const FR_MODULUS_BE: [u8; 32] = [
     0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00, 0x00, 0x01,
 ];
 
-/// Adds the BN254 scalar field modulus `r` to a canonical 32-byte big-endian
-/// coordinate, producing a non-canonical encoding that reduces to the same
-/// field element under `Bn254Fr::from_bytes`. Returns `None` if the sum
-/// overflows 32 bytes (only happens for `coord` very close to `r`, which is
-/// extremely unlikely for randomly generated points).
+/// Adds the BN254 scalar field modulus `r` (see [`FR_MODULUS_BE`]) to a
+/// canonical 32-byte big-endian coordinate, producing a non-canonical encoding
+/// that reduces to the same field element under `Bn254Fr::from_bytes`.
+///
+/// For any canonical `coord` (`coord < r`), `coord + r < 2r < 2^255 < 2^256`,
+/// so the 32-byte sum cannot overflow and [`add_modulus_be`] always returns
+/// `Some`. The `None` branch is purely defensive and only reachable if
+/// `coord >= 2^256 - r`, which requires a non-canonical / invalid input
+/// outside the field's representative range.
 fn add_modulus_be(coord: &[u8; 32]) -> Option<[u8; 32]> {
     let mut out = [0u8; 32];
     let mut carry: u16 = 0;

--- a/packages/contract-utils/src/crypto/test/mod.rs
+++ b/packages/contract-utils/src/crypto/test/mod.rs
@@ -1,3 +1,4 @@
+mod grumpkin;
 mod hashable;
 mod keccak;
 mod merkle;


### PR DESCRIPTION
## Summary

Adds Grumpkin (y² = x³ − 17 over BN254's scalar field F_r) affine point arithmetic to `packages/contract-utils/src/crypto/`, intended as a building block for on-chain Pedersen commitments, ECDH, and any other Grumpkin-based primitive built on top of CAP-80.

Resolves #700.

- `Grumpkin::{add, sub, neg}` — affine add/sub/neg with full identity handling (left/right identity, inverse, doubling, generic), implemented on top of the BN254 Fr host calls (`bn254_fr_{add, sub, mul, inv}`).
- `Grumpkin::{is_on_curve, is_identity, is_not_identity}` — validation helpers for points entering the system without a soundness proof. `is_on_curve` enforces both the curve equation and the **canonical 32-byte representative** of each coordinate (mirroring the SDK's own `Bn254Fp` validation), so byte equality on validated points is sound for uniqueness / nullifier / commitment-log keys.
- `Point` is a 64-byte `BytesN<64>` laid out as `be(x) || be(y)`; identity is the all-zero encoding.

### Out of scope (per the issue)

- Scalar multiplication — handled in-circuit via Noir's `multi_scalar_mul`.
- Batched `multi_add` — sequential `add` is fine for v0.8; revisit if benchmarks justify.

## Commits

1. `bump soroban-sdk to 26.0.0` — additive: CAP-80 BN254 Fr arithmetic + CAP-78/79/82.
2. `feat(crypto): on-chain Grumpkin affine point arithmetic` — the module + 24 tests.
3. `fix(grumpkin): reject non-canonical coordinate encodings in is_on_curve` — a self-review caught that `Bn254Fr::from_bytes` silently reduces mod r, which would have let two distinct byte encodings of the same logical commitment slip past the validator. Fix + 3 additional tests.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --release --locked --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] 27 Grumpkin tests pass (16 unit + 11 proptest): each branch (left/right identity, inverse, doubling, generic), neg/sub/identity edges, on-curve / off-curve / non-canonical / identity-encoding rejection, plus the algebraic identities from the issue — commutativity, associativity, identity law, inversion, Pedersen homomorphism. Ground-truth points come from `ark-grumpkin` (dev-dep).

## Notes for reviewers

- **SDK 25 → 26 bump**: required for `Bn254Fr` `Add/Sub/Mul/inv` (no equivalent surface in 25). Bump is additive per the SDK migration notes; the full workspace builds and tests pass unchanged. Worth a glance at the `Cargo.lock` diff in the first commit.
- **No on-curve check inside `add`/`sub`/`neg`**: documented precondition, matches the design's "validate at the trust boundary" stance. The validator is the line of defence; arithmetic is hot-path.
- **Cost benchmarks**: not produced here. Happy to add per-op CPU/memory numbers in a follow-up if maintainers want them in the PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grumpkin elliptic curve point arithmetic operations for advanced cryptographic support, including point addition, negation, subtraction, identity validation, and on-curve verification.

* **Dependencies**
  * Updated `soroban-sdk` to version 26.0.0.
  * Added `ark-*` cryptographic libraries for curve operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/stellar-contracts/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->