### PR TITLE
feat(confidential): verifier registry trait

### DIFF
--- a/packages/tokens/src/confidential/mod.rs
+++ b/packages/tokens/src/confidential/mod.rs
@@ -1,0 +1,13 @@
+//! # Confidential Token Module
+//!
+//! Building blocks for the confidential token wrapper, which encrypts balances
+//! and transfer amounts under Grumpkin ElGamal commitments and proves
+//! correctness via zero-knowledge circuits.
+//!
+//! ## Modules
+//!
+//! - **Verifier**: per-`CircuitType` UltraHonk verification key store consumed
+//!   by the wrapper to verify proofs accompanying every state-changing
+//!   operation (register, withdraw, transfer, operator flows).
+
+pub mod verifier;

--- a/packages/tokens/src/confidential/verifier/mod.rs
+++ b/packages/tokens/src/confidential/verifier/mod.rs
@@ -1,0 +1,308 @@
+//! # Confidential Verifier Registry
+//!
+//! Stores UltraHonk verification keys used by the confidential token wrapper to
+//! verify zero-knowledge proofs accompanying every state-changing operation.
+//! Each key is indexed by [`CircuitType`]. A single deployment can serve
+//! multiple token wrappers: wrapper-specific binding is enforced inside the
+//! circuit via the `wrap` field (DESIGN §2.7, §4.2), not by the verifier, so
+//! the same VK set is reusable across every wrapper that targets the same
+//! protocol version.
+//!
+//! # ⚠️ Not Production Ready
+//!
+//! This module is **unfinished**. [`ConfidentialVerifier::verify_proof`] has no
+//! working default implementation because its UltraHonk backend
+//! ([`Oghma/rs-soroban-ultrahonk`](https://github.com/Oghma/rs-soroban-ultrahonk))
+//! is still under development and **has not been audited**. Do **not** deploy a
+//! contract built on this trait to mainnet or any environment that handles
+//! real value. The trait surface, the [`VerifierStorageKey`] layout, and the
+//! VK-management helpers in [`storage`] are stable enough for the confidential
+//! token wrapper to scaffold against, and they are the only part of this
+//! module that is intended to be relied upon today.
+//!
+//! ## Why a Separate Contract
+//!
+//! Verification keys are referenced by the wrapper on every state-changing
+//! operation (register, withdraw, transfer, operator flows). Keeping them in a
+//! separate registry allows:
+//!
+//! - **Isolation**: VK-management privileges are scoped to the verifier admin,
+//!   distinct from token admin powers.
+//! - **Lifecycle**: per-circuit VKs can be rotated (e.g. when a circuit is
+//!   patched) without redeploying the wrapper, subject to the deployer's
+//!   governance posture (see DESIGN §3.5).
+//!
+//! ## VK Encoding
+//!
+//! Verification keys are opaque [`Bytes`] blobs from this module's point of
+//! view; structural validation lives in the future UltraHonk backend, not in
+//! the storage layer. The on-disk reference format committed under
+//! `circuits/vks/` is a JSON array of hex-encoded `Fr` field elements (one
+//! file per circuit, produced by `bb write_vk --output_format fields`).
+//!
+//! ## Storage
+//!
+//! Verification keys live in **instance** storage: there is exactly one VK per
+//! [`CircuitType`] for the lifetime of the verifier contract, and they are
+//! consulted on every wrapper invocation. Per the workspace conventions,
+//! instance-TTL management is the contract developer's responsibility — this
+//! module's helpers never call `instance().extend_ttl()`.
+//!
+//! ## Updating a Verification Key Is a Last Resort
+//!
+//! [`ConfidentialVerifier::update_verification_key`] (and the underlying
+//! [`storage::update_verification_key`] helper) is **soundness-critical** and
+//! should be treated as a break-glass operation. DESIGN §3.5 makes the
+//! strongest possible recommendation: ship VKs immutably and require a fresh
+//! deployment for any circuit change. If a deployment exposes an update path
+//! at all, it should be reserved for one situation: a discovered soundness
+//! bug in a circuit or verifier that needs a fast fix.
+//!
+//! Concretely, an update:
+//!
+//! - **Can silently break soundness.** A VK that does not correspond to the
+//!   audited circuit will happily verify forged proofs — including proofs that
+//!   mint tokens, drain accounts, or impersonate registered users. The on-chain
+//!   bytes are an opaque blob to this module; nothing here can detect a wrong,
+//!   corrupted, or maliciously crafted replacement.
+//! - **Invalidates every in-flight proof for the affected circuit.** Any proof
+//!   generated against the previous VK fails verification the instant the new
+//!   VK is activated, so the corresponding transactions revert at the
+//!   proof-verification boundary. Wallets must regenerate against the new VK
+//!   and resubmit (DESIGN §8.6 discusses this for the related auditor-key
+//!   rotation case; the same reasoning applies here).
+//! - **Should be gated.** Implementors are expected to put the update path
+//!   behind strong access control (multisig + timelock at a minimum) and to
+//!   publish enough material — circuit source, toolchain pin, SRS transcript
+//!   reference (DESIGN §10.6) — that any user can independently reproduce the
+//!   new VK before trusting it.
+//!
+//! Treat every call to `update_verification_key` as an emergency, not a
+//! routine operation.
+
+pub mod storage;
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contracterror, contractevent, contracttrait, contracttype, Address, Bytes, Env};
+pub use storage::{
+    get_verification_key, register_verification_key, update_verification_key, VerifierStorageKey,
+};
+
+/// Identifier of a zero-knowledge circuit whose verification key is stored in
+/// the registry. The numeric values are part of the on-chain interface and
+/// MUST NOT change.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum CircuitType {
+    Register = 0,
+    Withdraw = 1,
+    Transfer = 2,
+    OperatorTransfer = 3,
+    SetOperator = 4,
+    RevokeOperator = 5,
+}
+
+/// Trait for managing UltraHonk verification keys used by the confidential
+/// token wrapper.
+///
+/// The wrapper calls [`ConfidentialVerifier::verify_proof`] on every
+/// state-changing operation, passing the [`CircuitType`] that identifies the
+/// circuit, the serialized public inputs, and the proof blob.
+/// [`ConfidentialVerifier::register_verification_key`] and
+/// [`ConfidentialVerifier::update_verification_key`] are privileged operations
+/// expected to be gated by the implementor's access-control scheme.
+///
+/// # ⚠️ Not Production Ready
+///
+/// See the module-level warning. `verify_proof` cannot be wired to a real
+/// UltraHonk backend until `rs-soroban-ultrahonk` is released and audited.
+#[contracttrait]
+pub trait ConfidentialVerifier {
+    /// Registers an UltraHonk verification key under a fresh [`CircuitType`].
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `circuit_type` - The circuit to register the key under.
+    /// * `vk` - The serialized UltraHonk verification key.
+    /// * `operator` - The address authorizing the invocation.
+    ///
+    /// # Errors
+    ///
+    /// * [`VerifierError::VerificationKeyAlreadyRegistered`] - When
+    ///   `circuit_type` already has a verification key registered.
+    ///
+    /// # Events
+    ///
+    /// * topics - `["verification_key_registered", circuit_type: CircuitType]`
+    /// * data - `[vk: Bytes]`
+    ///
+    /// # Notes
+    ///
+    /// No default implementation is provided because this is a privileged
+    /// operation that requires custom access control. Access control should
+    /// be enforced on `operator` before calling
+    /// [`storage::register_verification_key`] for the implementation.
+    fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: Bytes, operator: Address);
+
+    /// Replaces the UltraHonk verification key registered under `circuit_type`.
+    ///
+    /// # ⚠️ Soundness-Critical Break-Glass Operation
+    ///
+    /// Updating a verification key is **not** a routine operation. A wrong,
+    /// corrupted, or maliciously crafted replacement makes the affected
+    /// circuit accept forged proofs — minting, draining, impersonation, and
+    /// every other constraint the circuit was meant to enforce silently
+    /// collapse. Activating a new VK also invalidates every in-flight proof
+    /// produced against the previous one.
+    ///
+    /// The recommended posture is **full immutability**: ship VKs fixed at
+    /// deployment and require a fresh deployment for any circuit change.
+    /// Exposing this method should be reserved for fixing a discovered
+    /// soundness bug in a circuit or verifier, and should be behind strong
+    /// governance (multisig + timelock at minimum). The new VK must be
+    /// independently reproducible from the audited circuit source, pinned
+    /// toolchain, and SRS transcript (DESIGN §10.6).
+    ///
+    /// Only an operator with sufficient permissions should be able to call
+    /// this function.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `circuit_type` - The circuit whose key is being updated.
+    /// * `new_vk` - The new serialized UltraHonk verification key.
+    /// * `operator` - The address authorizing the invocation.
+    ///
+    /// # Errors
+    ///
+    /// * [`VerifierError::VerificationKeyNotRegistered`] - When `circuit_type`
+    ///   has no registered key.
+    ///
+    /// # Events
+    ///
+    /// * topics - `["verification_key_updated", circuit_type: CircuitType]`
+    /// * data - `[old_vk: Bytes, new_vk: Bytes]`
+    ///
+    /// # Notes
+    ///
+    /// No default implementation is provided because this is a privileged
+    /// operation that requires custom access control. Access control should
+    /// be enforced on `operator` before calling
+    /// [`storage::update_verification_key`] for the implementation.
+    fn update_verification_key(
+        e: &Env,
+        circuit_type: CircuitType,
+        new_vk: Bytes,
+        operator: Address,
+    );
+
+    /// Verifies an UltraHonk proof against the verification key registered
+    /// under `circuit_type` and returns `true` iff the proof is valid for the
+    /// given `public_inputs`.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `circuit_type` - The circuit the proof was produced against.
+    /// * `public_inputs` - The serialized public inputs the prover committed
+    ///   to.
+    /// * `proof` - The serialized UltraHonk proof.
+    ///
+    /// # Errors
+    ///
+    /// * [`VerifierError::VerificationKeyNotRegistered`] - When `circuit_type`
+    ///   has no registered key.
+    ///
+    /// # Notes
+    ///
+    /// No default implementation is provided. The UltraHonk verification
+    /// backend lives in `Oghma/rs-soroban-ultrahonk`, which is still
+    /// under development and has not been audited (see the module-level
+    /// warning). Implementors MUST NOT ship a stub that returns `true`
+    /// unconditionally to any environment that handles real value.
+    fn verify_proof(e: &Env, circuit_type: CircuitType, public_inputs: Bytes, proof: Bytes)
+        -> bool;
+
+    /// Returns the UltraHonk verification key registered under `circuit_type`.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `circuit_type` - The circuit whose key is requested.
+    ///
+    /// # Errors
+    ///
+    /// * [`VerifierError::VerificationKeyNotRegistered`] - When `circuit_type`
+    ///   has no registered key.
+    fn get_verification_key(e: &Env, circuit_type: CircuitType) -> Bytes {
+        storage::get_verification_key(e, circuit_type)
+    }
+}
+
+// ################## ERRORS ##################
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum VerifierError {
+    /// Indicates `circuit_type` already has a verification key registered.
+    VerificationKeyAlreadyRegistered = 3400,
+    /// Indicates no verification key is registered under `circuit_type`.
+    VerificationKeyNotRegistered = 3401,
+    /// Indicates the proof failed UltraHonk verification.
+    InvalidProof = 3402,
+}
+
+// ################## EVENTS ##################
+
+/// Event emitted when a new verification key is registered.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerificationKeyRegistered {
+    #[topic]
+    pub circuit_type: CircuitType,
+    pub vk: Bytes,
+}
+
+/// Emits an event indicating a verification key has been registered.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `circuit_type` - The circuit the key was registered under.
+/// * `vk` - The serialized UltraHonk verification key.
+pub fn emit_verification_key_registered(e: &Env, circuit_type: CircuitType, vk: &Bytes) {
+    VerificationKeyRegistered { circuit_type, vk: vk.clone() }.publish(e);
+}
+
+/// Event emitted when a verification key is updated.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerificationKeyUpdated {
+    #[topic]
+    pub circuit_type: CircuitType,
+    pub old_vk: Bytes,
+    pub new_vk: Bytes,
+}
+
+/// Emits an event indicating a verification key has been updated.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `circuit_type` - The circuit whose key was updated.
+/// * `old_vk` - The previously registered verification key.
+/// * `new_vk` - The newly registered verification key.
+pub fn emit_verification_key_updated(
+    e: &Env,
+    circuit_type: CircuitType,
+    old_vk: &Bytes,
+    new_vk: &Bytes,
+) {
+    VerificationKeyUpdated { circuit_type, old_vk: old_vk.clone(), new_vk: new_vk.clone() }
+        .publish(e);
+}

