### PR TITLE
zero transfer fix

### DIFF
--- a/packages/accounts/src/policies/spending_limit.rs
+++ b/packages/accounts/src/policies/spending_limit.rs
@@ -246,6 +246,15 @@ pub fn enforce(
                             panic_with_error!(e, SpendingLimitError::LessThanZero)
                         }
 
+                        // A zero-amount transfer moves no funds and has no effect on the
+                        // spending budget, so it is always permitted. Without this guard a
+                        // zero transfer would be rejected whenever `cached_total_spent`
+                        // exceeds `spending_limit` (reachable after `set_spending_limit`
+                        // lowers the limit below the amount already spent in the window).
+                        if amount == 0 {
+                            return;
+                        }
+
                         // Clean up old entries outside the rolling window BEFORE checking limit
                         let removed_amount = cleanup_old_entries(
                             &mut data.spending_history,

--- a/packages/accounts/src/policies/test/spending_limit.rs
+++ b/packages/accounts/src/policies/test/spending_limit.rs
@@ -439,6 +439,46 @@ fn set_spending_limit_success() {
 }
 
 #[test]
+fn enforce_zero_amount_allowed_after_limit_reduction() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+    let smart_account = Address::generate(&e);
+    let context_rule = create_context_rule(&e);
+
+    e.mock_all_auths();
+
+    e.as_contract(&address, || {
+        let params = SpendingLimitAccountParams { spending_limit: 1_000_000, period_ledgers: 100 };
+        install(&e, &params, &context_rule, &smart_account);
+    });
+
+    // Spend 900,000, within the original limit.
+    e.as_contract(&address, || {
+        let context = create_transfer_context(&e, 900_000);
+        enforce(&e, &context, &context_rule.signers, &context_rule, &smart_account);
+    });
+
+    // Lower the limit below the amount already spent in the window.
+    e.as_contract(&address, || {
+        set_spending_limit(&e, 500_000, &context_rule, &smart_account);
+        let data = get_spending_limit_data(&e, context_rule.id, &smart_account);
+        assert!(data.cached_total_spent > data.spending_limit);
+    });
+
+    // A zero-amount transfer moves no funds and must be permitted even though
+    // `cached_total_spent` now exceeds `spending_limit`. It also must not mutate
+    // the spending history or cached total.
+    e.as_contract(&address, || {
+        let context = create_transfer_context(&e, 0);
+        enforce(&e, &context, &context_rule.signers, &context_rule, &smart_account);
+
+        let data = get_spending_limit_data(&e, context_rule.id, &smart_account);
+        assert_eq!(data.cached_total_spent, 900_000);
+        assert_eq!(data.spending_history.len(), 1);
+    });
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #3222)")]
 fn set_invalid_spending_limit() {
     let e = Env::default();


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #758 
<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-value transfers are now allowed even when spending is near or above the limit.
  * These transfers no longer trigger spending-history cleanup or change tracked totals.

* **Tests**
  * Added coverage to confirm zero-value transfers remain permitted after the spending limit is reduced.
  * Verified cached spending totals and history stay unchanged for zero-value transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->