### PR TITLE
fix(confidential): event emission and non-canonical encodings

### DIFF
--- a/packages/contract-utils/src/crypto/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/grumpkin.rs
@@ -110,6 +110,42 @@ impl Grumpkin {
         !Self::is_identity(p)
     }
 
+    /// Returns `true` iff `f` is a canonical 32-byte big-endian `Bn254Fr`
+    /// representative, i.e. its value as a 256-bit big-endian integer is
+    /// strictly less than the field modulus `r`.
+    ///
+    /// Required at any trust boundary that feeds bytes to the Soroban host's
+    /// `Bn254Fr` deserialiser. The host's `bn254_fr_from_u256val` (and the
+    /// SDK's `Bn254Fr::from_bytes` that wraps it) accepts any 32-byte
+    /// representative and silently reduces values `≥ r` modulo `r` rather
+    /// than rejecting them, so multiple distinct byte strings deserialise to
+    /// the same field element. Callers that persist or emit raw bytes (event
+    /// data, on-chain commitments) must enforce canonicality themselves to
+    /// keep state and events byte-unique per logical value.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - The 32-byte field representative.
+    pub fn is_canonical_field(f: &BytesN<32>) -> bool {
+        is_canonical_coord(&f.to_array())
+    }
+
+    /// Returns `true` iff both coordinates of `p` are canonical 32-byte
+    /// big-endian `Bn254Fr` representatives. See [`Self::is_canonical_field`]
+    /// for the rationale and host-deserialiser caveat.
+    ///
+    /// Performs no on-curve or non-identity check; combine with
+    /// [`Self::is_on_curve`] / [`Self::is_not_identity`] when those are also
+    /// required.
+    ///
+    /// # Arguments
+    ///
+    /// * `p` - The 64-byte point encoding.
+    pub fn is_canonical_point(p: &Point) -> bool {
+        let bytes = p.to_array();
+        is_canonical_coord(&bytes[..32]) && is_canonical_coord(&bytes[32..])
+    }
+
     /// Returns `true` iff `(x, y)` satisfies Grumpkin's curve equation
     /// `y² ≡ x³ - 17 (mod r)` **and** each coordinate is a canonical
     /// `Bn254Fr` representative (`< r` as a 32-byte big-endian integer).
