### PR TITLE
Bump `soroban_sdk` and docs fixes

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -58,14 +58,14 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
       - name: Check clippy
-        run: cargo clippy --release --locked --all-targets -- -D warnings
+        run: cargo +stable clippy --release --locked --all-targets -- -D warnings
 
       # TODO: re-enable this after we find a stable solution to same name functions across multiple contracts
       # - name: Check build
       #   run: cargo build --target wasm32v1-none --release
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --workspace --lcov --fail-under-lines 90 --output-path lcov.info
+        run: cargo +stable llvm-cov --workspace --lcov --fail-under-lines 90 --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "26.0.1"
+version = "26.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231ae1585d14b5059adde392ce80f6b151e0264ed62b121bca9fe025e8ace460"
+checksum = "eb9ee1c6ba495aa33b281a5818ece9b91f94ddbee93f08637d081983c36290ca"
 dependencies = [
  "serde",
  "serde_json",
@@ -2246,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "26.0.1"
+version = "26.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de6ad39b7070e8703d01c3abad13e75ea5e65b1a5ce5e86b98d724773282044"
+checksum = "c8c92772aaafb45bbfa8ea5baa5b453e84be4351ddb6383469acbcf3d64ddc8e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -2270,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "26.0.1"
+version = "26.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cd5e180920e224d209562cccffd27c35884d14c4dc296b295dfcebef46b6f1"
+checksum = "abbdc02e0d789df78c25b0d056eb01cc906feab690c74895febc96890a0e6aa0"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -2290,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "26.0.1"
+version = "26.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680c70a2ab6d7cde343e9a51dd141f2f4304a7282452df8dc540b9bf62565886"
+checksum = "e3afb753b6ec3329af9744091ebe9f4c047c8fd1078d333b3f83a598a22bef33"
 dependencies = [
  "base64",
  "sha2",
@@ -2303,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "26.0.1"
+version = "26.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e368f91c6633c25cd2d143fd82f84206b8e58718fc630d344f2fa33e6d31b1b"
+checksum = "29bcfaf56410230ab5f91088cc12ce7c890274ee3243206b48263ceb36ee2a27"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ categories = ["no-std", "wasm"]
 version = "0.7.1"
 
 [workspace.dependencies]
-soroban-sdk = { version = "26.0.0", features = [
+soroban-sdk = { version = "26.1.0", features = [
     "experimental_spec_shaking_v2",
 ] }
 soroban-poseidon = "26.0.0"

--- a/packages/contract-utils/src/math/test/i256_fixed_point.rs
+++ b/packages/contract-utils/src/math/test/i256_fixed_point.rs
@@ -91,7 +91,7 @@ fn test_mul_div_floor_large_number() {
 }
 
 #[test]
-#[should_panic(expected = "attempt to multiply with overflow")]
+#[should_panic(expected = "overflow")]
 fn test_mul_div_floor_phantom_overflow() {
     let env = Env::default();
     let x: I256 = I256::from_i128(&env, i128::MAX);
@@ -141,7 +141,7 @@ fn test_mul_div_ceil_large_number() {
 }
 
 #[test]
-#[should_panic(expected = "attempt to multiply with overflow")]
+#[should_panic(expected = "overflow")]
 fn test_mul_div_ceil_phantom_overflow() {
     let env = Env::default();
     let x: I256 = I256::from_i128(&env, i128::MAX);

--- a/packages/tokens/src/confidential/README.md
+++ b/packages/tokens/src/confidential/README.md
@@ -13,7 +13,7 @@ recipient addresses remain visible on-chain; amounts and balances do not.
 ## ⚠️ Not Production Ready
 
 The [`verifier`](./verifier/) module's UltraHonk backend
-([`rs-soroban-ultrahonk`](https://github.com/Oghma/rs-soroban-ultrahonk))
+([`rs-soroban-ultrahonk`](https://github.com/NethermindEth/rs-soroban-ultrahonk))
 is still under development and has **not been audited**. Do **not** deploy
 a contract built on this trait to mainnet or any environment that handles
 real value.

--- a/packages/tokens/src/confidential/docs/COMPLIANCE.md
+++ b/packages/tokens/src/confidential/docs/COMPLIANCE.md
@@ -34,7 +34,7 @@ Deployments that need separation of duties (distinct freeze, policy, and clawbac
 
 ## 2. Contract-Level Freeze
 
-The contract maintains a `frozen(account) -> bool` entry per account. Before applying any state change, every state-modifying operation runs `check_not_frozen` against each account it names (sender, recipient, spender). A frozen account cannot send, receive, deposit, withdraw, or participate as an spender. The check reverts at the contract boundary.
+The contract maintains a `frozen(account) -> bool` entry per account. Before applying any state change, every state-modifying operation runs `check_not_frozen` against each account it names (sender, recipient). A frozen account cannot send, receive, deposit, or withdraw. The check reverts at the contract boundary.
 
 Full freeze (rather than outbound-only) keeps semantics clean: no further accumulation is possible after the freeze takes effect.
 

--- a/packages/tokens/src/confidential/docs/DESIGN.md
+++ b/packages/tokens/src/confidential/docs/DESIGN.md
@@ -121,7 +121,7 @@ The system uses **Poseidon2**, the algebraic hash function native to Noir's stan
 
 **Usage in this system:**
 
-- Key derivation: $vk = \text{Poseidon2}(\delta_{\text{vk}}, sk, \text{addr_f})$
+- Key derivation: $vk = \text{Poseidon2}(\delta_{\text{vk}}, sk, \text{addr\\\_f})$
 - Randomness derivation: $r = \text{Poseidon2}(\delta_{\text{spend\\\_r}}, vk, \sigma)$
 - Symmetric encryption: $\tilde{v} = v + \text{Poseidon2}(\delta_{\text{tx\\\_amount}}, s, \sigma)$
 - Domain separation: each invocation includes a leading constant $\delta$ to prevent cross-context collisions
@@ -190,7 +190,7 @@ The contract, the SDK, the wallet, and any indexer reproduce the same Field valu
 
 | Site | When computed | Storage |
 |:---|:---|:---|
-| $\text{addr_f}$ | Once, by the contract's `__constructor` over `env.current_contract_address()` | Stored as a single Field in the contract's **instance storage** (§3.5); read on every proof verification |
+| $\text{addr\\\_f}$ | Once, by the contract's `__constructor` over `env.current_contract_address()` | Stored as a single Field in the contract's **instance storage** (§3.5); read on every proof verification |
 | $\text{op}_i$ | Per-call, by the contract at `set_spender` and `revoke_spender` over the `spender` argument | Not stored; recomputed each call. The circuit binds it via S5 / V3 |
 
 ---
@@ -238,7 +238,7 @@ i.e., the total committed value across all confidential accounts never exceeds t
 
 ### 3.5 Governance and Upgradeability
 
-The constructor binds the contract to fixed `admin`, `token`, `verifier`, and `auditor` addresses. It additionally computes and stores $\text{addr_f} = \text{address\\\_to\\\_field}(\text{env.current\\\_contract\\\_address}())$ (§2.7) in **instance storage** as a single canonical $\mathbb{F}_r$ Field; this is the value every owner-initiated proof references via constraints R2 / W2 / T2 / S2 / V2. The compressed `addr_f` Field is computed once at construction (not recomputed per call) to ensure all proofs across the contract's lifetime bind to the same Field representative of the contract's address. Beyond that, this specification does not prescribe a governance policy for upgrading these components or for rotating per-circuit verification keys. Concrete deployments differ widely in spender structure, regulatory posture, and emergency-response requirements, so these decisions are deliberately left to implementers.
+The constructor binds the contract to fixed `admin`, `token`, `verifier`, and `auditor` addresses. It additionally computes and stores $\text{addr\\\_f} = \text{address\\\_to\\\_field}(\text{env.current\\\_contract\\\_address}())$ (§2.7) in **instance storage** as a single canonical $\mathbb{F}_r$ Field; this is the value every owner-initiated proof references via constraints R2 / W2 / T2 / S2 / V2. The compressed `addr_f` Field is computed once at construction (not recomputed per call) to ensure all proofs across the contract's lifetime bind to the same Field representative of the contract's address. Beyond that, this specification does not prescribe a governance policy for upgrading these components or for rotating per-circuit verification keys. Concrete deployments differ widely in spender structure, regulatory posture, and emergency-response requirements, so these decisions are deliberately left to implementers.
 
 Questions an implementer must answer:
 
@@ -263,15 +263,15 @@ The spending public key is stored on-chain at registration. Knowledge of $sk$ is
 
 ### 4.2 Viewing Key
 
-$$vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr_f})$$
+$$vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr\\\_f})$$
 
-A scalar in $\mathbb{F}_r$, unique per $(sk, \text{addr_f})$ pair. Enables balance decryption without spending authority. Cannot recover $sk$ (Poseidon preimage resistance). Because $\text{addr_f}$ is bound into the derivation, proofs that constrain $vk$ (R2, W2, T2, S2, V2) are inherently bound to the contract contract, eliminating the need for explicit per-circuit context binding.
+A scalar in $\mathbb{F}_r$, unique per $(sk, \text{addr\\\_f})$ pair. Enables balance decryption without spending authority. Cannot recover $sk$ (Poseidon preimage resistance). Because $\text{addr\\\_f}$ is bound into the derivation, proofs that constrain $vk$ (R2, W2, T2, S2, V2) are inherently bound to the contract contract, eliminating the need for explicit per-circuit context binding.
 
 ### 4.3 Public Viewing Key
 
 $$\text{PVK} = vk \cdot H$$
 
-A Grumpkin point stored on-chain at registration. Serves as the recipient's ECDH public key for incoming transfers. The registration proof constrains $\text{PVK} = vk \cdot H$ where $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr_f})$ and $Y = sk \cdot H$, preventing a user from registering an unrelated $\text{PVK}$.
+A Grumpkin point stored on-chain at registration. Serves as the recipient's ECDH public key for incoming transfers. The registration proof constrains $\text{PVK} = vk \cdot H$ where $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr\\\_f})$ and $Y = sk \cdot H$, preventing a user from registering an unrelated $\text{PVK}$.
 
 ### 4.4 Delegation Viewing Key
 
@@ -493,7 +493,7 @@ An account provides a Grumpkin spending key $Y$, a public viewing key $\text{PVK
 | # | Constraint |
 |:--|:---|
 | R1 | $Y = sk \cdot H$ (spending key well-formed) |
-| R2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr_f})$ (viewing key correctly derived, binds proof to contract) |
+| R2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr\\\_f})$ (viewing key correctly derived, binds proof to contract) |
 | R3 | $\text{PVK} = vk \cdot H$ (public viewing key matches $vk$) |
 | R4 | $sk \neq 0$ (rules out $Y = \mathcal{O}$) |
 | R5 | $vk \neq 0$ (rules out $\text{PVK} = \mathcal{O}$, which would collapse every incoming-transfer ECDH) |
@@ -503,7 +503,7 @@ An account provides a Grumpkin spending key $Y$, a public viewing key $\text{PVK
 | Input | Notes |
 |:---|:---|
 | $Y$, $\text{PVK}$ | Prover-supplied; written to `account.spending_key` and `account.viewing_public_key` on success |
-| $\text{addr_f}$ | Loaded from instance storage; set once at construction (§3.5) |
+| $\text{addr\\\_f}$ | Loaded from instance storage; set once at construction (§3.5) |
 
 **Private witnesses:** $sk$.
 
@@ -554,7 +554,7 @@ The owner withdraws a public amount $a$ (typed `i128`) from their spendable bala
 | # | Constraint |
 |:--|:---|
 | W1 | $Y = sk \cdot H$ (owner key ownership) |
-| W2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr_f})$ (binds proof to contract) |
+| W2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr\\\_f})$ (binds proof to contract) |
 | W3 | The prover knows the opening $(v, r)$ of $C_{\text{spend}}$: $C_{\text{spend}} = v \cdot G + r \cdot H$ |
 | W4 | $v \in [0, 2^{127})$, $a \in [0, 2^{127})$, $v - a \in [0, 2^{127})$ (range validity, Section 2.6) |
 | W5 | $r' = \text{Poseidon}(\delta_{\text{spend\\\_r}}, vk, \sigma)$ (deterministic randomness for new balance) |
@@ -572,7 +572,7 @@ The owner withdraws a public amount $a$ (typed `i128`) from their spendable bala
 |:---|:---|
 | $C_{\text{spend}}$ | Loaded from `from.spendable_balance` |
 | $Y$ | Loaded from `from.spending_key` |
-| $\text{addr_f}$ | Loaded from instance storage; set once at construction (§3.5) |
+| $\text{addr\\\_f}$ | Loaded from instance storage; set once at construction (§3.5) |
 | $K_{\text{aud,s}}$ | Fetched from the auditor contract using `from.auditor_id` |
 | $a$ | Public withdrawal amount from invocation inputs |
 | $C_{\text{spend}}'$, $\sigma$, $\tilde{b}$, $R_e$, $\tilde{b}_{\text{aud,s}}$ | Prover-supplied; $C_{\text{spend}}'$ written to `from.spendable_balance`, the rest emitted in event |
@@ -611,7 +611,7 @@ The sender (account $A$, spending key $sk_A$) transfers a hidden amount $v_{\tex
 | # | Constraint |
 |:--|:---|
 | T1 | $Y_A = sk_A \cdot H$ (sender key ownership) |
-| T2 | $vk_A = \text{Poseidon}(\delta_{\text{vk}}, sk_A, \text{addr_f})$ (binds proof to contract) |
+| T2 | $vk_A = \text{Poseidon}(\delta_{\text{vk}}, sk_A, \text{addr\\\_f})$ (binds proof to contract) |
 | T3 | Prover knows opening $(v_A, r_A)$ of $C_{\text{spend}}^A$ |
 | T4 | $v_A \in [0, 2^{127})$, $v_{\text{tx}} \in [0, 2^{127})$, $v_A - v_{\text{tx}} \in [0, 2^{127})$ (range validity, Section 2.6) |
 | T5 | $S = r_e \cdot \text{PVK}_B$ (ECDH correctly computed) |
@@ -639,7 +639,7 @@ The sender (account $A$, spending key $sk_A$) transfers a hidden amount $v_{\tex
 | $C_{\text{spend}}^A$ | Loaded from sender's `spendable_balance` |
 | $Y_A$ | Loaded from sender's `spending_key` |
 | $\text{PVK}_B$ | Loaded from recipient's `viewing_public_key`. Recipient must be registered. |
-| $\text{addr_f}$ | Loaded from instance storage; set once at construction (§3.5) |
+| $\text{addr\\\_f}$ | Loaded from instance storage; set once at construction (§3.5) |
 | $K_{\text{aud,r}}$ | Fetched from the auditor contract using recipient's `auditor_id` |
 | $K_{\text{aud,s}}$ | Fetched from the auditor contract using sender's `auditor_id` |
 | $C_{\text{spend}}'$, $C_{\text{tx}}$, $R_e$, $\tilde{v}$, $\tilde{b}$, $\sigma$, $\tilde{v}_{\text{aud,r}}$, $\tilde{r}_{\text{aud,r}}$, $\tilde{v}_{\text{aud,s}}$, $\tilde{b}_{\text{aud,s}}$ | Prover-supplied; $C_{\text{spend}}'$ written to sender's `spendable_balance`, $C_{\text{tx}}$ added to recipient's `receiving_balance`, the rest emitted in event |
@@ -662,7 +662,7 @@ The owner locks funds from their spendable balance into a per-spender escrow. Th
 | # | Constraint |
 |:--|:---|
 | S1 | $Y = sk \cdot H$ (owner key ownership) |
-| S2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr_f})$ (binds proof to contract) |
+| S2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr\\\_f})$ (binds proof to contract) |
 | S3 | Prover knows opening $(v, r)$ of $C_{\text{spend}}$ |
 | S4 | $v \in [0, 2^{127})$, $v_a \in [0, 2^{127})$, $v - v_a \in [0, 2^{127})$ (range validity, Section 2.6) |
 | S5 | $dvk_i = \text{Poseidon}(\delta_{\text{dvk}}, vk, \text{op}_i)$ (delegation key derivation; contract-bound via $vk$) |
