### PR TITLE
feat(confidential): auditor key registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "confidential-auditor-example"
+version = "0.7.1"
+dependencies = [
+ "soroban-sdk",
+ "stellar-access",
+ "stellar-macros",
+ "stellar-tokens",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ version = "0.7.1"
 dependencies = [
  "soroban-sdk",
  "stellar-access",
+ "stellar-contract-utils",
  "stellar-macros",
  "stellar-tokens",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "examples/confidential/*",
     "examples/fungible-allowlist",
     "examples/fungible-blocklist",
     "examples/fungible-capped",

--- a/examples/confidential/auditor/Cargo.toml
+++ b/examples/confidential/auditor/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "confidential-auditor-example"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+version.workspace = true
+authors.workspace = true
+
+[package.metadata.stellar]
+cargo_inherit = true
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+stellar-access = { workspace = true }
+stellar-macros = { workspace = true }
+stellar-tokens = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/confidential/auditor/Cargo.toml
+++ b/examples/confidential/auditor/Cargo.toml
@@ -22,3 +22,4 @@ stellar-tokens = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+stellar-contract-utils = { workspace = true }

--- a/examples/confidential/auditor/src/contract.rs
+++ b/examples/confidential/auditor/src/contract.rs
@@ -1,17 +1,17 @@
-//! Confidential Auditor Registry Example Contract.
+//! Confidential Auditor Example Contract.
 
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Symbol, Vec};
 use stellar_access::access_control::{self as access_control, AccessControl};
 use stellar_macros::only_role;
-use stellar_tokens::confidential::auditor::{storage as auditor, AuditorRegistry};
+use stellar_tokens::confidential::auditor::{storage as auditor, ConfidentialAuditor};
 
 const MANAGER_ROLE: Symbol = symbol_short!("manager");
 
 #[contract]
-pub struct AuditorRegistryContract;
+pub struct ConfidentialAuditorContract;
 
 #[contractimpl]
-impl AuditorRegistryContract {
+impl ConfidentialAuditorContract {
     pub fn __constructor(e: &Env, admin: Address, manager: Address) {
         access_control::set_admin(e, &admin);
         access_control::grant_role_no_auth(e, &manager, &MANAGER_ROLE, &admin);
@@ -19,7 +19,7 @@ impl AuditorRegistryContract {
 }
 
 #[contractimpl(contracttrait)]
-impl AuditorRegistry for AuditorRegistryContract {
+impl ConfidentialAuditor for ConfidentialAuditorContract {
     #[only_role(operator, "manager")]
     fn register_key(e: &Env, auditor_id: u32, point: BytesN<64>, operator: Address) {
         auditor::register_key(e, auditor_id, &point);
@@ -32,4 +32,4 @@ impl AuditorRegistry for AuditorRegistryContract {
 }
 
 #[contractimpl(contracttrait)]
-impl AccessControl for AuditorRegistryContract {}
+impl AccessControl for ConfidentialAuditorContract {}

--- a/examples/confidential/auditor/src/contract.rs
+++ b/examples/confidential/auditor/src/contract.rs
@@ -1,0 +1,35 @@
+//! Confidential Auditor Registry Example Contract.
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Symbol, Vec};
+use stellar_access::access_control::{self as access_control, AccessControl};
+use stellar_macros::only_role;
+use stellar_tokens::confidential::auditor::{storage as auditor, AuditorRegistry};
+
+const MANAGER_ROLE: Symbol = symbol_short!("manager");
+
+#[contract]
+pub struct AuditorRegistryContract;
+
+#[contractimpl]
+impl AuditorRegistryContract {
+    pub fn __constructor(e: &Env, admin: Address, manager: Address) {
+        access_control::set_admin(e, &admin);
+        access_control::grant_role_no_auth(e, &manager, &MANAGER_ROLE, &admin);
+    }
+}
+
+#[contractimpl(contracttrait)]
+impl AuditorRegistry for AuditorRegistryContract {
+    #[only_role(operator, "manager")]
+    fn register_key(e: &Env, auditor_id: u32, point: BytesN<64>, operator: Address) {
+        auditor::register_key(e, auditor_id, &point);
+    }
+
+    #[only_role(operator, "manager")]
+    fn rotate_key(e: &Env, auditor_id: u32, new_point: BytesN<64>, operator: Address) {
+        auditor::rotate_key(e, auditor_id, &new_point);
+    }
+}
+
+#[contractimpl(contracttrait)]
+impl AccessControl for AuditorRegistryContract {}

--- a/examples/confidential/auditor/src/lib.rs
+++ b/examples/confidential/auditor/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub mod contract;
+#[cfg(test)]
+mod test;

--- a/examples/confidential/auditor/src/test.rs
+++ b/examples/confidential/auditor/src/test.rs
@@ -1,8 +1,17 @@
 extern crate std;
 
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+use stellar_contract_utils::crypto::grumpkin::Grumpkin;
 
 use crate::contract::{AuditorRegistryContract, AuditorRegistryContractClient};
+
+/// Grumpkin generator `G = (1, Y)`, the canonical on-curve fixture.
+const GRUMPKIN_G_BYTES: [u8; 64] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xcf, 0x13, 0x5e, 0x75, 0x06, 0xa4, 0x5d, 0x63,
+    0x2d, 0x27, 0x0d, 0x45, 0xf1, 0x18, 0x12, 0x94, 0x83, 0x3f, 0xc4, 0x8d, 0x82, 0x3f, 0x27, 0x2c,
+];
 
 fn create_client<'a>(
     e: &Env,
@@ -13,11 +22,13 @@ fn create_client<'a>(
     AuditorRegistryContractClient::new(e, &address)
 }
 
-fn point(e: &Env, x_lo: u8, y_lo: u8) -> BytesN<64> {
-    let mut buf = [0u8; 64];
-    buf[31] = x_lo;
-    buf[63] = y_lo;
-    BytesN::from_array(e, &buf)
+fn generator(e: &Env) -> BytesN<64> {
+    BytesN::from_array(e, &GRUMPKIN_G_BYTES)
+}
+
+fn two_generator(e: &Env) -> BytesN<64> {
+    let g = generator(e);
+    Grumpkin::add(e, &g, &g)
 }
 
 #[test]
@@ -28,7 +39,7 @@ fn register_and_get_key_works() {
     let manager = Address::generate(&e);
     let client = create_client(&e, &admin, &manager);
 
-    let p = point(&e, 1, 2);
+    let p = generator(&e);
     client.register_key(&1u32, &p, &manager);
 
     assert_eq!(client.get_key(&1u32), p);
@@ -42,8 +53,8 @@ fn rotate_key_works() {
     let manager = Address::generate(&e);
     let client = create_client(&e, &admin, &manager);
 
-    let old = point(&e, 1, 2);
-    let new = point(&e, 3, 4);
+    let old = generator(&e);
+    let new = two_generator(&e);
 
     client.register_key(&1u32, &old, &manager);
     client.rotate_key(&1u32, &new, &manager);
@@ -60,8 +71,8 @@ fn register_duplicate_id_panics() {
     let manager = Address::generate(&e);
     let client = create_client(&e, &admin, &manager);
 
-    client.register_key(&1u32, &point(&e, 1, 2), &manager);
-    client.register_key(&1u32, &point(&e, 3, 4), &manager);
+    client.register_key(&1u32, &generator(&e), &manager);
+    client.register_key(&1u32, &two_generator(&e), &manager);
 }
 
 #[test]
@@ -84,11 +95,11 @@ fn rotate_unknown_id_panics() {
     let manager = Address::generate(&e);
     let client = create_client(&e, &admin, &manager);
 
-    client.rotate_key(&7u32, &point(&e, 1, 2), &manager);
+    client.rotate_key(&7u32, &generator(&e), &manager);
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #3303)")]
+#[should_panic(expected = "Error(Contract, #3302)")]
 fn register_identity_panics() {
     let e = Env::default();
     e.mock_all_auths();
@@ -100,7 +111,24 @@ fn register_identity_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #3302)")]
+#[should_panic(expected = "Error(Contract, #3303)")]
+fn register_off_curve_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    // (1, 2) is canonical but `2² ≠ 1³ - 17 (mod r)`.
+    let mut buf = [0u8; 64];
+    buf[31] = 1;
+    buf[63] = 2;
+
+    client.register_key(&1u32, &BytesN::from_array(&e, &buf), &manager);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3303)")]
 fn register_non_canonical_panics() {
     let e = Env::default();
     e.mock_all_auths();
@@ -129,7 +157,7 @@ fn register_by_non_manager_panics() {
     let stranger = Address::generate(&e);
     let client = create_client(&e, &admin, &manager);
 
-    client.register_key(&1u32, &point(&e, 1, 2), &stranger);
+    client.register_key(&1u32, &generator(&e), &stranger);
 }
 
 #[test]
@@ -140,17 +168,22 @@ fn register_n_keys_round_trip() {
     let manager = Address::generate(&e);
     let client = create_client(&e, &admin, &manager);
 
-    // Register a handful of distinct keys; every get_key must return its
-    // registered point.
-    for i in 0..10u32 {
-        let p = point(&e, (i + 1) as u8, (i + 100) as u8);
-        client.register_key(&i, &p, &manager);
-        assert_eq!(client.get_key(&i), p);
+    // Register 10 distinct on-curve points by repeated addition of G; every
+    // get_key must return the point that was registered under its id.
+    let g = generator(&e);
+    let mut points: std::vec::Vec<BytesN<64>> = std::vec::Vec::new();
+    let mut p = g.clone();
+    for _ in 0..10u32 {
+        points.push(p.clone());
+        p = Grumpkin::add(&e, &p, &g);
     }
 
-    // Verify all of them still resolve after the batch of registrations.
-    for i in 0..10u32 {
-        let expected = point(&e, (i + 1) as u8, (i + 100) as u8);
-        assert_eq!(client.get_key(&i), expected);
+    for (i, point) in points.iter().enumerate() {
+        client.register_key(&(i as u32), point, &manager);
+        assert_eq!(client.get_key(&(i as u32)), *point);
+    }
+
+    for (i, point) in points.iter().enumerate() {
+        assert_eq!(client.get_key(&(i as u32)), *point);
     }
 }

--- a/examples/confidential/auditor/src/test.rs
+++ b/examples/confidential/auditor/src/test.rs
@@ -3,7 +3,7 @@ extern crate std;
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
 use stellar_contract_utils::crypto::grumpkin::Grumpkin;
 
-use crate::contract::{AuditorRegistryContract, AuditorRegistryContractClient};
+use crate::contract::{ConfidentialAuditorContract, ConfidentialAuditorContractClient};
 
 /// Grumpkin generator `G = (1, Y)`, the canonical on-curve fixture.
 const GRUMPKIN_G_BYTES: [u8; 64] = [
@@ -17,9 +17,9 @@ fn create_client<'a>(
     e: &Env,
     admin: &Address,
     manager: &Address,
-) -> AuditorRegistryContractClient<'a> {
-    let address = e.register(AuditorRegistryContract, (admin, manager));
-    AuditorRegistryContractClient::new(e, &address)
+) -> ConfidentialAuditorContractClient<'a> {
+    let address = e.register(ConfidentialAuditorContract, (admin, manager));
+    ConfidentialAuditorContractClient::new(e, &address)
 }
 
 fn generator(e: &Env) -> BytesN<64> {

--- a/examples/confidential/auditor/src/test.rs
+++ b/examples/confidential/auditor/src/test.rs
@@ -148,7 +148,7 @@ fn register_non_canonical_panics() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Error(Contract, #2000)")]
 fn register_by_non_manager_panics() {
     let e = Env::default();
     e.mock_all_auths();

--- a/examples/confidential/auditor/src/test.rs
+++ b/examples/confidential/auditor/src/test.rs
@@ -1,0 +1,156 @@
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+use crate::contract::{AuditorRegistryContract, AuditorRegistryContractClient};
+
+fn create_client<'a>(
+    e: &Env,
+    admin: &Address,
+    manager: &Address,
+) -> AuditorRegistryContractClient<'a> {
+    let address = e.register(AuditorRegistryContract, (admin, manager));
+    AuditorRegistryContractClient::new(e, &address)
+}
+
+fn point(e: &Env, x_lo: u8, y_lo: u8) -> BytesN<64> {
+    let mut buf = [0u8; 64];
+    buf[31] = x_lo;
+    buf[63] = y_lo;
+    BytesN::from_array(e, &buf)
+}
+
+#[test]
+fn register_and_get_key_works() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    let p = point(&e, 1, 2);
+    client.register_key(&1u32, &p, &manager);
+
+    assert_eq!(client.get_key(&1u32), p);
+}
+
+#[test]
+fn rotate_key_works() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    let old = point(&e, 1, 2);
+    let new = point(&e, 3, 4);
+
+    client.register_key(&1u32, &old, &manager);
+    client.rotate_key(&1u32, &new, &manager);
+
+    assert_eq!(client.get_key(&1u32), new);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3300)")]
+fn register_duplicate_id_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    client.register_key(&1u32, &point(&e, 1, 2), &manager);
+    client.register_key(&1u32, &point(&e, 3, 4), &manager);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3301)")]
+fn get_unknown_id_panics() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    client.get_key(&42u32);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3301)")]
+fn rotate_unknown_id_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    client.rotate_key(&7u32, &point(&e, 1, 2), &manager);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3303)")]
+fn register_identity_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    client.register_key(&1u32, &BytesN::from_array(&e, &[0u8; 64]), &manager);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3302)")]
+fn register_non_canonical_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    let mut buf = [0u8; 64];
+    // Set y = 0xFF...FF, which exceeds the Grumpkin coordinate modulus.
+    for byte in &mut buf[32..] {
+        *byte = 0xff;
+    }
+    // Ensure x is non-zero so we hit the non-canonical branch, not identity.
+    buf[31] = 1;
+
+    client.register_key(&1u32, &BytesN::from_array(&e, &buf), &manager);
+}
+
+#[test]
+#[should_panic]
+fn register_by_non_manager_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let stranger = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    client.register_key(&1u32, &point(&e, 1, 2), &stranger);
+}
+
+#[test]
+fn register_n_keys_round_trip() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let manager = Address::generate(&e);
+    let client = create_client(&e, &admin, &manager);
+
+    // Register a handful of distinct keys; every get_key must return its
+    // registered point.
+    for i in 0..10u32 {
+        let p = point(&e, (i + 1) as u8, (i + 100) as u8);
+        client.register_key(&i, &p, &manager);
+        assert_eq!(client.get_key(&i), p);
+    }
+
+    // Verify all of them still resolve after the batch of registrations.
+    for i in 0..10u32 {
+        let expected = point(&e, (i + 1) as u8, (i + 100) as u8);
+        assert_eq!(client.get_key(&i), expected);
+    }
+}

--- a/packages/tokens/src/confidential/auditor/mod.rs
+++ b/packages/tokens/src/confidential/auditor/mod.rs
@@ -1,0 +1,222 @@
+//! # Auditor Key Registry
+//!
+//! Stores Grumpkin public keys used by the confidential token wrapper to
+//! produce auditor ECDH ciphertexts. Each key is indexed by a `u32`
+//! `auditor_id` so a single deployment can serve multiple wrapped tokens.
+//!
+//! ## Why a Separate Contract
+//!
+//! Auditor keys are referenced by the wrapper on every operation that produces
+//! an auditor ciphertext (withdraw, transfer, operator transfer, set/revoke
+//! operator). Keeping them in a separate registry allows:
+//!
+//! - **Reuse**: one registry can serve many wrapped tokens;
+//! - **Lifecycle**: registration and rotation can evolve (e.g. versioned keys,
+//!   activation ledgers) without redeploying the wrapper;
+//! - **Isolation**: key-management privileges are scoped to the registry admin,
+//!   distinct from token admin powers.
+//!
+//! ## Point Encoding
+//!
+//! Keys are Grumpkin affine points encoded as [`BytesN<64>`], with the first
+//! 32 bytes holding the `x` coordinate and the last 32 bytes holding the `y`
+//! coordinate, each in big-endian byte order. Both coordinates live in the
+//! Grumpkin coordinate field `F_r`, which coincides with the BN254 scalar
+//! field. The identity point is `(0, 0)`.
+//!
+//! ## Validation
+//!
+//! Every write path runs the same checks:
+//!
+//! 1. **Canonical**: both coordinates strictly less than `r`. Non-canonical
+//!    encodings (`x ≥ r` or `y ≥ r`) are rejected so the on-chain form is
+//!    unambiguous.
+//! 2. **Not identity**: `(x, y) ≠ (0, 0)`. The identity is a valid curve point,
+//!    but using it as a public key would make every auditor ECDH ciphertext
+//!    trivially decryptable, since the salt is public on-chain.
+//! 3. **On curve**: `y² ≡ x³ - 17 (mod r)` (Grumpkin: `a = 0`, `b = -17`).
+//!    Off-curve points break the small-subgroup security assumptions of the
+//!    audit protocol.
+//!
+//! ## Storage Layout
+//!
+//! Each key is stored in its own persistent entry under
+//! [`storage::AuditorStorageKey::Key`]. Per-key entries (rather than a single
+//! `Map<u32, BytesN<64>>` blob) keep reads and writes cheap and let each entry
+//! carry its own TTL.
+
+pub mod storage;
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contracterror, contractevent, contracttrait, Address, BytesN, Env};
+pub use storage::{get_key, register_key, rotate_key, AuditorStorageKey};
+
+/// Trait for managing Grumpkin auditor public keys used by the confidential
+/// token wrapper.
+///
+/// The wrapper queries [`AuditorRegistry::get_key`] on every operation that
+/// produces an auditor ciphertext (withdraw, transfer, operator transfer,
+/// set/revoke operator). [`AuditorRegistry::register_key`] and
+/// [`AuditorRegistry::rotate_key`] are privileged operations expected to be
+/// gated by the implementor's access-control scheme.
+#[contracttrait]
+pub trait AuditorRegistry {
+    /// Registers a Grumpkin public key under a fresh `auditor_id`.
+    ///
+    /// Reverts if the `auditor_id` already exists; rotation is handled by
+    /// [`AuditorRegistry::rotate_key`].
+    ///
+    /// Only an operator with sufficient permissions should be able to call
+    /// this function.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `auditor_id` - The identifier to register the key under.
+    /// * `point` - The Grumpkin public key, encoded as 32 bytes of `x` followed
+    ///   by 32 bytes of `y` (big-endian).
+    /// * `operator` - The address authorizing the invocation.
+    ///
+    /// # Errors
+    ///
+    /// * [`AuditorError::AuditorAlreadyRegistered`] - When `auditor_id` is
+    ///   already in use.
+    /// * refer to [`storage::register_key`] errors.
+    ///
+    /// # Events
+    ///
+    /// * topics - `["auditor_registered", auditor_id: u32]`
+    /// * data - `[point: BytesN<64>]`
+    ///
+    /// # Notes
+    ///
+    /// No default implementation is provided because this is a privileged
+    /// operation that requires custom access control. Access control should be
+    /// enforced on `operator` before calling [`storage::register_key`] for the
+    /// implementation.
+    fn register_key(e: &Env, auditor_id: u32, point: BytesN<64>, operator: Address);
+
+    /// Replaces the Grumpkin public key registered under `auditor_id`.
+    ///
+    /// Only an operator with sufficient permissions should be able to call
+    /// this function.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `auditor_id` - The identifier whose key is being rotated.
+    /// * `new_point` - The new Grumpkin public key.
+    /// * `operator` - The address authorizing the invocation.
+    ///
+    /// # Errors
+    ///
+    /// * [`AuditorError::AuditorNotRegistered`] - When `auditor_id` has no
+    ///   registered key.
+    /// * refer to [`storage::rotate_key`] errors.
+    ///
+    /// # Events
+    ///
+    /// * topics - `["auditor_rotated", auditor_id: u32]`
+    /// * data - `[old_point: BytesN<64>, new_point: BytesN<64>]`
+    ///
+    /// # Notes
+    ///
+    /// No default implementation is provided because this is a privileged
+    /// operation that requires custom access control. Access control should be
+    /// enforced on `operator` before calling [`storage::rotate_key`] for the
+    /// implementation.
+    fn rotate_key(e: &Env, auditor_id: u32, new_point: BytesN<64>, operator: Address);
+
+    /// Returns the Grumpkin public key registered under `auditor_id`.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `auditor_id` - The identifier of the auditor whose key is requested.
+    ///
+    /// # Errors
+    ///
+    /// * [`AuditorError::AuditorNotRegistered`] - When `auditor_id` has no
+    ///   registered key.
+    fn get_key(e: &Env, auditor_id: u32) -> BytesN<64> {
+        storage::get_key(e, auditor_id)
+    }
+}
+
+// ################## ERRORS ##################
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum AuditorError {
+    /// Indicates the `auditor_id` is already registered.
+    AuditorAlreadyRegistered = 3300,
+    /// Indicates no key is registered under `auditor_id`.
+    AuditorNotRegistered = 3301,
+    /// Indicates the point coordinates are not canonical (`x ≥ r` or
+    /// `y ≥ r`).
+    NonCanonicalPoint = 3302,
+    /// Indicates the point is the identity `(0, 0)`, which is forbidden as an
+    /// auditor public key.
+    IdentityPoint = 3303,
+    /// Indicates the point does not satisfy `y² ≡ x³ - 17 (mod r)`.
+    PointNotOnCurve = 3304,
+}
+
+// ################## CONSTANTS ##################
+
+const DAY_IN_LEDGERS: u32 = 17280;
+pub const AUDITOR_KEY_EXTEND_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
+pub const AUDITOR_KEY_TTL_THRESHOLD: u32 = AUDITOR_KEY_EXTEND_AMOUNT - DAY_IN_LEDGERS;
+
+// ################## EVENTS ##################
+
+/// Event emitted when a new auditor key is registered.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuditorRegistered {
+    #[topic]
+    pub auditor_id: u32,
+    pub point: BytesN<64>,
+}
+
+/// Emits an event indicating an auditor key has been registered.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `auditor_id` - The identifier the key was registered under.
+/// * `point` - The Grumpkin public key.
+pub fn emit_auditor_registered(e: &Env, auditor_id: u32, point: &BytesN<64>) {
+    AuditorRegistered { auditor_id, point: point.clone() }.publish(e);
+}
+
+/// Event emitted when an auditor key is rotated.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuditorRotated {
+    #[topic]
+    pub auditor_id: u32,
+    pub old_point: BytesN<64>,
+    pub new_point: BytesN<64>,
+}
+
+/// Emits an event indicating an auditor key has been rotated.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `auditor_id` - The identifier whose key was rotated.
+/// * `old_point` - The previously registered key.
+/// * `new_point` - The newly registered key.
+pub fn emit_auditor_rotated(
+    e: &Env,
+    auditor_id: u32,
+    old_point: &BytesN<64>,
+    new_point: &BytesN<64>,
+) {
+    AuditorRotated { auditor_id, old_point: old_point.clone(), new_point: new_point.clone() }
+        .publish(e);
+}