--- a/packages/tokens/src/confidential/verifier/storage.rs
+++ b/packages/tokens/src/confidential/verifier/storage.rs
@@ -79,7 +79,7 @@ pub fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: &Bytes)
 ///
 /// - **A wrong VK silently breaks soundness.** This function writes the
 ///   `new_vk` bytes verbatim; nothing here checks that they correspond to the
-///   audited circuit. A corrupted, mis-derived, or maliciously crafted
+///   audited circuit. A corrupted, misderived, or maliciously crafted
 ///   replacement will happily verify forged proofs — minting tokens, draining
 ///   accounts, impersonating registered users.
 /// - **The update invalidates every in-flight proof for the affected circuit.**

--- a/packages/tokens/src/confidential/verifier/storage.rs
+++ b/packages/tokens/src/confidential/verifier/storage.rs
@@ -1,0 +1,132 @@
+use soroban_sdk::{contracttype, panic_with_error, Bytes, Env};
+
+use crate::confidential::verifier::{
+    emit_verification_key_registered, emit_verification_key_updated, CircuitType, VerifierError,
+};
+
+/// Storage keys for the verifier registry.
+#[contracttype]
+pub enum VerifierStorageKey {
+    /// Maps [`CircuitType`] to its serialized UltraHonk verification key.
+    Vk(CircuitType),
+}
+
+// ################## QUERY STATE ##################
+
+/// Returns the UltraHonk verification key registered under `circuit_type`.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `circuit_type` - The circuit whose key is requested.
+///
+/// # Errors
+///
+/// * [`VerifierError::VerificationKeyNotRegistered`] - When `circuit_type` has
+///   no registered key.
+pub fn get_verification_key(e: &Env, circuit_type: CircuitType) -> Bytes {
+    e.storage()
+        .instance()
+        .get(&VerifierStorageKey::Vk(circuit_type))
+        .unwrap_or_else(|| panic_with_error!(e, VerifierError::VerificationKeyNotRegistered))
+}
+
+// ################## CHANGE STATE ##################
+
+/// Registers an UltraHonk verification key under a fresh [`CircuitType`].
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `circuit_type` - The circuit to register the key under.
+/// * `vk` - The serialized UltraHonk verification key.
+///
+/// # Errors
+///
+/// * [`VerifierError::VerificationKeyAlreadyRegistered`] - When `circuit_type`
+///   already has a verification key registered.
+///
+/// # Events
+///
+/// * topics - `["verification_key_registered", circuit_type: CircuitType]`
+/// * data - `[vk: Bytes]`
+///
+/// # Security Warning
+///
+/// **IMPORTANT**: This function bypasses authorization checks and should
+/// only be used:
+/// - During contract initialization/construction
+/// - In admin functions that implement their own authorization logic
+///
+/// Using this function in public-facing methods may create significant
+/// security risks as it could allow unauthorized modifications.
+pub fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: &Bytes) {
+    let key = VerifierStorageKey::Vk(circuit_type);
+    if e.storage().instance().has(&key) {
+        panic_with_error!(e, VerifierError::VerificationKeyAlreadyRegistered);
+    }
+
+    e.storage().instance().set(&key, vk);
+    emit_verification_key_registered(e, circuit_type, vk);
+}
+
+/// Replaces the UltraHonk verification key registered under `circuit_type`.
+///
+/// # ⚠️ Soundness-Critical Break-Glass Operation
+///
+/// Updating a verification key is **not** a routine operation and must be
+/// treated as an emergency response, not a maintenance task. Concretely:
+///
+/// - **A wrong VK silently breaks soundness.** This function writes the
+///   `new_vk` bytes verbatim; nothing here checks that they correspond to the
+///   audited circuit. A corrupted, mis-derived, or maliciously crafted
+///   replacement will happily verify forged proofs — minting tokens, draining
+///   accounts, impersonating registered users.
+/// - **The update invalidates every in-flight proof for the affected circuit.**
+///   Any proof generated against the previous VK fails the instant the new VK
+///   is activated; wallets must regenerate against the new VK and resubmit.
+/// - **The caller is responsible for governance.** The recommended posture is
+///   full immutability. If an update path is exposed at all, it should be gated
+///   by multisig + timelock, and the new VK must be independently reproducible
+///   from the audited circuit source, pinned toolchain, and SRS transcript
+///   (DESIGN §10.6).
+///
+/// Use only in response to a discovered soundness bug in a circuit or
+/// verifier that cannot be fixed by a fresh deployment.
+///
+/// # Arguments
+///
+/// * `e` - Access to the Soroban environment.
+/// * `circuit_type` - The circuit whose key is being updated.
+/// * `new_vk` - The new serialized UltraHonk verification key.
+///
+/// # Errors
+///
+/// * [`VerifierError::VerificationKeyNotRegistered`] - When `circuit_type` has
+///   no registered key.
+///
+/// # Events
+///
+/// * topics - `["verification_key_updated", circuit_type: CircuitType]`
+/// * data - `[old_vk: Bytes, new_vk: Bytes]`
+///
+/// # Security Warning
+///
+/// **IMPORTANT**: This function bypasses authorization checks and should
+/// only be used:
+/// - During contract initialization/construction
+/// - In admin functions that implement their own authorization logic
+///
+/// Using this function in public-facing methods may create significant
+/// security risks as it could allow unauthorized modifications.
+pub fn update_verification_key(e: &Env, circuit_type: CircuitType, new_vk: &Bytes) {
+    let key = VerifierStorageKey::Vk(circuit_type);
+    let old_vk: Bytes = e
+        .storage()
+        .instance()
+        .get(&key)
+        .unwrap_or_else(|| panic_with_error!(e, VerifierError::VerificationKeyNotRegistered));
+
+    e.storage().instance().set(&key, new_vk);
+    emit_verification_key_updated(e, circuit_type, &old_vk, new_vk);
+}