@@ -129,8 +165,7 @@ impl Grumpkin {
     /// * `e` - Access to the Soroban environment.
     /// * `p` - The point to validate.
     pub fn is_on_curve(e: &Env, p: &Point) -> bool {
-        let bytes = p.to_array();
-        if !is_canonical_coord(&bytes[..32]) || !is_canonical_coord(&bytes[32..]) {
+        if !Self::is_canonical_point(p) {
             return false;
         }
         let (x, y) = Self::coordinates(e, p);

--- a/packages/tokens/src/confidential/README.md
+++ b/packages/tokens/src/confidential/README.md
@@ -20,7 +20,7 @@ real value.
 
 ## Layout
 
-```
+```text
 confidential/
 ├── mod.rs          # ConfidentialToken trait + Hooks + events
 ├── storage.rs      # operation-level orchestration, public-input assembly

--- a/packages/tokens/src/confidential/README.md
+++ b/packages/tokens/src/confidential/README.md
@@ -35,7 +35,7 @@ confidential/
 
 A single deployment is **three contracts** wired together:
 
-1. A `ConfidentialToken` contract (wraps one SEP-41 asset).
+1. A `ConfidentialToken` contract.
 2. A `ConfidentialAuditor` registry (Grumpkin public keys, indexed by
    `auditor_id`; reusable across multiple tokens).
 3. A `ConfidentialVerifier` registry (one UltraHonk VK per

--- a/packages/tokens/src/confidential/README.md
+++ b/packages/tokens/src/confidential/README.md
@@ -1,0 +1,100 @@
+# Confidential Token
+
+A Soroban contract suite that provides SEP-41 tokens with **private balances
+and transfers**. Balances are stored as unchunked Pedersen commitments on
+the Grumpkin curve; every state-changing operation that consumes private
+state is accompanied by an UltraHonk zero-knowledge proof that the contract
+verifies cross-contract. Recipients and auditors recover plaintext via
+per-transfer ephemeral ECDH.
+
+The protocol provides **confidentiality, not anonymity** — sender and
+recipient addresses remain visible on-chain; amounts and balances do not.
+
+## ⚠️ Not Production Ready
+
+The [`verifier`](./verifier/) module's UltraHonk backend
+([`rs-soroban-ultrahonk`](https://github.com/Oghma/rs-soroban-ultrahonk))
+is still under development and has **not been audited**. Do **not** deploy
+a contract built on this trait to mainnet or any environment that handles
+real value.
+
+## Layout
+
+```
+confidential/
+├── mod.rs          # ConfidentialToken trait + Hooks + events
+├── storage.rs      # operation-level orchestration, public-input assembly
+├── auditor/        # Grumpkin auditor-key registry (separate contract)
+├── verifier/       # UltraHonk VK registry (separate contract)
+├── compliance/     # turnkey ComplianceHooks: freeze, SAC passthrough, external policy
+├── circuits/       # Noir/UltraHonk circuits + pinned VKs
+└── docs/
+    ├── DESIGN.md       # full protocol specification
+    └── COMPLIANCE.md   # compliance-extension specification
+```
+
+A single deployment is **three contracts** wired together:
+
+1. A `ConfidentialToken` contract (wraps one SEP-41 asset).
+2. A `ConfidentialAuditor` registry (Grumpkin public keys, indexed by
+   `auditor_id`; reusable across multiple tokens).
+3. A `ConfidentialVerifier` registry (one UltraHonk VK per
+   [`CircuitType`]; reusable across tokens that share the protocol
+   version).
+
+## Modules
+
+### `confidential_token`
+
+The core module holds the per-account `ConfidentialAccount` and
+per-`(owner, spender)` `SpenderDelegation` entries, and exposes the 
+entry points that drive them. Every state-changing entry point:
+
+1. Calls `require_auth()` on the appropriate account.
+2. XDR-decodes the `data: Bytes` envelope into a typed `…Payload`.
+3. Runs the matching [`Hooks`] callback.
+4. Delegates to a function in [`storage`] that loads trusted public
+   inputs, assembles the public-input blob, calls
+   [`ConfidentialVerifier::verify_proof`] cross-contract, applies the
+   state mutation, and emits the event.
+
+The `Hooks` associated type is the extension point — wire `NoHooks` for a
+plain deployment, or [`ComplianceHooks`](./compliance/) for a gated one.
+
+### `auditor`
+
+Stores Grumpkin public keys used to produce per-transfer auditor
+ciphertexts. Each key is indexed by a `u32` `auditor_id`. Writes (register
+/ rotate) are privileged and require the implementor to wire access
+control.
+
+### `verifier`
+
+Stores one UltraHonk verification key per [`CircuitType`]. Updating a VK is
+**soundness-critical** and should be treated as a break-glass operation —
+see the module docstring for the rationale and the recommended governance
+posture.
+
+### `compliance`
+
+A turnkey [`Hooks`] implementation layering deployer-configurable
+controls on top of the token: per-account freezing, SAC `authorized()`
+passthrough, and an optional external authorization policy. Wire as
+`type Hooks = ComplianceHooks;`. See
+[`docs/COMPLIANCE.md`](./docs/COMPLIANCE.md) for the specification.
+
+### `circuits`
+
+Noir sources, build scripts, and the pinned UltraHonk VKs that the
+verifier registry serves. Regeneration is gated on a CI diff against the
+committed `circuits/vks/*.vk.json` files; see
+[`circuits/vks/README.md`](./circuits/vks/README.md) for the toolchain
+pin and re-extraction procedure.
+
+## Documentation
+
+- [`docs/DESIGN.md`](./docs/DESIGN.md) — full protocol specification
+  (cryptographic preliminaries, account model, circuits, public-input
+  tables, security analysis).
+- [`docs/COMPLIANCE.md`](./docs/COMPLIANCE.md) — compliance extension
+  specification.

--- a/packages/tokens/src/confidential/compliance/mod.rs
+++ b/packages/tokens/src/confidential/compliance/mod.rs
@@ -187,7 +187,7 @@ pub trait ConfidentialCompliance: ConfidentialToken {
 pub struct ComplianceHooks;
 
 impl Hooks for ComplianceHooks {
-    fn on_register(e: &Env, account: &Address, _payload: Val) {
+    fn on_register(e: &Env, account: &Address, _auditor_id: u32, _payload: Val) {
         let Some(config) = storage::compliance_config(e) else {
             return;
         };

--- a/packages/tokens/src/confidential/compliance/storage.rs
+++ b/packages/tokens/src/confidential/compliance/storage.rs
@@ -48,15 +48,19 @@ pub fn compliance_config(e: &Env) -> Option<ComplianceConfig> {
 
 /// Returns whether `account` is currently frozen.
 ///
-/// Returns `false` when compliance is not configured.
+/// Returns `false` when compliance is not configured, ignoring any stale
+/// `Frozen` entry left over from a prior configuration.
 ///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.
 /// * `account` - The address to query.
 pub fn is_frozen(e: &Env, account: &Address) -> bool {
+    if compliance_config(e).is_none() {
+        return false;
+    }
     let key = ComplianceStorageKey::Frozen(account.clone());
-    if e.storage().persistent().get::<_, bool>(&key).is_some() {
+    if e.storage().persistent().has(&key) {
         e.storage().persistent().extend_ttl(&key, FROZEN_TTL_THRESHOLD, FROZEN_EXTEND_AMOUNT);
         true
     } else {

--- a/packages/tokens/src/confidential/compliance/test.rs
+++ b/packages/tokens/src/confidential/compliance/test.rs
@@ -12,8 +12,8 @@ use stellar_event_assertion::EventAssertion;
 use crate::confidential::{
     compliance::{
         storage::{compliance_config, freeze, is_frozen, set_compliance_config, unfreeze},
-        ComplianceConfig, ComplianceHooks, ConfidentialCompliance, ConfidentialComplianceClient,
-        Policy,
+        ComplianceConfig, ComplianceHooks, ComplianceStorageKey, ConfidentialCompliance,
+        ConfidentialComplianceClient, Policy,
     },
     storage::{set_address_as_field_element, set_auditor, set_underlying_asset, set_verifier},
     verifier::CircuitType,
@@ -213,6 +213,25 @@ fn unfreeze_without_config_panics_not_configured() {
     let h = setup();
     let alice = Address::generate(&h.e);
     h.e.as_contract(&h.host, || unfreeze(&h.e, &alice));
+}
+
+#[test]
+fn is_frozen_ignores_stale_flag_when_config_removed() {
+    // Freeze alice under an active config, then simulate the config being
+    // wiped (e.g. via a storage migration or instance-entry rotation). The
+    // persistent Frozen flag survives, but is_frozen must report false
+    // because compliance is no longer configured.
+    let h = setup();
+    let alice = Address::generate(&h.e);
+    h.e.as_contract(&h.host, || {
+        set_compliance_config(&h.e, &base_config());
+        freeze(&h.e, &alice);
+        assert!(is_frozen(&h.e, &alice));
+
+        h.e.storage().instance().remove(&ComplianceStorageKey::Config);
+        assert!(compliance_config(&h.e).is_none());
+        assert!(!is_frozen(&h.e, &alice));
+    });
 }
 
 // ################## FREEZE FLOW ##################

--- a/packages/tokens/src/confidential/compliance/test.rs
+++ b/packages/tokens/src/confidential/compliance/test.rs
@@ -189,7 +189,7 @@ fn hooks_short_circuit_without_config() {
         ComplianceHooks::on_merge(&h.e, &alice);
         ComplianceHooks::on_transfer(&h.e, &alice, &bob, void_val(&h.e));
         ComplianceHooks::on_deposit(&h.e, &alice, &bob, 0);
-        ComplianceHooks::on_register(&h.e, &alice, void_val(&h.e));
+        ComplianceHooks::on_register(&h.e, &alice, 0, void_val(&h.e));
         ComplianceHooks::on_withdraw(&h.e, &alice, &bob, 0, void_val(&h.e));
         ComplianceHooks::on_spender_transfer(&h.e, &op, &alice, &bob, void_val(&h.e));
         ComplianceHooks::on_set_spender(&h.e, &alice, &op, 0, void_val(&h.e));
@@ -393,7 +393,7 @@ fn on_register_skips_freeze_check() {
         freeze(&h.e, &alice);
         // No panic: register predates the account entry, so the freeze
         // gate is intentionally skipped.
-        ComplianceHooks::on_register(&h.e, &alice, void_val(&h.e));
+        ComplianceHooks::on_register(&h.e, &alice, 0, void_val(&h.e));
     });
 }
 

--- a/packages/tokens/src/confidential/docs/DESIGN.md
+++ b/packages/tokens/src/confidential/docs/DESIGN.md
@@ -82,7 +82,9 @@ A Grumpkin point is a pair $(x, y) \in \mathbb{F}_r^2$. Noir's native `Field` ty
 2. Mask the top 2 bits to zero, yielding a 254-bit candidate $x \in [0, 2^{254})$.
 3. If $x \geq r$, reject and return to step 1.
 4. If the call site requires $x \neq 0$ and $x = 0$, reject and return to step 1.
-5. Output $x$ in its canonical form -- as a Noir `Field` for in-circuit use, or as 32 big-endian bytes (`BytesN<32>`) for storage and event emission. Per §10.8 / §11 this canonical encoding is what the Soroban host's `bn254_fr_*` deserialization accepts; non-canonical values (i.e. $x \geq r$) are rejected at the host boundary.
+5. Output $x$ in its canonical form -- as a Noir `Field` for in-circuit use, or as 32 big-endian bytes (`BytesN<32>`) for storage and event emission.
+
+**Host deserialiser caveat.** The Soroban host's `bn254_fr_from_u256val` (the underlying primitive of `Bn254Fr::from_bytes`) accepts any 32-byte representative and *silently reduces* values $x \geq r$ modulo $r$ rather than rejecting them. Two distinct byte strings ($x$ and $x + r$) therefore deserialise to the same $\mathbb{F}_r$ element, which means a verifier alone cannot distinguish canonical from non-canonical inputs. To keep stored state and emitted events byte-unique per logical value, the contract layer enforces canonicality on every prover-supplied $\mathbb{F}_r$ representative *before* the bytes reach the verifier.
 
 ### 2.3 Pedersen Commitments
 
@@ -1152,7 +1154,7 @@ Requires `bn254_fr_{add, sub, mul, inv}` host calls (CAP-80, Section 10.7).
 2. **Points read from prior on-chain state.** $C_{\text{spend}}$, $C_{\text{receive}}$, stored $Y$ / $\text{PVK}$, and allowance commitments were validated through path (1) when first written. The contract trusts them on subsequent reads.
 3. **Auditor keys (the only proof-less entry point).** $K_{\text{aud}}$ is registered in the auditor contract by the auditor itself, with no accompanying proof. The auditor contract performs canonical encoding, on-curve ($y^2 \equiv x^3 - 17 \pmod{r}$), and non-identity checks at insertion (Section 3.1); the contract trusts the fetched value.
 
-**Canonical encoding** ($x, y \in [0, r)$ as 32-byte representatives) is enforced at the XDR / Soroban host boundary when bytes are deserialized into `BnScalar`; no additional check is needed inside the contract.
+**Canonical encoding** ($x, y \in [0, r)$ as 32-byte representatives) is enforced **by the contract** at the verifier boundary, not by the Soroban host. The host's `bn254_fr_from_u256val` reduces non-canonical inputs modulo $r$ rather than rejecting them (§2.2 *Host deserialiser caveat*), so the same logical point $(x, y)$ admits multiple byte encodings ($\text{be}(x) \mathbin\| \text{be}(y)$ and $\text{be}(x+r) \mathbin\| \text{be}(y)$, etc.) if the contract does not pre-validate. Every prover-supplied scalar and coordinate that reaches the verifier — and therefore every byte string that gets persisted or emitted downstream — is the unique canonical representative of its field element.
 
 ---
 

--- a/packages/tokens/src/confidential/docs/DESIGN.md
+++ b/packages/tokens/src/confidential/docs/DESIGN.md
@@ -172,7 +172,7 @@ When the owner spends after a merge, the spend proof constrains the full post-me
 
 ### 2.7 Address-to-Field Encoding
 
-In Soroban, the SDK's `Address` host type covers exactly the two `ScAddressType` variants the contract interacts with as actors: `Account` (Stellar ed25519 account) and `Contract` (Soroban contract instance). The protocol encodes those addresses via their **canonical Stellar strkey** (SEP-23) representation:
+In Soroban, the host's `address_to_strkey` function is defined for the two `ScAddressType` variants the contract interacts with as actors -- `Account` (Stellar ed25519 account) and `Contract` (Soroban contract instance) -- and errors on every other variant the SDK's `Address` type can wrap. The protocol encodes those addresses via their **canonical Stellar strkey** (SEP-23) representation:
 
 $$\text{enc}(a) \;=\; \text{Address::to\\\_string}(a)\text{.to\\\_bytes}() \;\in\; \{\text{ASCII}\}^{56}$$
 
@@ -232,7 +232,7 @@ i.e., the total committed value across all confidential accounts never exceeds t
 - *Non-rebasing.* The token's balance attributed to the contract address changes only as a result of explicit operations that the contract itself originated. Tokens whose balances change as a function of supply, oracle data, or external triggers break the accounting invariant and are unsupported.
 - *No fee-on-transfer.* `token.transfer(from, to, amount)` MUST move exactly `amount` units. A fee deducted in transit would leave the contract's confidential accounting larger than its public backing.
 - *Deterministic revert.* A failed `token.transfer` MUST cause the enclosing contract invocation (`deposit` or `withdraw`) to revert atomically, so confidential state is never updated against a token transfer that did not happen.
-- *Underlying clawback / freeze / deauthorization.* If the underlying SEP-41 (especially a Stellar Asset Contract) supports issuer-level clawback or freeze that can reduce or block the contract's holdings, confidential accounting at the contract layer may temporarily or permanently exceed the contract's accessible backing. This is an operational risk borne by the deployer's choice of underlying token. The token layer offers its own freeze and per-account clawback flows that operate inside the confidential surface; see [COMPLIANCE.md](./COMPLIANCE.md) §2 (contract-level freeze) and §5 (admin + auditor clawback). [COMPLIANCE.md](./COMPLIANCE.md) §2.2 additionally specifies SAC authorization passthrough, which composes the contract's freeze with the issuer's freeze without requiring the admin to mirror state.
+- *Underlying clawback / freeze / deauthorization.* These are surfaces of the Stellar Asset Contract (`StellarAssetInterface`), not the generic SEP-41 (`TokenInterface`). If the underlying token is a SAC whose issuer can clawback, freeze, or deauthorize the contract's holdings, confidential accounting at the contract layer may temporarily or permanently exceed the contract's accessible backing. This is an operational risk borne by the deployer's choice of underlying token. The token layer offers its own freeze and per-account clawback flows that operate inside the confidential surface; see [COMPLIANCE.md](./COMPLIANCE.md) §2 (contract-level freeze) and §5 (admin + auditor clawback). [COMPLIANCE.md](./COMPLIANCE.md) §2.2 additionally specifies SAC authorization passthrough, which composes the contract's freeze with the issuer's freeze without requiring the admin to mirror state.
 
 **Non-negativity check.** The contract's public interface uses `i128` end-to-end, matching SEP-41. Every entrypoint that accepts a public amount (`deposit`, `withdraw`) MUST reject `amount < 0` and revert. The in-circuit range constraint (Section 2.6) bounds the same value at $2^{127}$ from above; together they pin the contract's value domain to $[0, 2^{127}) = [0, \text{i128::MAX}]$, matching SEP-41 exactly. No conversion at the SEP-41 boundary is needed.
 
@@ -1110,10 +1110,10 @@ where $[x]_1 = x \cdot G_1$ and $[x]_2 = x \cdot G_2$ are BN254 group elements. 
 
 ### 10.7 Dependency: CAP-80
 
-[CAP-80](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0080.md) introduces host functions required for efficient UltraHonk verification and on-chain Grumpkin point arithmetic:
+[CAP-80](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0080.md) introduces the host functions required for efficient UltraHonk verification and on-chain Grumpkin point arithmetic. The rollout spans two protocols; both are required, so **protocol 26 is the effective minimum**.
 
-- `bn254_g1_msm`: Batched scalar-point multiplication on BN254 G1.
-- `bn254_fr_{add, sub, mul, inv, pow}`: $\mathbb{F}_r$ scalar arithmetic.
+- **Protocol 25:** `bn254_g1_{add, mul}`, `bn254_multi_pairing_check`.
+- **Protocol 26:** `bn254_g1_msm`, `bn254_g1_is_on_curve`, `bn254_fr_{add, sub, mul, inv, pow}` -- the $\mathbb{F}_r$ scalar arithmetic underpinning Grumpkin point operations.
 
 ### 10.8 On-Chain Point Arithmetic
 
@@ -1280,8 +1280,8 @@ The auditor's allowance tracking does **not** use this method: per-event allowan
 
 | Dependency | Status | Impact |
 |:---|:---|:---|
-| **Protocol 25** (BN254 native support) | Available | `bn254.g1_add()`, `g1_mul()`, `pairing_check()`, `BnScalar` Fr arithmetic |
-| **CAP-80** (BN254 host functions) | Available | Required for efficient UltraHonk verification and Grumpkin point arithmetic |
+| **Protocol 25** (BN254 G1 + pairing) | Available | `bn254_g1_{add, mul}`, `bn254_multi_pairing_check` |
+| **Protocol 26 / CAP-80** (BN254 Fr + MSM) | Available | `bn254_g1_msm`, `bn254_g1_is_on_curve`, `bn254_fr_{add, sub, mul, inv, pow}` -- required for UltraHonk verification and on-chain Grumpkin point arithmetic |
 | **Modified UltraHonk verifier** | To be built | Multi-VK support (one per circuit type) |
 | **Noir circuits** | To be built | 6 circuits using `std::embedded_curve_ops` for Grumpkin |
 | **Grumpkin point arithmetic library** | To be built | On-chain point add/sub using BN254 Fr ops, identity handling |

--- a/packages/tokens/src/confidential/mod.rs
+++ b/packages/tokens/src/confidential/mod.rs
@@ -71,14 +71,6 @@
 //! points on-curve, and the auditor registry's insertion-time validation
 //! covers the lone proof-less point input.
 //!
-//! **Operational implication for verifier implementations.** Future verifier
-//! backends (UltraHonk, Groth16, or otherwise) MUST consume the
-//! `public_inputs` blob through a deserialiser equivalent to the host's
-//! `bn254_fr_from_u256val`. The canonical-encoding precondition is now an
-//! invariant of every chunk in that blob; an implementation that re-validates
-//! internally is welcome to do so, but the contract layer already guarantees
-//! the precondition on entry.
-//!
 //! ## Contract Binding
 //!
 //! Every owner-initiated proof references a `addr_f` field, computed once at

--- a/packages/tokens/src/confidential/mod.rs
+++ b/packages/tokens/src/confidential/mod.rs
@@ -39,6 +39,46 @@
 //! (no length prefix); any divergence from the order the prover used will
 //! cause verification to fail.
 //!
+//! ### Encoding Validation
+//!
+//! Each 32-byte chunk of the public-input blob is deserialised into a
+//! `Bn254Fr` by the Soroban host's `bn254_fr_from_u256val`. The host
+//! silently reduces values `≥ r` modulo `r` rather than rejecting them. Two
+//! distinct byte strings (`x` and `x + r`) therefore deserialise to the same
+//! field element, the verifier accepts both for a proof generated against `x`,
+//! and the contract would persist whichever bytes the caller supplied —
+//! breaking byte-uniqueness for stored state and emitted events.
+//!
+//! The contract closes this gap at the verifier boundary. The append
+//! helpers in [`storage`] (`append_field`, `append_point`) call
+//! [`Grumpkin::is_canonical_field`] / [`Grumpkin::is_canonical_point`]. By the
+//! time `verify_proof` is invoked, every caller-supplied scalar and Grumpkin
+//! coordinate is guaranteed to be the unique canonical big-endian
+//! representative of its field element, and values the contract subsequently
+//! persists are byte-unique per logical value.
+//!
+//! The check is by deliberate design **not** an on-curve check. Prover-
+//! supplied points are constrained on-curve in-circuit by their
+//! `multi_scalar_mul` derivation and pinned to `≠ O` by explicit
+//! nonzero-scalar constraints (DESIGN §10.8: R4/R5, W8, T13, S13, O13, V10).
+//! The only proof-less Grumpkin entry point is the auditor key, which the
+//! auditor contract validates canonical-encoding, on-curve, and non-identity
+//! at insertion via [`auditor::storage::validate_point`].
+//!
+//! Together these three boundaries discharge the trust-boundary rule of
+//! DESIGN §7.1: the canonical-encoding guard at the verifier boundary keeps
+//! caller bytes byte-unique, the in-circuit constraints keep prover-supplied
+//! points on-curve, and the auditor registry's insertion-time validation
+//! covers the lone proof-less point input.
+//!
+//! **Operational implication for verifier implementations.** Future verifier
+//! backends (UltraHonk, Groth16, or otherwise) MUST consume the
+//! `public_inputs` blob through a deserialiser equivalent to the host's
+//! `bn254_fr_from_u256val`. The canonical-encoding precondition is now an
+//! invariant of every chunk in that blob; an implementation that re-validates
+//! internally is welcome to do so, but the contract layer already guarantees
+//! the precondition on entry.
+//!
 //! ## Contract Binding
 //!
 //! Every owner-initiated proof references a `addr_f` field, computed once at
@@ -528,6 +568,13 @@ pub enum ConfidentialTokenError {
     /// Indicates the SEP-41 token address has already been set;
     /// re-initialization is forbidden.
     UnderlyingAssetAlreadySet = 3513,
+    /// Indicates a prover-supplied 32-byte field representative or Grumpkin
+    /// coordinate is not a canonical `Bn254Fr` value (`≥ r`). The Soroban
+    /// host's `bn254_fr_*` deserialiser silently reduces non-canonical
+    /// encodings, so the contract enforces canonicality at the verifier
+    /// boundary to keep stored state and emitted events byte-unique per
+    /// logical value.
+    NonCanonicalEncoding = 3514,
 }
 
 // ################## CONSTANTS ##################

--- a/packages/tokens/src/confidential/mod.rs
+++ b/packages/tokens/src/confidential/mod.rs
@@ -149,8 +149,10 @@ pub use storage::{
 #[allow(unused_variables)]
 pub trait Hooks {
     /// Invoked after `register`'s auth and payload decode, before account
-    /// creation. `payload: Val` carries a [`RegisterPayload`].
-    fn on_register(e: &Env, account: &Address, payload: Val) {}
+    /// creation. `payload: Val` carries a [`RegisterPayload`]. `auditor_id`
+    /// is the caller-selected auditor key index — forwarded so the hook
+    /// can enforce an approved-auditor policy.
+    fn on_register(e: &Env, account: &Address, auditor_id: u32, payload: Val) {}
 
     /// Invoked after `deposit`'s auth, before SEP-41 transfer and balance
     /// update.
@@ -235,7 +237,7 @@ pub trait ConfidentialToken {
         account.require_auth();
 
         let decoded: RegisterData = storage::decode_data(e, &data);
-        Self::Hooks::on_register(e, &account, decoded.payload.clone().into_val(e));
+        Self::Hooks::on_register(e, &account, auditor_id, decoded.payload.clone().into_val(e));
         storage::register(e, &account, auditor_id, &decoded.payload, &decoded.proof);
     }
 

--- a/packages/tokens/src/confidential/storage.rs
+++ b/packages/tokens/src/confidential/storage.rs
@@ -1286,13 +1286,39 @@ fn verify(e: &Env, circuit_type: CircuitType, public_inputs: &Bytes, proof: &Byt
     }
 }
 
-/// Appends a Grumpkin point (`x || y`, 64 bytes) to the public-input blob.
+/// Appends a Grumpkin point (`x || y`, 64 bytes) to the public-input blob,
+/// after asserting both coordinates are canonical `Bn254Fr` representatives.
+///
+/// The Soroban host's `bn254_fr_from_u256val` reduces non-canonical 32-byte
+/// inputs modulo `r` instead of rejecting them, so caller-supplied bytes
+/// `x` and `x + r` would deserialise to the same field element and both
+/// satisfy the same proof. This check enforces byte-uniqueness on every
+/// chunk before the verifier sees it; see the
+/// [module-level "Encoding Validation" docs](super) for the rationale.
+///
+/// # Errors
+///
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When either coordinate
+///   is `≥ r`.
 fn append_point(pi: &mut Bytes, p: &Point) {
+    if !Grumpkin::is_canonical_point(p) {
+        panic_with_error!(pi.env(), ConfidentialTokenError::NonCanonicalEncoding);
+    }
     pi.append(&Bytes::from(p));
 }
 
-/// Appends a 32-byte field element to the public-input blob.
+/// Appends a 32-byte field element to the public-input blob, after
+/// asserting it is a canonical `Bn254Fr` representative. See
+/// [`append_point`] for the rationale.
+///
+/// # Errors
+///
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When the value is `≥
+///   r`.
 fn append_field(pi: &mut Bytes, f: &BytesN<32>) {
+    if !Grumpkin::is_canonical_field(f) {
+        panic_with_error!(pi.env(), ConfidentialTokenError::NonCanonicalEncoding);
+    }
     pi.append(&Bytes::from(f));
 }
 

--- a/packages/tokens/src/confidential/storage.rs
+++ b/packages/tokens/src/confidential/storage.rs
@@ -760,7 +760,7 @@ pub fn confidential_transfer_from(
     payload: &SpenderTransferPayload,
     proof: &Bytes,
 ) {
-    let delegation = get_spender_delegation(e, from, spender);
+    let mut delegation = get_spender_delegation(e, from, spender);
     if e.ledger().sequence() > delegation.live_until_ledger {
         panic_with_error!(e, ConfidentialTokenError::DelegationExpired);
     }
@@ -775,6 +775,8 @@ pub fn confidential_transfer_from(
     // owner).
     let k_aud_s = auditor.get_key(&owner.auditor_id);
 
+    // Capture it here to emit in the event below.
+    let sigma_a = delegation.allowance_salt.clone();
     // PI order (DESIGN §7.8):
     //   C_a, sigma_a, Y_op, PVK_recipient, K_aud_r, K_aud_s,
     //   C_a', C_tx, R_e, v_tilde, a_tilde', sigma_a',
@@ -799,14 +801,14 @@ pub fn confidential_transfer_from(
 
     verify(e, CircuitType::SpenderTransfer, &pi, proof);
 
-    update_delegation(
-        e,
-        from,
-        spender,
-        &payload.c_a_new,
-        &payload.a_tilde_new,
-        &payload.sigma_a_new,
-    );
+    // Update delegation.
+    delegation.allowance_commitment = payload.c_a_new.clone();
+    delegation.encrypted_allowance = payload.a_tilde_new.clone();
+    delegation.allowance_salt = payload.sigma_a_new.clone();
+    e.storage()
+        .persistent()
+        .set(&ConfidentialTokenStorageKey::Delegation(from.clone(), spender.clone()), &delegation);
+
     add_to_receiving(e, to, &payload.c_tx);
 
     emit_spender_transfer(
@@ -816,7 +818,7 @@ pub fn confidential_transfer_from(
         to,
         &payload.r_e,
         &payload.v_tilde,
-        &payload.sigma_a_new,
+        &sigma_a,
         &payload.v_aud_r,
         &payload.r_aud_r,
         &payload.v_aud_s,
@@ -1217,39 +1219,6 @@ fn set_delegation(e: &Env, owner: &Address, spender: &Address, delegation: &Spen
         panic_with_error!(e, ConfidentialTokenError::DelegationAlreadyExists);
     }
     e.storage().persistent().set(&key, delegation);
-}
-
-/// Updates a delegation's allowance commitment, encrypted allowance, and
-/// salt after an spender transfer.
-///
-/// # Arguments
-///
-/// * `e` - Access to the Soroban environment.
-/// * `owner` - The delegating account.
-/// * `spender` - The delegated spender.
-/// * `c_a_new` - New allowance commitment.
-/// * `a_tilde_new` - New encrypted allowance scalar.
-/// * `sigma_a_new` - New allowance salt.
-///
-/// # Errors
-///
-/// * [`ConfidentialTokenError::DelegationNotFound`] - When no delegation exists
-///   for the pair.
-fn update_delegation(
-    e: &Env,
-    owner: &Address,
-    spender: &Address,
-    c_a_new: &Point,
-    a_tilde_new: &BytesN<32>,
-    sigma_a_new: &BytesN<32>,
-) {
-    let mut delegation = get_spender_delegation(e, owner, spender);
-    delegation.allowance_commitment = c_a_new.clone();
-    delegation.encrypted_allowance = a_tilde_new.clone();
-    delegation.allowance_salt = sigma_a_new.clone();
-    e.storage()
-        .persistent()
-        .set(&ConfidentialTokenStorageKey::Delegation(owner.clone(), spender.clone()), &delegation);
 }
 
 /// Deletes the `(owner, spender)` delegation entry (revoke path).

--- a/packages/tokens/src/confidential/storage.rs
+++ b/packages/tokens/src/confidential/storage.rs
@@ -402,6 +402,8 @@ pub fn delegation_exists(e: &Env, owner: &Address, spender: &Address) -> bool {
 ///
 /// * [`ConfidentialTokenError::AccountAlreadyRegistered`] - When `account` is
 ///   already registered.
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When point coordinates
+///   or fields from the proof are non-canonical.
 /// * [`ConfidentialTokenError::InvalidProof`] - When the proof fails
 ///   verification.
 /// * refer to [`crate::confidential::auditor::ConfidentialAuditor::get_key`]
@@ -555,6 +557,8 @@ pub fn merge(e: &Env, account: &Address) {
 /// * [`ConfidentialTokenError::NegativeAmount`] - When `amount < 0`.
 /// * [`ConfidentialTokenError::AccountNotRegistered`] - When `from` is not
 ///   registered.
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When point coordinates
+///   or fields from the proof are non-canonical.
 /// * [`ConfidentialTokenError::InvalidProof`] - When the proof fails
 ///   verification.
 /// * refer to [`crate::confidential::auditor::ConfidentialAuditor::get_key`]
@@ -646,6 +650,8 @@ pub fn withdraw(
 ///
 /// * [`ConfidentialTokenError::AccountNotRegistered`] - When `from` or `to` is
 ///   not registered.
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When point coordinates
+///   or fields from the proof are non-canonical.
 /// * [`ConfidentialTokenError::InvalidProof`] - When the proof fails
 ///   verification.
 /// * refer to [`crate::confidential::auditor::ConfidentialAuditor::get_key`]
@@ -737,6 +743,8 @@ pub fn confidential_transfer(
 ///   has no delegation.
 /// * [`ConfidentialTokenError::DelegationExpired`] - When the delegation has
 ///   expired.
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When point coordinates
+///   or fields from the proof are non-canonical.
 /// * [`ConfidentialTokenError::InvalidProof`] - When the proof fails
 ///   verification.
 /// * refer to [`crate::confidential::auditor::ConfidentialAuditor::get_key`]
@@ -847,6 +855,8 @@ pub fn confidential_transfer_from(
 ///   `spender` is not registered.
 /// * [`ConfidentialTokenError::DelegationAlreadyExists`] - When a delegation
 ///   already exists for the `(account, spender)` pair.
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When point coordinates
+///   or fields from the proof are non-canonical.
 /// * [`ConfidentialTokenError::InvalidProof`] - When the proof fails
 ///   verification.
 /// * refer to [`crate::confidential::auditor::ConfidentialAuditor::get_key`]
@@ -945,6 +955,8 @@ pub fn set_spender(
 ///   registered.
 /// * [`ConfidentialTokenError::DelegationNotFound`] - When `(account, spender)`
 ///   has no delegation.
+/// * [`ConfidentialTokenError::NonCanonicalEncoding`] - When point coordinates
+///   or fields from the proof are non-canonical.
 /// * [`ConfidentialTokenError::InvalidProof`] - When the proof fails
 ///   verification.
 /// * refer to [`crate::confidential::auditor::ConfidentialAuditor::get_key`]

--- a/packages/tokens/src/confidential/test.rs
+++ b/packages/tokens/src/confidential/test.rs
@@ -39,7 +39,13 @@ fn fixture_point(e: &Env) -> BytesN<64> {
 }
 
 fn fixture_field(e: &Env, byte: u8) -> BytesN<32> {
-    BytesN::from_array(e, &[byte; 32])
+    let mut bytes = [byte; 32];
+    // Zero the top byte so the 256-bit value is bounded by 2^248 - 1,
+    // well below the BN254 scalar field modulus r ≈ 2^254. Lets the tests
+    // keep using arbitrary sentinel bytes without tripping the
+    // canonical-encoding check in `append_field` / `append_point`.
+    bytes[0] = 0;
+    BytesN::from_array(e, &bytes)
 }
 
 // ################## MOCK CONTRACTS ##################
@@ -293,6 +299,56 @@ fn register_invalid_proof_panics() {
     let h = setup_with_failing_verifier();
     let alice = Address::generate(&h.e);
     h.token.register(&alice, &1u32, &register_data(&h.e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3514)")]
+fn withdraw_non_canonical_scalar_panics() {
+    // Sigma supplied as raw `[0xff; 32]` exceeds the BN254 scalar field
+    // modulus r. The append helper must revert with `NonCanonicalEncoding`
+    // before the bytes reach the verifier (which would otherwise silently
+    // reduce them mod r and accept malleable encodings).
+    let h = setup();
+    let alice = Address::generate(&h.e);
+    h.token.register(&alice, &1u32, &register_data(&h.e));
+
+    let payload = WithdrawData {
+        payload: WithdrawPayload {
+            c_spend_new: fixture_point(&h.e),
+            b_tilde: fixture_field(&h.e, 0x11),
+            r_e: fixture_point(&h.e),
+            sigma: BytesN::from_array(&h.e, &[0xff; 32]),
+            b_aud_s: fixture_field(&h.e, 0x12),
+        },
+        proof: Bytes::new(&h.e),
+    }
+    .to_xdr(&h.e);
+
+    h.token.withdraw(&alice, &Address::generate(&h.e), &0i128, &payload);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3514)")]
+fn register_non_canonical_point_coord_panics() {
+    // A point whose x-coordinate exceeds r. Both coordinates must be
+    // canonical or `append_point` reverts before verification.
+    let h = setup();
+    let alice = Address::generate(&h.e);
+
+    let mut non_canonical = [0u8; 64];
+    non_canonical[..32].copy_from_slice(&[0xff; 32]);
+    // y stays at zero; only x triggers the revert.
+
+    let payload = RegisterData {
+        payload: RegisterPayload {
+            y: BytesN::from_array(&h.e, &non_canonical),
+            pvk: fixture_point(&h.e),
+        },
+        proof: Bytes::new(&h.e),
+    }
+    .to_xdr(&h.e);
+
+    h.token.register(&alice, &1u32, &payload);
 }
 
 #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for canonical encoding of cryptographic field elements and Grumpkin points in the confidential token system.
  * New error code (3514) introduced for non-canonical encoding rejections.

* **Bug Fixes**
  * Contract now enforces canonical encoding checks at verifier boundaries to prevent byte-ambiguity issues.

* **Documentation**
  * Added comprehensive guide for the confidential token suite.
  * Updated design documentation explaining encoding validation requirements and trust boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->