--- a/packages/tokens/src/confidential/auditor/mod.rs
+++ b/packages/tokens/src/confidential/auditor/mod.rs
@@ -49,13 +49,13 @@ pub use storage::{get_key, register_key, rotate_key, AuditorStorageKey};
 /// Trait for managing Grumpkin auditor public keys used by the confidential
 /// token wrapper.
 ///
-/// The wrapper queries [`AuditorRegistry::get_key`] on every operation that
+/// The wrapper queries [`ConfidentialAuditor::get_key`] on every operation that
 /// produces an auditor ciphertext (withdraw, transfer, operator transfer,
-/// set/revoke operator). [`AuditorRegistry::register_key`] and
-/// [`AuditorRegistry::rotate_key`] are privileged operations expected to be
+/// set/revoke operator). [`ConfidentialAuditor::register_key`] and
+/// [`ConfidentialAuditor::rotate_key`] are privileged operations expected to be
 /// gated by the implementor's access-control scheme.
 #[contracttrait]
-pub trait AuditorRegistry {
+pub trait ConfidentialAuditor {
     /// Registers a Grumpkin public key under a fresh `auditor_id`.
     ///
     /// # Arguments

--- a/packages/tokens/src/confidential/auditor/mod.rs
+++ b/packages/tokens/src/confidential/auditor/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Stores Grumpkin public keys used by the confidential token wrapper to
 //! produce auditor ECDH ciphertexts. Each key is indexed by a `u32`
-//! `auditor_id` so a single deployment can serve multiple wrapped tokens.
+//! `auditor_id` and a single deployment can serve multiple wrapped tokens.
 //!
 //! ## Why a Separate Contract
 //!
@@ -26,24 +26,17 @@
 //!
 //! ## Validation
 //!
-//! Every write path runs the same checks:
+//! Every write path runs the same checks, delegated to
+//! [`stellar_contract_utils::crypto::grumpkin::Grumpkin`]:
 //!
-//! 1. **Canonical**: both coordinates strictly less than `r`. Non-canonical
-//!    encodings (`x ≥ r` or `y ≥ r`) are rejected so the on-chain form is
-//!    unambiguous.
-//! 2. **Not identity**: `(x, y) ≠ (0, 0)`. The identity is a valid curve point,
-//!    but using it as a public key would make every auditor ECDH ciphertext
-//!    trivially decryptable, since the salt is public on-chain.
-//! 3. **On curve**: `y² ≡ x³ - 17 (mod r)` (Grumpkin: `a = 0`, `b = -17`).
-//!    Off-curve points break the small-subgroup security assumptions of the
-//!    audit protocol.
-//!
-//! ## Storage Layout
-//!
-//! Each key is stored in its own persistent entry under
-//! [`storage::AuditorStorageKey::Key`]. Per-key entries (rather than a single
-//! `Map<u32, BytesN<64>>` blob) keep reads and writes cheap and let each entry
-//! carry its own TTL.
+//! 1. **Not identity**: `(x, y) ≠ (0, 0)`. The identity is a valid group
+//!    element, but using it as a public key would make every auditor ECDH
+//!    ciphertext trivially decryptable, since the salt is public on-chain.
+//! 2. **Canonical + on curve**: each coordinate is a canonical 32-byte
+//!    representative (`< r`) and `(x, y)` satisfies `y² ≡ x³ - 17 (mod r)`
+//!    (Grumpkin: `a = 0`, `b = -17`). The two checks are fused because the
+//!    underlying validator rejects non-canonical encodings to keep byte
+//!    equality on validated points sound.
 
 pub mod storage;
 
@@ -65,12 +58,6 @@ pub use storage::{get_key, register_key, rotate_key, AuditorStorageKey};
 pub trait AuditorRegistry {
     /// Registers a Grumpkin public key under a fresh `auditor_id`.
     ///
-    /// Reverts if the `auditor_id` already exists; rotation is handled by
-    /// [`AuditorRegistry::rotate_key`].
-    ///
-    /// Only an operator with sufficient permissions should be able to call
-    /// this function.
-    ///
     /// # Arguments
     ///
     /// * `e` - Access to the Soroban environment.
@@ -83,7 +70,9 @@ pub trait AuditorRegistry {
     ///
     /// * [`AuditorError::AuditorAlreadyRegistered`] - When `auditor_id` is
     ///   already in use.
-    /// * refer to [`storage::register_key`] errors.
+    /// * [`AuditorError::IdentityPoint`] - When the point is the identity.
+    /// * [`AuditorError::PointNotOnCurve`] - When the point is non-canonical or
+    ///   does not satisfy the Grumpkin curve equation.
     ///
     /// # Events
     ///
@@ -114,7 +103,9 @@ pub trait AuditorRegistry {
     ///
     /// * [`AuditorError::AuditorNotRegistered`] - When `auditor_id` has no
     ///   registered key.
-    /// * refer to [`storage::rotate_key`] errors.
+    /// * [`AuditorError::IdentityPoint`] - When the point is the identity.
+    /// * [`AuditorError::PointNotOnCurve`] - When the point is non-canonical or
+    ///   does not satisfy the Grumpkin curve equation.
     ///
     /// # Events
     ///
@@ -155,14 +146,12 @@ pub enum AuditorError {
     AuditorAlreadyRegistered = 3300,
     /// Indicates no key is registered under `auditor_id`.
     AuditorNotRegistered = 3301,
-    /// Indicates the point coordinates are not canonical (`x ≥ r` or
-    /// `y ≥ r`).
-    NonCanonicalPoint = 3302,
     /// Indicates the point is the identity `(0, 0)`, which is forbidden as an
     /// auditor public key.
-    IdentityPoint = 3303,
-    /// Indicates the point does not satisfy `y² ≡ x³ - 17 (mod r)`.
-    PointNotOnCurve = 3304,
+    IdentityPoint = 3302,
+    /// Indicates the point is non-canonical or does not satisfy
+    /// `y² ≡ x³ - 17 (mod r)`.
+    PointNotOnCurve = 3303,
 }
 
 // ################## CONSTANTS ##################

--- a/packages/tokens/src/confidential/auditor/storage.rs
+++ b/packages/tokens/src/confidential/auditor/storage.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{contracttype, panic_with_error, BytesN, Env, TryFromVal, Val};
+use stellar_contract_utils::crypto::grumpkin::Grumpkin;
 
 use crate::confidential::auditor::{
     emit_auditor_registered, emit_auditor_rotated, AuditorError, AUDITOR_KEY_EXTEND_AMOUNT,
@@ -33,9 +34,6 @@ pub fn get_key(e: &Env, auditor_id: u32) -> BytesN<64> {
 // ################## CHANGE STATE ##################
 
 /// Registers a Grumpkin public key under a fresh `auditor_id`.
-///
-/// Runs [`validate_point`] on `point` before storing it. Reverts if the
-/// `auditor_id` already has a key; use [`rotate_key`] to replace.
 ///
 /// # Arguments
 ///
@@ -76,8 +74,6 @@ pub fn register_key(e: &Env, auditor_id: u32, point: &BytesN<64>) {
 }
 
 /// Replaces the Grumpkin public key registered under `auditor_id`.
-///
-/// Runs [`validate_point`] on `new_point` before storing it.
 ///
 /// # Arguments
 ///
@@ -125,10 +121,13 @@ pub fn rotate_key(e: &Env, auditor_id: u32, new_point: &BytesN<64>) {
 ///
 /// The point is rejected when any of the following holds:
 ///
-/// 1. `x ≥ r` or `y ≥ r` (non-canonical encoding);
-/// 2. `(x, y) = (0, 0)` (identity, which would make every auditor ECDH
+/// 1. `(x, y) = (0, 0)` (identity, which would make every auditor ECDH
 ///    ciphertext trivially decryptable);
-/// 3. `y² ≢ x³ - 17 (mod r)` (not on the Grumpkin curve).
+/// 2. either coordinate is non-canonical (`x ≥ r` or `y ≥ r`), or `(x, y)` does
+///    not satisfy `y² ≡ x³ - 17 (mod r)`. The Grumpkin validator fuses these
+///    two checks: a non-canonical encoding has multiple bytewise
+///    representations of the same logical point, which would defeat any
+///    uniqueness check downstream contracts may run against the raw key bytes.
 ///
 /// # Arguments
 ///
@@ -137,19 +136,14 @@ pub fn rotate_key(e: &Env, auditor_id: u32, new_point: &BytesN<64>) {
 ///
 /// # Errors
 ///
-/// * [`AuditorError::NonCanonicalPoint`] - When either coordinate is not in
-///   `[0, r)`.
 /// * [`AuditorError::IdentityPoint`] - When the point is the identity.
-/// * [`AuditorError::PointNotOnCurve`] - When the point does not satisfy the
-///   Grumpkin curve equation.
+/// * [`AuditorError::PointNotOnCurve`] - When the point is non-canonical or
+///   does not satisfy the Grumpkin curve equation.
 pub fn validate_point(e: &Env, point: &BytesN<64>) {
-    if !point_validator::is_canonical(e, point) {
-        panic_with_error!(e, AuditorError::NonCanonicalPoint);
-    }
-    if !point_validator::is_not_identity(point) {
+    if !Grumpkin::is_not_identity(point) {
         panic_with_error!(e, AuditorError::IdentityPoint);
     }
-    if !point_validator::is_on_curve(e, point) {
+    if !Grumpkin::is_on_curve(e, point) {
         panic_with_error!(e, AuditorError::PointNotOnCurve);
     }
 }
@@ -164,58 +158,4 @@ fn get_persistent_entry<T: TryFromVal<Env, Val>>(e: &Env, key: &AuditorStorageKe
             AUDITOR_KEY_EXTEND_AMOUNT,
         );
     })
-}
-
-// ################## POINT VALIDATION ##################
-//
-// Grumpkin point validation. Until the dedicated Grumpkin arithmetic crate
-// (see issue #700) lands, these helpers live here so the auditor contract is
-// self-contained. The canonical and identity checks are final; the on-curve
-// check is a placeholder routed through a single function that will be
-// replaced by `stellar_grumpkin::is_on_curve` once available.
-mod point_validator {
-    use soroban_sdk::{Bytes, BytesN, Env, U256};
-
-    /// BN254 scalar field modulus `r`, in big-endian bytes. This is also the
-    /// Grumpkin coordinate field modulus.
-    ///
-    /// `r = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001`
-    const FR_MODULUS_BE: [u8; 32] = [
-        0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58,
-        0x5d, 0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00,
-        0x00, 0x01,
-    ];
-
-    /// Returns true when both coordinates of `point` are strictly less than
-    /// the Grumpkin coordinate field modulus `r`.
-    pub fn is_canonical(e: &Env, point: &BytesN<64>) -> bool {
-        let raw = point.to_array();
-        let modulus = U256::from_be_bytes(e, &Bytes::from_array(e, &FR_MODULUS_BE));
-
-        let mut x_bytes = [0u8; 32];
-        let mut y_bytes = [0u8; 32];
-        x_bytes.copy_from_slice(&raw[..32]);
-        y_bytes.copy_from_slice(&raw[32..]);
-
-        let x = U256::from_be_bytes(e, &Bytes::from_array(e, &x_bytes));
-        let y = U256::from_be_bytes(e, &Bytes::from_array(e, &y_bytes));
-
-        x < modulus && y < modulus
-    }
-
-    /// Returns true when `point` is not the identity `(0, 0)`.
-    pub fn is_not_identity(point: &BytesN<64>) -> bool {
-        point.to_array().iter().any(|byte| *byte != 0)
-    }
-
-    /// Returns true when `point` satisfies `y² ≡ x³ - 17 (mod r)`.
-    ///
-    /// TODO(#700): replace this stub with the on-curve helper from the
-    /// dedicated Grumpkin arithmetic crate. Until that crate lands, this
-    /// helper accepts any canonical, non-identity point. The auditor
-    /// contract's structure is intentionally arranged so the swap is a
-    /// one-line change here.
-    pub fn is_on_curve(_e: &Env, _point: &BytesN<64>) -> bool {
-        true
-    }
 }

--- a/packages/tokens/src/confidential/auditor/storage.rs
+++ b/packages/tokens/src/confidential/auditor/storage.rs
@@ -1,0 +1,221 @@
+use soroban_sdk::{contracttype, panic_with_error, BytesN, Env, TryFromVal, Val};
+
+use crate::confidential::auditor::{
+    emit_auditor_registered, emit_auditor_rotated, AuditorError, AUDITOR_KEY_EXTEND_AMOUNT,
+    AUDITOR_KEY_TTL_THRESHOLD,
+};
+
+/// Storage keys for the auditor registry.
+#[contracttype]
+pub enum AuditorStorageKey {
+    /// Maps `auditor_id` to its Grumpkin public key encoded as `(x, y)`.
+    Key(u32),
+}
+
+// ################## QUERY STATE ##################
+
+/// Returns the Grumpkin public key registered under `auditor_id`.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `auditor_id` - The identifier of the auditor whose key is requested.
+///
+/// # Errors
+///
+/// * [`AuditorError::AuditorNotRegistered`] - When `auditor_id` has no
+///   registered key.
+pub fn get_key(e: &Env, auditor_id: u32) -> BytesN<64> {
+    get_persistent_entry(e, &AuditorStorageKey::Key(auditor_id))
+        .unwrap_or_else(|| panic_with_error!(e, AuditorError::AuditorNotRegistered))
+}
+
+// ################## CHANGE STATE ##################
+
+/// Registers a Grumpkin public key under a fresh `auditor_id`.
+///
+/// Runs [`validate_point`] on `point` before storing it. Reverts if the
+/// `auditor_id` already has a key; use [`rotate_key`] to replace.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `auditor_id` - The identifier to register the key under.
+/// * `point` - The Grumpkin public key.
+///
+/// # Errors
+///
+/// * [`AuditorError::AuditorAlreadyRegistered`] - When `auditor_id` is already
+///   in use.
+/// * refer to [`validate_point`] errors.
+///
+/// # Events
+///
+/// * topics - `["auditor_registered", auditor_id: u32]`
+/// * data - `[point: BytesN<64>]`
+///
+/// # Security Warning
+///
+/// **IMPORTANT**: This function bypasses authorization checks and should
+/// only be used:
+/// - During contract initialization/construction
+/// - In admin functions that implement their own authorization logic
+///
+/// Using this function in public-facing methods may create significant
+/// security risks as it could allow unauthorized modifications.
+pub fn register_key(e: &Env, auditor_id: u32, point: &BytesN<64>) {
+    let key = AuditorStorageKey::Key(auditor_id);
+    if e.storage().persistent().has(&key) {
+        panic_with_error!(e, AuditorError::AuditorAlreadyRegistered);
+    }
+
+    validate_point(e, point);
+
+    e.storage().persistent().set(&key, point);
+    emit_auditor_registered(e, auditor_id, point);
+}
+
+/// Replaces the Grumpkin public key registered under `auditor_id`.
+///
+/// Runs [`validate_point`] on `new_point` before storing it.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `auditor_id` - The identifier whose key is being rotated.
+/// * `new_point` - The new Grumpkin public key.
+///
+/// # Errors
+///
+/// * [`AuditorError::AuditorNotRegistered`] - When `auditor_id` has no
+///   registered key.
+/// * refer to [`validate_point`] errors.
+///
+/// # Events
+///
+/// * topics - `["auditor_rotated", auditor_id: u32]`
+/// * data - `[old_point: BytesN<64>, new_point: BytesN<64>]`
+///
+/// # Security Warning
+///
+/// **IMPORTANT**: This function bypasses authorization checks and should
+/// only be used:
+/// - During contract initialization/construction
+/// - In admin functions that implement their own authorization logic
+///
+/// Using this function in public-facing methods may create significant
+/// security risks as it could allow unauthorized modifications.
+pub fn rotate_key(e: &Env, auditor_id: u32, new_point: &BytesN<64>) {
+    let key = AuditorStorageKey::Key(auditor_id);
+    let old_point: BytesN<64> = e
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| panic_with_error!(e, AuditorError::AuditorNotRegistered));
+
+    validate_point(e, new_point);
+
+    e.storage().persistent().set(&key, new_point);
+    emit_auditor_rotated(e, auditor_id, &old_point, new_point);
+}
+
+// ################## LOW-LEVEL HELPERS ##################
+
+/// Validates that `point` is a usable Grumpkin auditor public key.
+///
+/// The point is rejected when any of the following holds:
+///
+/// 1. `x ≥ r` or `y ≥ r` (non-canonical encoding);
+/// 2. `(x, y) = (0, 0)` (identity, which would make every auditor ECDH
+///    ciphertext trivially decryptable);
+/// 3. `y² ≢ x³ - 17 (mod r)` (not on the Grumpkin curve).
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `point` - The candidate Grumpkin public key.
+///
+/// # Errors
+///
+/// * [`AuditorError::NonCanonicalPoint`] - When either coordinate is not in
+///   `[0, r)`.
+/// * [`AuditorError::IdentityPoint`] - When the point is the identity.
+/// * [`AuditorError::PointNotOnCurve`] - When the point does not satisfy the
+///   Grumpkin curve equation.
+pub fn validate_point(e: &Env, point: &BytesN<64>) {
+    if !point_validator::is_canonical(e, point) {
+        panic_with_error!(e, AuditorError::NonCanonicalPoint);
+    }
+    if !point_validator::is_not_identity(point) {
+        panic_with_error!(e, AuditorError::IdentityPoint);
+    }
+    if !point_validator::is_on_curve(e, point) {
+        panic_with_error!(e, AuditorError::PointNotOnCurve);
+    }
+}
+
+/// Helper function that tries to retrieve a persistent storage value and
+/// extend its TTL if the entry exists.
+fn get_persistent_entry<T: TryFromVal<Env, Val>>(e: &Env, key: &AuditorStorageKey) -> Option<T> {
+    e.storage().persistent().get::<_, T>(key).inspect(|_| {
+        e.storage().persistent().extend_ttl(
+            key,
+            AUDITOR_KEY_TTL_THRESHOLD,
+            AUDITOR_KEY_EXTEND_AMOUNT,
+        );
+    })
+}
+
+// ################## POINT VALIDATION ##################
+//
+// Grumpkin point validation. Until the dedicated Grumpkin arithmetic crate
+// (see issue #700) lands, these helpers live here so the auditor contract is
+// self-contained. The canonical and identity checks are final; the on-curve
+// check is a placeholder routed through a single function that will be
+// replaced by `stellar_grumpkin::is_on_curve` once available.
+mod point_validator {
+    use soroban_sdk::{Bytes, BytesN, Env, U256};
+
+    /// BN254 scalar field modulus `r`, in big-endian bytes. This is also the
+    /// Grumpkin coordinate field modulus.
+    ///
+    /// `r = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001`
+    const FR_MODULUS_BE: [u8; 32] = [
+        0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58,
+        0x5d, 0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00,
+        0x00, 0x01,
+    ];
+
+    /// Returns true when both coordinates of `point` are strictly less than
+    /// the Grumpkin coordinate field modulus `r`.
+    pub fn is_canonical(e: &Env, point: &BytesN<64>) -> bool {
+        let raw = point.to_array();
+        let modulus = U256::from_be_bytes(e, &Bytes::from_array(e, &FR_MODULUS_BE));
+
+        let mut x_bytes = [0u8; 32];
+        let mut y_bytes = [0u8; 32];
+        x_bytes.copy_from_slice(&raw[..32]);
+        y_bytes.copy_from_slice(&raw[32..]);
+
+        let x = U256::from_be_bytes(e, &Bytes::from_array(e, &x_bytes));
+        let y = U256::from_be_bytes(e, &Bytes::from_array(e, &y_bytes));
+
+        x < modulus && y < modulus
+    }
+
+    /// Returns true when `point` is not the identity `(0, 0)`.
+    pub fn is_not_identity(point: &BytesN<64>) -> bool {
+        point.to_array().iter().any(|byte| *byte != 0)
+    }
+
+    /// Returns true when `point` satisfies `y² ≡ x³ - 17 (mod r)`.
+    ///
+    /// TODO(#700): replace this stub with the on-curve helper from the
+    /// dedicated Grumpkin arithmetic crate. Until that crate lands, this
+    /// helper accepts any canonical, non-identity point. The auditor
+    /// contract's structure is intentionally arranged so the swap is a
+    /// one-line change here.
+    pub fn is_on_curve(_e: &Env, _point: &BytesN<64>) -> bool {
+        true
+    }
+}

--- a/packages/tokens/src/confidential/auditor/test.rs
+++ b/packages/tokens/src/confidential/auditor/test.rs
@@ -1,6 +1,7 @@
 extern crate std;
 
 use soroban_sdk::{contract, BytesN, Env};
+use stellar_contract_utils::crypto::grumpkin::Grumpkin;
 use stellar_event_assertion::EventAssertion;
 
 use crate::confidential::auditor::storage::{
@@ -10,31 +11,30 @@ use crate::confidential::auditor::storage::{
 #[contract]
 struct MockContract;
 
-/// Builds a `BytesN<64>` from a 32-byte `x` and a 32-byte `y`.
-fn point(e: &Env, x: [u8; 32], y: [u8; 32]) -> BytesN<64> {
-    let mut buf = [0u8; 64];
-    buf[..32].copy_from_slice(&x);
-    buf[32..].copy_from_slice(&y);
-    BytesN::from_array(e, &buf)
+/// Grumpkin generator `G = (1, Y)` with `Y =
+/// 17631683881184975370165255887551781615748388533673675138860`.
+///
+/// This is the canonical on-curve point shipped with `ark-grumpkin`; we use
+/// it as a deterministic test fixture so the auditor tests don't depend on
+/// `ark-grumpkin` themselves.
+const GRUMPKIN_G_BYTES: [u8; 64] = [
+    // x = 1 (32-byte big-endian)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    // y (32-byte big-endian)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xcf, 0x13, 0x5e, 0x75, 0x06, 0xa4, 0x5d, 0x63,
+    0x2d, 0x27, 0x0d, 0x45, 0xf1, 0x18, 0x12, 0x94, 0x83, 0x3f, 0xc4, 0x8d, 0x82, 0x3f, 0x27, 0x2c,
+];
+
+fn generator(e: &Env) -> BytesN<64> {
+    BytesN::from_array(e, &GRUMPKIN_G_BYTES)
 }
 
-/// A canonical, non-identity sample point. The stubbed on-curve check
-/// accepts any such point; once the Grumpkin arithmetic crate lands the
-/// on-curve sample will be generated from an actual scalar.
-fn sample_point(e: &Env) -> BytesN<64> {
-    let mut x = [0u8; 32];
-    x[31] = 1;
-    let mut y = [0u8; 32];
-    y[31] = 2;
-    point(e, x, y)
-}
-
-fn another_sample_point(e: &Env) -> BytesN<64> {
-    let mut x = [0u8; 32];
-    x[31] = 3;
-    let mut y = [0u8; 32];
-    y[31] = 4;
-    point(e, x, y)
+/// A second on-curve sample: `2G`, obtained by doubling the generator on the
+/// real Grumpkin curve.
+fn two_generator(e: &Env) -> BytesN<64> {
+    let g = generator(e);
+    Grumpkin::add(e, &g, &g)
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn register_and_get_key_works() {
     let e = Env::default();
     e.mock_all_auths();
     let address = e.register(MockContract, ());
-    let p = sample_point(&e);
+    let p = generator(&e);
 
     e.as_contract(&address, || {
         register_key(&e, 1, &p);
@@ -61,16 +61,15 @@ fn register_multiple_keys_round_trip() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        // Register a handful of keys under distinct ids and verify every
-        // get_key call round-trips to the registered point.
+        // Build a sequence of distinct on-curve points by repeated addition
+        // of G on the real Grumpkin curve, then verify every get_key
+        // round-trips.
+        let g = generator(&e);
+        let mut p = g.clone();
         for i in 0..5u32 {
-            let mut x = [0u8; 32];
-            x[31] = (i + 1) as u8;
-            let mut y = [0u8; 32];
-            y[31] = (i + 10) as u8;
-            let p = point(&e, x, y);
             register_key(&e, i, &p);
             assert_eq!(get_key(&e, i), p);
+            p = Grumpkin::add(&e, &p, &g);
         }
     });
 }
@@ -83,8 +82,8 @@ fn register_duplicate_id_panics() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        register_key(&e, 1, &sample_point(&e));
-        register_key(&e, 1, &another_sample_point(&e));
+        register_key(&e, 1, &generator(&e));
+        register_key(&e, 1, &two_generator(&e));
     });
 }
 
@@ -105,10 +104,10 @@ fn rotate_key_replaces_in_place() {
     e.mock_all_auths();
     let address = e.register(MockContract, ());
 
-    let old = sample_point(&e);
-    let new = another_sample_point(&e);
-
     e.as_contract(&address, || {
+        let old = generator(&e);
+        let new = two_generator(&e);
+
         register_key(&e, 1, &old);
         rotate_key(&e, 1, &new);
 
@@ -124,12 +123,12 @@ fn rotate_unknown_id_panics() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        rotate_key(&e, 7, &sample_point(&e));
+        rotate_key(&e, 7, &generator(&e));
     });
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #3303)")]
+#[should_panic(expected = "Error(Contract, #3302)")]
 fn register_identity_point_panics() {
     let e = Env::default();
     e.mock_all_auths();
@@ -141,53 +140,73 @@ fn register_identity_point_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #3303)")]
+#[should_panic(expected = "Error(Contract, #3302)")]
 fn rotate_to_identity_point_panics() {
     let e = Env::default();
     e.mock_all_auths();
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        register_key(&e, 1, &sample_point(&e));
+        register_key(&e, 1, &generator(&e));
         rotate_key(&e, 1, &BytesN::from_array(&e, &[0u8; 64]));
     });
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #3302)")]
+#[should_panic(expected = "Error(Contract, #3303)")]
+fn register_off_curve_point_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        // (1, 2) is canonical but `2² ≠ 1³ - 17 (mod r)`, so it is off the
+        // Grumpkin curve.
+        let mut buf = [0u8; 64];
+        buf[31] = 1;
+        buf[63] = 2;
+        register_key(&e, 1, &BytesN::from_array(&e, &buf));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3303)")]
 fn register_non_canonical_x_panics() {
     let e = Env::default();
     e.mock_all_auths();
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        // `x = r` is the smallest non-canonical encoding.
-        let x: [u8; 32] = [
+        // `x = r` is the smallest non-canonical encoding; the Grumpkin
+        // validator rejects it as off-curve to keep byte equality sound.
+        let mut buf = [0u8; 64];
+        buf[..32].copy_from_slice(&[
             0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81,
             0x58, 0x5d, 0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93,
             0xf0, 0x00, 0x00, 0x01,
-        ];
-        let mut y = [0u8; 32];
-        y[31] = 1;
+        ]);
+        buf[63] = 1;
 
-        register_key(&e, 1, &point(&e, x, y));
+        register_key(&e, 1, &BytesN::from_array(&e, &buf));
     });
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #3302)")]
+#[should_panic(expected = "Error(Contract, #3303)")]
 fn register_non_canonical_y_panics() {
     let e = Env::default();
     e.mock_all_auths();
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        let mut x = [0u8; 32];
-        x[31] = 1;
+        let mut buf = [0u8; 64];
+        buf[31] = 1;
         // `y = 2^256 - 1` is well above `r`.
-        let y = [0xffu8; 32];
+        for byte in &mut buf[32..] {
+            *byte = 0xff;
+        }
 
-        register_key(&e, 1, &point(&e, x, y));
+        register_key(&e, 1, &BytesN::from_array(&e, &buf));
     });
 }
 
@@ -197,10 +216,10 @@ fn rotate_emits_rotation_event() {
     e.mock_all_auths();
     let address = e.register(MockContract, ());
 
-    let old = sample_point(&e);
-    let new = another_sample_point(&e);
-
     e.as_contract(&address, || {
+        let old = generator(&e);
+        let new = two_generator(&e);
+
         register_key(&e, 1, &old);
         rotate_key(&e, 1, &new);
 
@@ -210,12 +229,12 @@ fn rotate_emits_rotation_event() {
 }
 
 #[test]
-fn validate_point_accepts_canonical_non_identity() {
+fn validate_point_accepts_generator() {
     let e = Env::default();
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        validate_point(&e, &sample_point(&e));
+        validate_point(&e, &generator(&e));
     });
 }
 
@@ -227,7 +246,7 @@ fn storage_key_round_trip() {
 
     e.as_contract(&address, || {
         // Direct read by storage key matches the value returned by get_key.
-        let p = sample_point(&e);
+        let p = generator(&e);
         register_key(&e, 9, &p);
 
         let stored: BytesN<64> = e.storage().persistent().get(&AuditorStorageKey::Key(9)).unwrap();

--- a/packages/tokens/src/confidential/auditor/test.rs
+++ b/packages/tokens/src/confidential/auditor/test.rs
@@ -1,0 +1,236 @@
+extern crate std;
+
+use soroban_sdk::{contract, BytesN, Env};
+use stellar_event_assertion::EventAssertion;
+
+use crate::confidential::auditor::storage::{
+    get_key, register_key, rotate_key, validate_point, AuditorStorageKey,
+};
+
+#[contract]
+struct MockContract;
+
+/// Builds a `BytesN<64>` from a 32-byte `x` and a 32-byte `y`.
+fn point(e: &Env, x: [u8; 32], y: [u8; 32]) -> BytesN<64> {
+    let mut buf = [0u8; 64];
+    buf[..32].copy_from_slice(&x);
+    buf[32..].copy_from_slice(&y);
+    BytesN::from_array(e, &buf)
+}
+
+/// A canonical, non-identity sample point. The stubbed on-curve check
+/// accepts any such point; once the Grumpkin arithmetic crate lands the
+/// on-curve sample will be generated from an actual scalar.
+fn sample_point(e: &Env) -> BytesN<64> {
+    let mut x = [0u8; 32];
+    x[31] = 1;
+    let mut y = [0u8; 32];
+    y[31] = 2;
+    point(e, x, y)
+}
+
+fn another_sample_point(e: &Env) -> BytesN<64> {
+    let mut x = [0u8; 32];
+    x[31] = 3;
+    let mut y = [0u8; 32];
+    y[31] = 4;
+    point(e, x, y)
+}
+
+#[test]
+fn register_and_get_key_works() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+    let p = sample_point(&e);
+
+    e.as_contract(&address, || {
+        register_key(&e, 1, &p);
+
+        assert_eq!(get_key(&e, 1), p);
+
+        let assertion = EventAssertion::new(&e, address.clone());
+        assertion.assert_event_count(1);
+    });
+}
+
+#[test]
+fn register_multiple_keys_round_trip() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        // Register a handful of keys under distinct ids and verify every
+        // get_key call round-trips to the registered point.
+        for i in 0..5u32 {
+            let mut x = [0u8; 32];
+            x[31] = (i + 1) as u8;
+            let mut y = [0u8; 32];
+            y[31] = (i + 10) as u8;
+            let p = point(&e, x, y);
+            register_key(&e, i, &p);
+            assert_eq!(get_key(&e, i), p);
+        }
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3300)")]
+fn register_duplicate_id_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        register_key(&e, 1, &sample_point(&e));
+        register_key(&e, 1, &another_sample_point(&e));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3301)")]
+fn get_unknown_id_panics() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let _ = get_key(&e, 42);
+    });
+}
+
+#[test]
+fn rotate_key_replaces_in_place() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    let old = sample_point(&e);
+    let new = another_sample_point(&e);
+
+    e.as_contract(&address, || {
+        register_key(&e, 1, &old);
+        rotate_key(&e, 1, &new);
+
+        assert_eq!(get_key(&e, 1), new);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3301)")]
+fn rotate_unknown_id_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        rotate_key(&e, 7, &sample_point(&e));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3303)")]
+fn register_identity_point_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        register_key(&e, 1, &BytesN::from_array(&e, &[0u8; 64]));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3303)")]
+fn rotate_to_identity_point_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        register_key(&e, 1, &sample_point(&e));
+        rotate_key(&e, 1, &BytesN::from_array(&e, &[0u8; 64]));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3302)")]
+fn register_non_canonical_x_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        // `x = r` is the smallest non-canonical encoding.
+        let x: [u8; 32] = [
+            0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29, 0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81,
+            0x58, 0x5d, 0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91, 0x43, 0xe1, 0xf5, 0x93,
+            0xf0, 0x00, 0x00, 0x01,
+        ];
+        let mut y = [0u8; 32];
+        y[31] = 1;
+
+        register_key(&e, 1, &point(&e, x, y));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3302)")]
+fn register_non_canonical_y_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let mut x = [0u8; 32];
+        x[31] = 1;
+        // `y = 2^256 - 1` is well above `r`.
+        let y = [0xffu8; 32];
+
+        register_key(&e, 1, &point(&e, x, y));
+    });
+}
+
+#[test]
+fn rotate_emits_rotation_event() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    let old = sample_point(&e);
+    let new = another_sample_point(&e);
+
+    e.as_contract(&address, || {
+        register_key(&e, 1, &old);
+        rotate_key(&e, 1, &new);
+
+        // 2 events: AuditorRegistered + AuditorRotated.
+        EventAssertion::new(&e, address.clone()).assert_event_count(2);
+    });
+}
+
+#[test]
+fn validate_point_accepts_canonical_non_identity() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        validate_point(&e, &sample_point(&e));
+    });
+}
+
+#[test]
+fn storage_key_round_trip() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        // Direct read by storage key matches the value returned by get_key.
+        let p = sample_point(&e);
+        register_key(&e, 9, &p);
+
+        let stored: BytesN<64> = e.storage().persistent().get(&AuditorStorageKey::Key(9)).unwrap();
+        assert_eq!(stored, p);
+    });
+}