--- a/packages/tokens/src/confidential/verifier/test.rs
+++ b/packages/tokens/src/confidential/verifier/test.rs
@@ -1,0 +1,143 @@
+extern crate std;
+
+use soroban_sdk::{contract, Bytes, Env};
+use stellar_event_assertion::EventAssertion;
+
+use crate::confidential::verifier::{
+    storage::{
+        get_verification_key, register_verification_key, update_verification_key,
+        VerifierStorageKey,
+    },
+    CircuitType,
+};
+
+#[contract]
+struct MockContract;
+
+fn vk_bytes(e: &Env, seed: u8) -> Bytes {
+    Bytes::from_array(e, &[seed; 32])
+}
+
+#[test]
+fn register_and_get_verification_key_works() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+    let vk = vk_bytes(&e, 0xab);
+
+    e.as_contract(&address, || {
+        register_verification_key(&e, CircuitType::Register, &vk);
+
+        assert_eq!(get_verification_key(&e, CircuitType::Register), vk);
+
+        EventAssertion::new(&e, address.clone()).assert_event_count(1);
+    });
+}
+
+#[test]
+fn register_each_circuit_round_trips() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        for (i, circuit) in [
+            CircuitType::Register,
+            CircuitType::Withdraw,
+            CircuitType::Transfer,
+            CircuitType::OperatorTransfer,
+            CircuitType::SetOperator,
+            CircuitType::RevokeOperator,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let vk = vk_bytes(&e, i as u8);
+            register_verification_key(&e, circuit, &vk);
+            assert_eq!(get_verification_key(&e, circuit), vk);
+        }
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3400)")]
+fn register_twice_panics_with_already_registered() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        register_verification_key(&e, CircuitType::Withdraw, &vk_bytes(&e, 0x01));
+        register_verification_key(&e, CircuitType::Withdraw, &vk_bytes(&e, 0x02));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3401)")]
+fn get_unregistered_panics_with_not_registered() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let _ = get_verification_key(&e, CircuitType::Transfer);
+    });
+}
+
+#[test]
+fn update_verification_key_replaces_in_place() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let old = vk_bytes(&e, 0x10);
+        let new = vk_bytes(&e, 0x20);
+
+        register_verification_key(&e, CircuitType::Transfer, &old);
+        update_verification_key(&e, CircuitType::Transfer, &new);
+
+        assert_eq!(get_verification_key(&e, CircuitType::Transfer), new);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3401)")]
+fn update_unregistered_panics_with_not_registered() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        update_verification_key(&e, CircuitType::SetOperator, &vk_bytes(&e, 0xff));
+    });
+}
+
+#[test]
+fn update_emits_update_event() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let old = vk_bytes(&e, 0x10);
+        let new = vk_bytes(&e, 0x20);
+
+        register_verification_key(&e, CircuitType::OperatorTransfer, &old);
+        update_verification_key(&e, CircuitType::OperatorTransfer, &new);
+
+        // 2 events: VerificationKeyRegistered + VerificationKeyUpdated.
+        EventAssertion::new(&e, address.clone()).assert_event_count(2);
+    });
+}
+
+#[test]
+fn storage_key_round_trip() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let vk = vk_bytes(&e, 0x77);
+        register_verification_key(&e, CircuitType::RevokeOperator, &vk);
+
+        let stored: Bytes = e
+            .storage()
+            .instance()
+            .get(&VerifierStorageKey::Vk(CircuitType::RevokeOperator))
+            .unwrap();
+        assert_eq!(stored, vk);
+    });
+}