@@ -688,7 +688,7 @@ The owner locks funds from their spendable balance into a per-spender escrow. Th
 | $Y$ | Loaded from owner's `spending_key` |
 | $Y_{\text{op}}$ | Loaded from spender account's `spending_key`. Spender must be registered. |
 | $\text{op}_i$ | $\text{address\\\_to\\\_field}$(`spender` argument), computed per-call by the contract (§2.7) |
-| $\text{addr_f}$ | Loaded from instance storage; set once at construction (§3.5) |
+| $\text{addr\\\_f}$ | Loaded from instance storage; set once at construction (§3.5) |
 | $K_{\text{aud,s}}$ | Fetched from the auditor contract using owner's `auditor_id` |
 | $C_{\text{spend}}'$, $C_a$, escrowed\_dvk, $\tilde{b}$, $\tilde{a}$, $\sigma$, $\sigma_a$, $R_e$, $\tilde{v}_{\text{aud,s}}$, $\tilde{b}_{\text{aud,s}}$ | Prover-supplied; $C_{\text{spend}}'$ written to owner's `spendable_balance`, the delegation fields written to storage, the rest emitted in event |
 
@@ -754,7 +754,7 @@ The owner reclaims the remaining escrowed allowance.
 | # | Constraint |
 |:--|:---|
 | V1 | $Y = sk \cdot H$ (owner key ownership) |