--- a/packages/tokens/src/confidential/mod.rs
+++ b/packages/tokens/src/confidential/mod.rs
@@ -1,0 +1,13 @@
+//! # Confidential Token Module
+//!
+//! Building blocks for the confidential token wrapper, which encrypts balances
+//! and transfer amounts under Grumpkin ElGamal commitments and proves
+//! correctness via zero-knowledge circuits.
+//!
+//! ## Modules
+//!
+//! - **Auditor Registry**: per-`auditor_id` Grumpkin public key store consumed
+//!   by the wrapper to build auditor ECDH ciphertexts on withdraw, transfer,
+//!   and operator flows.
+
+pub mod auditor;

--- a/packages/tokens/src/lib.rs
+++ b/packages/tokens/src/lib.rs
@@ -13,6 +13,7 @@
 
 #![no_std]
 
+pub mod confidential;
 pub mod fungible;
 pub mod non_fungible;
 pub mod rwa;


### PR DESCRIPTION
## Summary

Closes #702.

Adds an auditor key registry contract used by the confidential token wrapper to look up Grumpkin public keys when producing auditor ECDH ciphertexts.

- `packages/tokens/src/confidential/auditor/` — library module exposing the `AuditorRegistry` trait, `AuditorError` enum, `AuditorRegistered` / `AuditorRotated` events, and storage-level `register_key` / `rotate_key` / `get_key` helpers.
- `examples/confidential/auditor/` — example contract wiring `AuditorRegistry` to `stellar-access`, gating `register_key` / `rotate_key` behind a `"manager"` role.
- Points are stored as `BytesN<64>` (affine `(x, y)`, big-endian) under per-key persistent entries. Reads extend TTL; writes do not. The trait surface is `register_key(auditor_id, point, operator)`, `rotate_key(auditor_id, new_point, operator)`, `get_key(auditor_id) -> BytesN<64>`.
- Validation delegates to `stellar_contract_utils::crypto::grumpkin::Grumpkin`: identity rejection (`(0, 0)`) and the fused canonical + on-curve check (`y² ≡ x³ - 17 (mod r)`). Error codes: `AuditorAlreadyRegistered = 3300`, `AuditorNotRegistered = 3301`, `IdentityPoint = 3302`, `PointNotOnCurve = 3303`.

## Test plan

- [x] `cargo test --workspace` (1462 passed, 0 failed)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --release --locked --all-targets -- -D warnings`
- [x] Library tests cover: register + get round-trip, N-key round-trip, duplicate id, get/rotate of unknown id, identity rejection on register and rotate, off-curve rejection, non-canonical x/y rejection, rotation event emission, validator accepts the Grumpkin generator, direct storage-key round-trip
- [x] Example tests cover: register + get round-trip via the client, rotate, duplicate id, get/rotate unknown id, identity/off-curve/non-canonical rejection, non-manager caller rejection, 10-key round-trip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confidential auditor registry contract with key registration and rotation capabilities
  * Introduced auditor key storage and management infrastructure

* **Examples**
  * Added example implementation of confidential auditor registry contract

* **Tests**
  * Added comprehensive test coverage for auditor registry and key storage operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/stellar-contracts/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->