--- a/packages/tokens/src/lib.rs
+++ b/packages/tokens/src/lib.rs
@@ -7,12 +7,15 @@
 //!
 //! - `fungible`: Implementation of fungible tokens (similar to ERC-20)
 //! - `non_fungible`: Implementation of non-fungible tokens (similar to ERC-721)
+//! - `confidential`: Building blocks for the confidential token wrapper
+//!   (encrypted balances + zero-knowledge proofs)
 //!
 //! Each module provides its own set of traits, functions, and extensions for
 //! working with the respective token type.
 
 #![no_std]
 
+pub mod confidential;
 pub mod fungible;
 pub mod non_fungible;
 pub mod rwa;


### PR DESCRIPTION
## Summary

- Adds `ConfidentialVerifier` `#[contracttrait]` (DESIGN §10.5) under `packages/tokens/src/confidential/verifier/`, generating `ConfidentialVerifierClient` for the future wrapper contract to consume.
- Defines `CircuitType` (6 variants — Register / Withdraw / Transfer / OperatorTransfer / SetOperator / RevokeOperator, DESIGN §10.1) and per-circuit VK storage on **instance** storage, with `register_verification_key` / `update_verification_key` / `get_verification_key` helpers + `VerificationKeyRegistered` / `VerificationKeyUpdated` events. Error range `3400-3402`.
- `verify_proof` is intentionally left without a default body and the module ships with a loud "⚠️ Not Production Ready" banner: the UltraHonk backend (`Oghma/rs-soroban-ultrahonk`) is still under development and unaudited.
- `update_verification_key` carries an explicit break-glass warning on both the trait method and the storage helper: a wrong VK silently breaks soundness, an update invalidates every in-flight proof for the affected circuit, and the path should be gated by multisig + timelock and reserved for soundness-bug fixes.

Note on the stack: this branch is cut from `main`, which has no `confidential/mod.rs` yet (the auditor module lives only on `feat/confidential-auditor`). So this PR also adds `pub mod confidential;` to `lib.rs` and creates `confidential/mod.rs`. When the auditor PR lands first the merge will need to re-add `pub mod auditor;` and the auditor entry in the module doc list — trivial conflict.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --release --locked --all-targets -- -D warnings`
- [x] `cargo build --package stellar-tokens` (`ConfidentialVerifierClient` shows up in generated artefacts)
- [x] `cargo test --package stellar-tokens confidential::` — 8/8 pass (register / update / get round-trips, error paths `3400` / `3401`, event counts, raw storage-key round-trip)
- [ ] End-to-end `verify_proof` verification deferred to the PR that wires `rs-soroban-ultrahonk`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confidential token wrapper module with support for encrypted balances and zero-knowledge proof verification.
  * Implemented verification key registry for managing cryptographic proofs across multiple operation types.
  * Enables secure token operations including transfers and withdrawals via zero-knowledge circuits.

* **Tests**
  * Added comprehensive test suite validating verification key registration, updates, and storage operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/stellar-contracts/pull/734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->