-| V2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr_f})$ (binds proof to contract) |
+| V2 | $vk = \text{Poseidon}(\delta_{\text{vk}}, sk, \text{addr\\\_f})$ (binds proof to contract) |
 | V3 | $dvk_i = \text{Poseidon}(\delta_{\text{dvk}}, vk, \text{op}_i)$ |
 | V4 | Prover knows opening $(v_a, r_a)$ of $C_a$, with $r_a = \text{Poseidon}(\delta_{\text{allow\\\_r}}, dvk_i, \sigma_a)$ (allowance randomness matches stored state, mirrors O3) |
 | V5 | Prover knows opening $(v_s, r_s)$ of $C_{\text{spend}}$ |
@@ -777,7 +777,7 @@ The owner reclaims the remaining escrowed allowance.
 | $C_a$, $\sigma_a$ | Loaded from the `(account, spender)` delegation entry |
 | $Y$ | Loaded from owner's `spending_key` |
 | $\text{op}_i$ | $\text{address\\\_to\\\_field}$(`spender` argument), computed per-call by the contract (§2.7) |
-| $\text{addr_f}$ | Loaded from instance storage; set once at construction (§3.5) |
+| $\text{addr\\\_f}$ | Loaded from instance storage; set once at construction (§3.5) |
 | $K_{\text{aud,s}}$ | Fetched from the auditor contract using owner's `auditor_id` |
 | $C_{\text{spend}}'$, $\tilde{b}$, $\sigma$, $R_e$, $\tilde{v}_{\text{aud,s}}$, $\tilde{b}_{\text{aud,s}}$ | Prover-supplied; $C_{\text{spend}}'$ written to owner's `spendable_balance`, delegation entry deleted, the rest emitted in event |
 

