### PR TITLE
Gate the spender through the compliance policy (audit L-01)

### DIFF
--- a/packages/tokens/src/confidential/compliance/mod.rs
+++ b/packages/tokens/src/confidential/compliance/mod.rs
@@ -164,21 +164,36 @@ pub trait ConfidentialCompliance: ConfidentialToken {
 /// the active [`ComplianceConfig`]. Wire as `type Hooks = ComplianceHooks;`
 /// on a contract that implements [`ConfidentialToken`].
 ///
-/// Each callback follows the same three-stage sequence when a configuration
+/// Each gated party is checked against up to three gates when a configuration
 /// is present:
 ///
-/// 1. Reverts [`ComplianceError::AccountFrozen`] if the address is frozen (with
-///    the exception for `spender`).
+/// 1. Reverts [`ComplianceError::AccountFrozen`] if the address is frozen.
 /// 2. When `config.policy = Some(p)`, calls `p.is_authorized` and reverts
 ///    [`ComplianceError::NotAuthorizedByPolicy`] on `false`.
 /// 3. When `config.sac_passthrough = true`, calls the underlying SEP-41 token's
 ///    `authorized` view and reverts [`ComplianceError::NotAuthorizedBySac`] on
 ///    `false`.
 ///
-/// Special cases:
+/// Which parties pass which gates:
 ///
-/// * [`on_register`](Hooks::on_register) skips the freeze branch but still
-///   applies policy and SAC.
+/// * [`on_deposit`](Hooks::on_deposit), [`on_withdraw`](Hooks::on_withdraw),
+///   [`on_transfer`](Hooks::on_transfer): `from` and `to` pass all three gates.
+///   [`on_merge`](Hooks::on_merge): `account` passes all three.
+/// * [`on_register`](Hooks::on_register): `account` skips the freeze gate
+///   (registration predates the account entry) but passes policy and SAC.
+/// * [`on_spender_transfer`](Hooks::on_spender_transfer): `from` and `to` pass
+///   all three gates; `spender` passes only the policy gate.
+/// * [`on_set_spender`](Hooks::on_set_spender): the delegating `account` passes
+///   all three gates; `spender` passes only the policy gate, so a delegation to
+///   a policy-denied spender fails at grant time rather than at spend time.
+/// * [`on_revoke_spender`](Hooks::on_revoke_spender): `account` passes all
+///   three gates; `spender` is not gated at all. Revocation is the owner's
+///   escape hatch — blocking it once the spender turns non-compliant would
+///   entrench the bad delegation.
+///
+/// The spender is exempt from the freeze and SAC gates everywhere: both
+/// target fund ownership, and the spender holds no funds in this model,
+/// mirroring the fungible and rwa allowance models.
 ///
 /// Deployments that need additional behaviour (audit mirroring, rate
 /// limiting, or alternative deposit semantics — see
@@ -228,7 +243,7 @@ impl Hooks for ComplianceHooks {
 
     fn on_spender_transfer(
         e: &Env,
-        _spender: &Address,
+        spender: &Address,
         from: &Address,
         to: &Address,
         _payload: Val,
@@ -236,16 +251,18 @@ impl Hooks for ComplianceHooks {
         let Some(config) = storage::compliance_config(e) else {
             return;
         };
-        // Gate `from` and `to` only, consistent with the fungible and rwa allowance
-        // models.
+        // `from` and `to` pass all three gates; the spender holds no funds, so
+        // it skips freeze and SAC (consistent with the fungible and rwa
+        // allowance models) but must still clear the external policy.
         storage::gate_account(e, from, &config);
         storage::gate_account(e, to, &config);
+        storage::check_policy(e, spender, &config);
     }
 
     fn on_set_spender(
         e: &Env,
         account: &Address,
-        _spender: &Address,
+        spender: &Address,
         _live_until_ledger: u32,
         _payload: Val,
     ) {
@@ -253,6 +270,7 @@ impl Hooks for ComplianceHooks {
             return;
         };
         storage::gate_account(e, account, &config);
+        storage::check_policy(e, spender, &config);
     }
 
     fn on_revoke_spender(e: &Env, account: &Address, _spender: &Address, _payload: Val) {

--- a/packages/tokens/src/confidential/compliance/test.rs
+++ b/packages/tokens/src/confidential/compliance/test.rs
@@ -434,6 +434,48 @@ fn rotating_policy_to_none_skips_policy_gate() {
     });
 }
 
+#[test]
+#[should_panic(expected = "Error(Contract, #3602)")]
+fn on_spender_transfer_rejects_policy_denied_spender() {
+    let h = setup();
+    let alice = Address::generate(&h.e);
+    let bob = Address::generate(&h.e);
+    let op = Address::generate(&h.e);
+    let policy = h.e.register(DenyOnePolicy, (op.clone(),));
+    h.e.as_contract(&h.host, || {
+        set_compliance_config(&h.e, &ComplianceConfig { policy: Some(policy), ..base_config() });
+        ComplianceHooks::on_spender_transfer(&h.e, &op, &alice, &bob, void_val(&h.e));
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3602)")]
+fn on_set_spender_rejects_policy_denied_spender() {
+    // Delegating to a policy-denied spender fails at grant time.
+    let h = setup();
+    let alice = Address::generate(&h.e);
+    let op = Address::generate(&h.e);
+    let policy = h.e.register(DenyOnePolicy, (op.clone(),));
+    h.e.as_contract(&h.host, || {
+        set_compliance_config(&h.e, &ComplianceConfig { policy: Some(policy), ..base_config() });
+        ComplianceHooks::on_set_spender(&h.e, &alice, &op, 0, void_val(&h.e));
+    });
+}
+
+#[test]
+fn on_revoke_spender_allows_policy_denied_spender() {
+    // Revocation is the owner's escape hatch: it must stay possible even
+    // after the spender turns non-compliant.
+    let h = setup();
+    let alice = Address::generate(&h.e);
+    let op = Address::generate(&h.e);
+    let policy = h.e.register(DenyOnePolicy, (op.clone(),));
+    h.e.as_contract(&h.host, || {
+        set_compliance_config(&h.e, &ComplianceConfig { policy: Some(policy), ..base_config() });
+        ComplianceHooks::on_revoke_spender(&h.e, &alice, &op, void_val(&h.e));
+    });
+}
+
 // ################## SAC PASSTHROUGH ##################
 
 #[test]
@@ -458,6 +500,21 @@ fn panics_when_sac_unauthorized() {
     h.e.as_contract(&h.host, || {
         set_compliance_config(&h.e, &ComplianceConfig { sac_passthrough: true, ..base_config() });
         ComplianceHooks::on_merge(&h.e, &alice);
+    });
+}
+
+#[test]
+fn on_spender_transfer_when_spender_sac_unauthorized() {
+    // The SAC gate targets fund ownership; the spender holds no funds and is
+    // intentionally exempt.
+    let h = setup();
+    let alice = Address::generate(&h.e);
+    let bob = Address::generate(&h.e);
+    let op = Address::generate(&h.e);
+    h.sac.set_authorized(&op, &false);
+    h.e.as_contract(&h.host, || {
+        set_compliance_config(&h.e, &ComplianceConfig { sac_passthrough: true, ..base_config() });
+        ComplianceHooks::on_spender_transfer(&h.e, &op, &alice, &bob, void_val(&h.e));
     });
 }
 

--- a/packages/tokens/src/confidential/docs/COMPLIANCE.md
+++ b/packages/tokens/src/confidential/docs/COMPLIANCE.md
@@ -38,7 +38,7 @@ The contract maintains a `frozen(account) -> bool` entry per account. Before app
 
 Full freeze (rather than outbound-only) keeps semantics clean: no further accumulation is possible after the freeze takes effect.
 
-The spender named by the delegation flows (`set_spender`, `confidential_transfer_from`, `revoke_spender`) is not an account for the purposes of the freeze check: the freeze targets fund ownership, and the spender holds no funds — the value being moved stays the owner's, and freezing the owner halts the delegation. This mirrors the allowance models of the library's fungible and rwa tokens. The spender is instead gated by the policy contract (§3).
+The spender named by the delegation flows (`set_spender`, `confidential_transfer_from`) is not an account for the purposes of the freeze check: the freeze targets fund ownership, and the spender holds no funds — the value being moved stays the owner's, and freezing the owner halts the delegation. This mirrors the allowance models of the library's fungible and rwa tokens. The spender is instead gated by the policy contract (§3).
 
 ### 2.1 Core Interface Additions
 

--- a/packages/tokens/src/confidential/docs/COMPLIANCE.md
+++ b/packages/tokens/src/confidential/docs/COMPLIANCE.md
@@ -38,6 +38,8 @@ The contract maintains a `frozen(account) -> bool` entry per account. Before app
 
 Full freeze (rather than outbound-only) keeps semantics clean: no further accumulation is possible after the freeze takes effect.
 
+The spender named by the delegation flows (`set_spender`, `confidential_transfer_from`, `revoke_spender`) is not an account for the purposes of the freeze check: the freeze targets fund ownership, and the spender holds no funds — the value being moved stays the owner's, and freezing the owner halts the delegation. This mirrors the allowance models of the library's fungible and rwa tokens. The spender is instead gated by the policy contract (§3).
+
 ### 2.1 Core Interface Additions
 
 Three functions are added to the core contract interface:
@@ -60,6 +62,8 @@ $$\text{permitted}(a) = \neg \text{frozen}(a) \\;\land\\; \text{policy\\\_ok}(a)
 
 Off by default. Issuer-led deployments using a SAC underlying opt in at construction. The cost is one extra cross-contract invocation per named account per operation. This is the *transitive compliance* pattern: the issuer's own freeze/deauthorize, driven through the SAC's standardized admin interface (`set_authorized`, CAP-0046-06), takes effect at the confidential layer with no state mirrored by the token admin.
 
+Like the contract-level freeze (§2), the SAC check names only fund-holding parties: the spender of a delegated flow is exempt.
+
 ---
 
 ## 3. Policy Contract
@@ -81,6 +85,8 @@ This single hook covers the common deployment modes without baking them into the
 Membership management, list semantics, and identity proofs live entirely inside the policy contract. The token's only agreement with the policy is the boolean return value.
 
 Externalizing the policy also lets a single registry serve multiple tokens. An issuer running several confidential tokens (different denominations, jurisdictions, or product lines) can point every token at the same KYC or sanctions contract and maintain one source of truth, rather than mirroring lists into each token. The `token` argument to `is_authorized` lets the registry apply per-token rules when needed (e.g., a jurisdiction filter) without giving up the shared baseline.
+
+**Spender gating.** Unlike the freeze (§2) and SAC (§2.2) checks, the policy gate also names the spender of a delegated flow: `set_spender` checks the spender at grant time — a delegation to a policy-denied spender fails when it is established, not only when it is exercised — and `confidential_transfer_from` checks the spender at spend time, alongside `from` and `to`. `revoke_spender` deliberately does not gate the spender: revocation is the owner's escape hatch, and blocking it once the spender turns non-compliant would entrench the bad delegation (the owner is still gated on revocation, as on every other operation).
 
 The policy address is rotatable via `set_compliance_config` (§6) under admin auth (§1.1). Setting it to `None` disables the gate. The policy is part of the deployment's trust surface.
 


### PR DESCRIPTION
Fixes #769

The built-in `ComplianceHooks` received the spender as `_spender` and never forwarded it to any gate: `on_spender_transfer`, `on_set_spender`, and `on_revoke_spender` gated only the owner and the `from`/`to` parties. A compliant owner could therefore delegate to a policy-denied spender, and that spender could direct confidential transfers of the owner's funds with no way for the administrator to intervene short of freezing the owner. The module docs recorded only a freeze-check exception for the spender, understating the actual exemption.

### Gating matrix (as implemented)

| Callback | Owner / `from` / `to` | `spender` |
|:---|:---|:---|
| `on_spender_transfer` | freeze + policy + SAC | **policy only** (new) |
| `on_set_spender` | freeze + policy + SAC | **policy only** (new) — a delegation to a policy-denied spender fails at grant time |
| `on_revoke_spender` | freeze + policy + SAC (unchanged) | not gated — revocation is the owner's escape hatch; blocking it once the spender turns non-compliant would entrench the bad delegation |

The freeze and SAC exemptions for the spender are intentional and kept: both gates target fund ownership, and the spender holds no funds in this model, mirroring the fungible and rwa allowance models. They are now stated explicitly in the `ComplianceHooks` docstring and in `docs/COMPLIANCE.md` (§§2–3), and pinned by tests so they cannot regress silently.

There is **no `Policy` ABI change**: the spender is checked through the existing `storage::check_policy` / `is_authorized(account, token)` interface.

### Verification

- `cargo test --package stellar-tokens` — 680 passed, 0 failed (38 in `confidential::compliance`, including 4 new tests)
- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --release --locked --package stellar-tokens --all-targets -- -D warnings` — clean

#### PR Checklist

- [x] Tests
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delegated spenders are now checked against external compliance policies when being granted spending permissions or used for delegated transfers.
  * Delegated spender policy checks correctly do not block revocation.
  * Spender authorization is now enforced when SAC passthrough is enabled.

* **Documentation**
  * Clarified how freeze, policy, and SAC compliance checks apply to delegated spending operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->