### PR TITLE
max balance fail on recovery fix

### DIFF
--- a/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
@@ -231,6 +231,12 @@ pub fn mark_preset_completed(e: &Env, token: &Address) {
 /// where `from` and `to` resolve to the same identity are no-ops: no debit,
 /// no credit, no cap check.
 ///
+/// When `from`'s live identity entry has already been removed by account
+/// recovery, the sender is resolved through the IRS recovery record rather than
+/// reverting on the source lookup, so a forced/recovery transfer still updates
+/// the books. Once `from` recovered to `to`, both sides resolve to the same
+/// identity and the movement is a same-identity no-op.
+///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.
@@ -266,8 +272,22 @@ pub fn on_transfer(
     require_non_negative_amount(e, amount);
 
     let irs = get_irs_client(e, token);
-    let id_from = irs.stored_identity(from);
     let id_to = irs.stored_identity(to);
+
+    // `from`'s live identity entry may have been removed by account recovery
+    // (`recover_identity` moves the identity to the new wallet and deletes the
+    // old mapping). When the live lookup fails, resolve the sender through the
+    // recovery record so a forced/recovery transfer stays bookkeeping-correct
+    // instead of reverting here. A sender that was never registered (no live
+    // identity and no recovery record) still reverts via the final
+    // `stored_identity`, exactly as before.
+    let id_from = match irs.try_stored_identity(from) {
+        Ok(Ok(id)) => id,
+        _ => match irs.get_recovered_to(from) {
+            Some(recovered_wallet) => irs.stored_identity(&recovered_wallet),
+            None => irs.stored_identity(from),
+        },
+    };
 
     if id_from == id_to {
         return;

--- a/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
@@ -276,17 +276,19 @@ pub fn on_transfer(
 
     // `from`'s live identity entry may have been removed by account recovery
     // (`recover_identity` moves the identity to the new wallet and deletes the
-    // old mapping). When the live lookup fails, resolve the sender through the
-    // recovery record so a forced/recovery transfer stays bookkeeping-correct
-    // instead of reverting here. A sender that was never registered (no live
-    // identity and no recovery record) still reverts via the final
-    // `stored_identity`, exactly as before.
+    // old mapping). When the live lookup fails with a contract error, resolve
+    // the sender through the recovery record so a forced/recovery transfer stays
+    // bookkeeping-correct instead of reverting here. A sender that was never
+    // registered (failed lookup, no recovery record) re-raises the IRS error.
     let id_from = match irs.try_stored_identity(from) {
         Ok(Ok(id)) => id,
-        _ => match irs.get_recovered_to(from) {
+        Err(Ok(err)) => match irs.get_recovered_to(from) {
             Some(recovered_wallet) => irs.stored_identity(&recovered_wallet),
-            None => irs.stored_identity(from),
+            None => panic_with_error!(e, err),
         },
+        // A conversion failure or host-level invoke error is unreachable with a
+        // correctly configured IRS; terminate by re-issuing the call.
+        _ => irs.stored_identity(from),
     };
 
     if id_from == id_to {

--- a/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
@@ -30,6 +30,7 @@ struct MockIRSContract;
 enum MockIRSStorageKey {
     Identity(Address),
     RecoveredTo(Address),
+    Removed(Address),
 }
 
 #[contractimpl]
@@ -83,9 +84,11 @@ impl IdentityRegistryStorage for MockIRSContract {
             .get::<_, Address>(&MockIRSStorageKey::Identity(account.clone()))
         {
             identity
-        } else if e.storage().persistent().has(&MockIRSStorageKey::RecoveredTo(account.clone())) {
-            // Model the real IRS: once recovery removes the mapping, the lookup
-            // reverts with `IdentityNotFound`.
+        } else if e.storage().persistent().has(&MockIRSStorageKey::RecoveredTo(account.clone()))
+            || e.storage().persistent().has(&MockIRSStorageKey::Removed(account.clone()))
+        {
+            // Model the real IRS: once the mapping is gone (recovery or
+            // `remove_identity`), the lookup reverts with `IdentityNotFound`.
             panic_with_error!(e, IRSError::IdentityNotFound)
         } else {
             account
@@ -142,6 +145,13 @@ impl MockIRSContract {
         e.storage().persistent().set(&MockIRSStorageKey::Identity(new_account.clone()), &identity);
         e.storage().persistent().remove(&old_key);
         e.storage().persistent().set(&MockIRSStorageKey::RecoveredTo(old_account), &new_account);
+    }
+
+    /// Models `remove_identity`: deletes the mapping without recording a
+    /// recovery target, so the lookup reverts like the real IRS.
+    pub fn remove(e: &Env, account: Address) {
+        e.storage().persistent().remove(&MockIRSStorageKey::Identity(account.clone()));
+        e.storage().persistent().set(&MockIRSStorageKey::Removed(account), &());
     }
 }
 
@@ -432,6 +442,40 @@ fn forced_transfer_after_recovery_to_third_party_updates_books() {
         // is credited unchecked because the transfer is forced.
         assert_eq!(get_id_balance(&e, &token, &identity), 50);
         assert_eq!(get_id_balance(&e, &token, &third_id), 30);
+    });
+}
+
+// Regression: a sender whose identity was removed *without* recovery has no
+// record to fall back to, so the hook re-raises the IRS error it captured
+// (`IdentityNotFound`, #321) rather than silently swallowing it.
+#[test]
+#[should_panic(expected = "Error(Contract, #321)")]
+fn on_transfer_reraises_irs_error_when_source_unregistered() {
+    let e = Env::default();
+    let module_id = e.register(TestMaxBalanceContract, ());
+    let irs_id = e.register(MockIRSContract, ());
+    let irs = MockIRSContractClient::new(&e, &irs_id);
+    let token = Address::generate(&e);
+    let from_wallet = Address::generate(&e);
+    let to_wallet = Address::generate(&e);
+    let from_id = Address::generate(&e);
+    let to_id = Address::generate(&e);
+
+    irs.set_identity(&from_wallet, &from_id);
+    irs.set_identity(&to_wallet, &to_id);
+
+    e.as_contract(&module_id, || {
+        set_irs_address(&e, &token, &irs_id);
+        set_max_balance(&e, &token, 100);
+        on_created(&e, &from_wallet, 50, &token);
+    });
+
+    // Identity removed without recovery: the source lookup reverts and there is
+    // no recovery record, so the captured error must propagate unchanged.
+    irs.remove(&from_wallet);
+
+    e.as_contract(&module_id, || {
+        on_transfer(&e, &from_wallet, &to_wallet, 10, &TransferKind::Standard, &token);
     });
 }
 

--- a/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
@@ -1,7 +1,7 @@
 extern crate std;
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype,
+    contract, contractimpl, contracttype, panic_with_error,
     testutils::{Address as _, Events as _},
     vec, Address, Env, Val, Vec,
 };
@@ -18,7 +18,7 @@ use crate::rwa::{
         },
         TransferKind,
     },
-    identity_registry_storage::{CountryDataManager, IdentityRegistryStorage},
+    identity_registry_storage::{CountryDataManager, IRSError, IdentityRegistryStorage},
     utils::token_binder::TokenBinder,
 };
 
@@ -29,6 +29,7 @@ struct MockIRSContract;
 #[derive(Clone)]
 enum MockIRSStorageKey {
     Identity(Address),
+    RecoveredTo(Address),
 }
 
 #[contractimpl]
@@ -76,10 +77,23 @@ impl IdentityRegistryStorage for MockIRSContract {
     }
 
     fn stored_identity(e: &Env, account: Address) -> Address {
-        e.storage()
+        if let Some(identity) = e
+            .storage()
             .persistent()
-            .get(&MockIRSStorageKey::Identity(account.clone()))
-            .unwrap_or(account)
+            .get::<_, Address>(&MockIRSStorageKey::Identity(account.clone()))
+        {
+            identity
+        } else if e.storage().persistent().has(&MockIRSStorageKey::RecoveredTo(account.clone())) {
+            // Model the real IRS: once recovery removes the mapping, the lookup
+            // reverts with `IdentityNotFound`.
+            panic_with_error!(e, IRSError::IdentityNotFound)
+        } else {
+            account
+        }
+    }
+
+    fn get_recovered_to(e: &Env, old_account: Address) -> Option<Address> {
+        e.storage().persistent().get(&MockIRSStorageKey::RecoveredTo(old_account))
     }
 }
 
@@ -117,6 +131,17 @@ impl CountryDataManager for MockIRSContract {
 impl MockIRSContract {
     pub fn set_identity(e: &Env, account: Address, identity: Address) {
         e.storage().persistent().set(&MockIRSStorageKey::Identity(account), &identity);
+    }
+
+    /// Models `recover_identity`: moves the identity from `old_account` to
+    /// `new_account`, removes the old mapping, and records the recovery target.
+    pub fn recover(e: &Env, old_account: Address, new_account: Address) {
+        let old_key = MockIRSStorageKey::Identity(old_account.clone());
+        let identity: Address =
+            e.storage().persistent().get(&old_key).expect("identity must be set before recovery");
+        e.storage().persistent().set(&MockIRSStorageKey::Identity(new_account.clone()), &identity);
+        e.storage().persistent().remove(&old_key);
+        e.storage().persistent().set(&MockIRSStorageKey::RecoveredTo(old_account), &new_account);
     }
 }
 
@@ -331,6 +356,82 @@ fn on_transfer_forced_bypasses_cap_but_updates_books() {
 
         assert_eq!(get_id_balance(&e, &token, &from_id), 25);
         assert_eq!(get_id_balance(&e, &token, &to_id), 55);
+    });
+}
+
+// Regression: after `recover_identity` removes the old wallet's identity, the
+// RWA recovery flow moves the balance via a forced transfer to the recovery
+// target. The hook must not revert on the now-missing source identity; it
+// resolves `from` through the recovery record, finds the same identity on both
+// sides, and leaves the per-identity book untouched (a same-identity no-op).
+#[test]
+fn forced_transfer_after_recovery_is_noop_and_does_not_revert() {
+    let e = Env::default();
+    let module_id = e.register(TestMaxBalanceContract, ());
+    let irs_id = e.register(MockIRSContract, ());
+    let irs = MockIRSContractClient::new(&e, &irs_id);
+    let token = Address::generate(&e);
+    let old_wallet = Address::generate(&e);
+    let new_wallet = Address::generate(&e);
+    let identity = Address::generate(&e);
+
+    irs.set_identity(&old_wallet, &identity);
+
+    e.as_contract(&module_id, || {
+        set_irs_address(&e, &token, &irs_id);
+        set_max_balance(&e, &token, 100);
+        on_created(&e, &old_wallet, 80, &token);
+    });
+
+    // Identity recovery moves the identity to the new wallet and removes the
+    // old mapping, so `stored_identity(old_wallet)` now reverts.
+    irs.recover(&old_wallet, &new_wallet);
+
+    e.as_contract(&module_id, || {
+        // The documented recovery move: forced transfer of the whole balance
+        // from the (now identity-less) old wallet to the recovery target.
+        on_transfer(&e, &old_wallet, &new_wallet, 80, &TransferKind::Forced, &token);
+
+        // Same identity on both sides => the aggregate is unchanged and correct.
+        assert_eq!(get_id_balance(&e, &token, &identity), 80);
+    });
+}
+
+// Regression: a forced transfer out of a recovered (identity-less) wallet to a
+// *different* identity must still keep the books straight. The source resolves
+// through the recovery record to its identity, which differs from the
+// recipient's, so the move debits and credits both aggregates as normal.
+#[test]
+fn forced_transfer_after_recovery_to_third_party_updates_books() {
+    let e = Env::default();
+    let module_id = e.register(TestMaxBalanceContract, ());
+    let irs_id = e.register(MockIRSContract, ());
+    let irs = MockIRSContractClient::new(&e, &irs_id);
+    let token = Address::generate(&e);
+    let old_wallet = Address::generate(&e);
+    let new_wallet = Address::generate(&e);
+    let third_wallet = Address::generate(&e);
+    let identity = Address::generate(&e);
+    let third_id = Address::generate(&e);
+
+    irs.set_identity(&old_wallet, &identity);
+    irs.set_identity(&third_wallet, &third_id);
+
+    e.as_contract(&module_id, || {
+        set_irs_address(&e, &token, &irs_id);
+        set_max_balance(&e, &token, 100);
+        on_created(&e, &old_wallet, 80, &token);
+    });
+
+    irs.recover(&old_wallet, &new_wallet);
+
+    e.as_contract(&module_id, || {
+        on_transfer(&e, &old_wallet, &third_wallet, 30, &TransferKind::Forced, &token);
+
+        // `identity` (resolved via the recovery record) is debited; `third_id`
+        // is credited unchecked because the transfer is forced.
+        assert_eq!(get_id_balance(&e, &token, &identity), 50);
+        assert_eq!(get_id_balance(&e, &token, &third_id), 30);
     });
 }
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #757 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [ ] Tests
- [ ] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer handling for recovered accounts so balances resolve correctly after identity recovery.
  * Forced transfers now correctly treat same-identity cases as no-ops instead of reverting.
  * Transfers to third parties after recovery now update account limits and bookkeeping using the resolved identities.
* **Tests**
  * Added regression coverage for forced transfers after identity recovery, including same-identity and third-party scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->