--- a/packages/tokens/src/confidential/verifier/mod.rs
+++ b/packages/tokens/src/confidential/verifier/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! This module is **unfinished**. [`ConfidentialVerifier::verify_proof`] has no
 //! working default implementation because its UltraHonk backend
-//! ([`Oghma/rs-soroban-ultrahonk`](https://github.com/Oghma/rs-soroban-ultrahonk))
+//! ([`NethermindEth/rs-soroban-ultrahonk`](https://github.com/NethermindEth/rs-soroban-ultrahonk))
 //! is still under development and **has not been audited**. Do **not** deploy a
 //! contract built on this trait to mainnet or any environment that handles
 //! real value. The trait surface, the [`VerifierStorageKey`] layout, and the
@@ -220,7 +220,7 @@ pub trait ConfidentialVerifier {
     /// # Notes
     ///
     /// No default implementation is provided. The UltraHonk verification
-    /// backend lives in `Oghma/rs-soroban-ultrahonk`, which is still
+    /// backend lives in `NethermindEth/rs-soroban-ultrahonk`, which is still
     /// under development and has not been audited (see the module-level
     /// warning). Implementors MUST NOT ship a stub that returns `true`
     /// unconditionally to any environment that handles real value.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Confidential Token compliance documentation regarding account freeze behavior and which accounts are checked during operations.
  * Standardized design documentation formatting and presentation of contract-bound address field identifiers.
  * Updated UltraHonk verifier module backend repository references.

* **Chores**
  * Updated Soroban SDK dependency to version 26.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->