### PR TITLE
Validate Grumpkin point inputs at the public API (audit L-05)

### DIFF
--- a/packages/contract-utils/src/crypto/error.rs
+++ b/packages/contract-utils/src/crypto/error.rs
@@ -10,4 +10,7 @@ pub enum CryptoError {
     MerkleIndexOutOfBounds = 1401,
     /// No data in hasher state.
     HasherEmptyState = 1402,
+    /// The point is neither the canonical identity encoding nor a canonical
+    /// on-curve point.
+    InvalidPoint = 1403,
 }

--- a/packages/contract-utils/src/crypto/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/grumpkin.rs
@@ -8,9 +8,15 @@
 //! This module exposes:
 //!
 //! * [`Grumpkin::add`], [`Grumpkin::sub`], [`Grumpkin::neg`], [`Grumpkin::mul`]
-//!   — affine point arithmetic with full identity handling.
-//! * [`Grumpkin::is_on_curve`], [`Grumpkin::is_not_identity`] — validation
-//!   helpers for points that enter the system without a soundness proof.
+//!   — affine point arithmetic with full identity handling. Every point input
+//!   is validated at entry: the canonical identity encoding is accepted as `O`,
+//!   any other input must be a canonical on-curve point, and violations panic
+//!   with [`CryptoError::InvalidPoint`].
+//! * [`Grumpkin::is_on_curve`], [`Grumpkin::is_not_identity`],
+//!   [`Grumpkin::is_canonical_point`], [`Grumpkin::is_canonical_field`] —
+//!   non-panicking validation helpers for trust boundaries that need to accept
+//!   or reject foreign bytes with a domain-specific error (e.g. user-supplied
+//!   public keys) before they reach this API.
 //! * [`Grumpkin::identity`] — the encoded point at infinity, `(0, 0)` over 64
 //!   bytes.
 //! * [`Grumpkin::generator`] — the canonical Barretenberg generator `G` used by
@@ -23,8 +29,17 @@
 //! identity is the all-zero encoding `(0, 0)` and is handled as a special case
 //! in arithmetic. Real curve points cannot share this encoding because
 //! `0² ≠ 0³ - 17 (mod r)`.
+//!
+//! The Soroban host reduces non-canonical `Bn254Fr` encodings modulo `r`
+//! instead of rejecting them, so distinct byte strings can decode to the same
+//! coordinates (e.g. `be(r) || be(r)` decodes to `(0, 0)`). The arithmetic
+//! entry points therefore reject any non-canonical encoding before decoding;
+//! within that validated domain every logical point has exactly one byte
+//! encoding and byte comparison decides point equality.
 
-use soroban_sdk::{crypto::bn254::Bn254Fr, BytesN, Env, U256};
+use soroban_sdk::{crypto::bn254::Bn254Fr, panic_with_error, BytesN, Env, U256};
+
+use crate::crypto::error::CryptoError;
 
 /// Affine encoding of a Grumpkin point as a 64-byte value.
 ///
@@ -59,11 +74,18 @@ const GENERATOR_BYTES: [u8; 64] = [
 
 /// Grumpkin point arithmetic over `Bn254Fr`.
 ///
-/// The implementation performs no on-curve check on its inputs: callers must
-/// ensure inputs are valid curve points before calling [`Self::add`],
-/// [`Self::sub`], or [`Self::neg`]. Use [`Self::is_on_curve`] and
-/// [`Self::is_not_identity`] at trust boundaries (e.g. user-supplied points
-/// without an accompanying soundness proof).
+/// The arithmetic entry points ([`Self::add`], [`Self::sub`], [`Self::neg`],
+/// [`Self::mul`]) validate every point input once at entry: the canonical
+/// identity encoding is accepted as `O`, any other input must be a canonical
+/// on-curve point, and violations panic with [`CryptoError::InvalidPoint`].
+/// Intermediate results are on the curve by construction and are not
+/// re-validated.
+///
+/// [`Self::is_on_curve`], [`Self::is_canonical_point`],
+/// [`Self::is_canonical_field`] and [`Self::is_not_identity`] remain available
+/// as non-panicking checks for trust boundaries that need to accept or reject
+/// foreign bytes with a domain-specific error (e.g. user-supplied public keys
+/// without an accompanying soundness proof) before they reach this API.
 pub struct Grumpkin;
 
 impl Grumpkin {
@@ -92,7 +114,15 @@ impl Grumpkin {
         BytesN::from_array(e, &GENERATOR_BYTES)
     }
 
-    /// Returns `true` iff `p` is the identity (all-zero 64-byte encoding).
+    /// Returns `true` iff `p` is the canonical identity encoding (the
+    /// all-zero 64 bytes).
+    ///
+    /// The decision is made on raw bytes and is only meaningful for canonical
+    /// encodings: a non-canonical encoding whose coordinates reduce to `(0,
+    /// 0)` modulo `r` (e.g. `be(r) || be(r)`) returns `false`. The arithmetic
+    /// entry points reject such encodings with
+    /// [`CryptoError::InvalidPoint`] instead of treating them as the
+    /// identity.
     ///
     /// # Arguments
     ///
@@ -181,13 +211,14 @@ impl Grumpkin {
     ///
     /// * `e` - Access to the Soroban environment.
     /// * `p` - The point to negate.
+    ///
+    /// # Errors
+    ///
+    /// * [`CryptoError::InvalidPoint`] - When `p` is neither the canonical
+    ///   identity encoding nor a canonical on-curve point.
     pub fn neg(e: &Env, p: &Point) -> Point {
-        if Self::is_identity(p) {
-            return p.clone();
-        }
-        let (x, y) = Self::coordinates(e, p);
-        let neg_y = fr_zero(e) - y;
-        Self::from_xy(e, &x, &neg_y)
+        Self::require_valid_point(e, p);
+        Self::neg_unchecked(e, p)
     }
 
     /// Returns `p1 + p2` on Grumpkin.
@@ -208,7 +239,133 @@ impl Grumpkin {
     /// * `e` - Access to the Soroban environment.
     /// * `p1` - The first summand.
     /// * `p2` - The second summand.
+    ///
+    /// # Errors
+    ///
+    /// * [`CryptoError::InvalidPoint`] - When `p1` or `p2` is neither the
+    ///   canonical identity encoding nor a canonical on-curve point.
     pub fn add(e: &Env, p1: &Point, p2: &Point) -> Point {
+        Self::require_valid_point(e, p1);
+        Self::require_valid_point(e, p2);
+        Self::add_unchecked(e, p1, p2)
+    }
+
+    /// Returns `p1 - p2 = p1 + (-p2)`. Subtraction of a point from itself
+    /// returns `O` via the inverse case in [`Self::add`].
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p1` - The minuend.
+    /// * `p2` - The subtrahend.
+    ///
+    /// # Errors
+    ///
+    /// * [`CryptoError::InvalidPoint`] - When `p1` or `p2` is neither the
+    ///   canonical identity encoding nor a canonical on-curve point.
+    pub fn sub(e: &Env, p1: &Point, p2: &Point) -> Point {
+        Self::require_valid_point(e, p1);
+        Self::require_valid_point(e, p2);
+        Self::add_unchecked(e, p1, &Self::neg_unchecked(e, p2))
+    }
+
+    /// Returns `scalar · p` on Grumpkin via double-and-add.
+    ///
+    /// Handles edges cleanly: `0 · p = O` for any `p`, and `scalar · O = O`
+    /// for any `scalar`.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p` - The base point.
+    /// * `scalar` - The scalar multiplier. Sized for the on-chain consumers'
+    ///   needs (token amounts and similar bounded quantities); off-chain
+    ///   provers typically use larger scalars and should pre-compute on the
+    ///   prover side rather than calling this function.
+    ///
+    /// # Errors
+    ///
+    /// * [`CryptoError::InvalidPoint`] - When `p` is neither the canonical
+    ///   identity encoding nor a canonical on-curve point.
+    pub fn mul(e: &Env, p: &Point, scalar: u128) -> Point {
+        Self::require_valid_point(e, p);
+        if scalar == 0 || Self::is_identity(p) {
+            return Self::identity(e);
+        }
+        let mut k = scalar;
+        let mut result = Self::identity(e);
+        let mut base = p.clone();
+        while k > 0 {
+            if k & 1 == 1 {
+                result = Self::add_unchecked(e, &result, &base);
+            }
+            k >>= 1;
+            if k > 0 {
+                base = Self::add_unchecked(e, &base, &base);
+            }
+        }
+        result
+    }
+
+    /// Encodes `(x, y)` as a 64-byte [`Point`].
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `x` - The x-coordinate as a `Bn254Fr` element.
+    /// * `y` - The y-coordinate as a `Bn254Fr` element.
+    pub fn from_xy(e: &Env, x: &Bn254Fr, y: &Bn254Fr) -> Point {
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&x.to_bytes().to_array());
+        bytes[32..].copy_from_slice(&y.to_bytes().to_array());
+        BytesN::from_array(e, &bytes)
+    }
+
+    /// Decodes `(x, y)` from a 64-byte [`Point`].
+    ///
+    /// Performs no validation: non-canonical coordinates are reduced modulo
+    /// `r` by the host deserialiser. See [`Self::is_canonical_field`].
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `p` - The encoded point to decode.
+    pub fn coordinates(e: &Env, p: &Point) -> (Bn254Fr, Bn254Fr) {
+        let bytes = p.to_array();
+        let mut x = [0u8; 32];
+        let mut y = [0u8; 32];
+        x.copy_from_slice(&bytes[..32]);
+        y.copy_from_slice(&bytes[32..]);
+        (
+            Bn254Fr::from_bytes(BytesN::from_array(e, &x)),
+            Bn254Fr::from_bytes(BytesN::from_array(e, &y)),
+        )
+    }
+
+    /// Panics with [`CryptoError::InvalidPoint`] unless `p` is the canonical
+    /// identity encoding or a canonical on-curve point.
+    fn require_valid_point(e: &Env, p: &Point) {
+        if !Self::is_identity(p) && !Self::is_on_curve(e, p) {
+            panic_with_error!(e, CryptoError::InvalidPoint);
+        }
+    }
+
+    /// [`Self::neg`] without input validation. `p` must be the canonical
+    /// identity encoding or a canonical on-curve point.
+    fn neg_unchecked(e: &Env, p: &Point) -> Point {
+        if Self::is_identity(p) {
+            return p.clone();
+        }
+        let (x, y) = Self::coordinates(e, p);
+        let neg_y = fr_zero(e) - y;
+        Self::from_xy(e, &x, &neg_y)
+    }
+
+    /// [`Self::add`] without input validation. Both inputs must be the
+    /// canonical identity encoding or canonical on-curve points. Keeps
+    /// chained operations on intermediate results — which are on the curve by
+    /// construction — free of redundant validation.
+    fn add_unchecked(e: &Env, p1: &Point, p2: &Point) -> Point {
         if Self::is_identity(p1) {
             return p2.clone();
         }
@@ -243,82 +400,6 @@ impl Grumpkin {
         let x3 = lambda.clone() * lambda.clone() - x1.clone() - x2;
         let y3 = lambda * (x1 - x3.clone()) - y1;
         Self::from_xy(e, &x3, &y3)
-    }
-
-    /// Returns `p1 - p2 = p1 + (-p2)`. Subtraction of a point from itself
-    /// returns `O` via the inverse case in [`Self::add`].
-    ///
-    /// # Arguments
-    ///
-    /// * `e` - Access to the Soroban environment.
-    /// * `p1` - The minuend.
-    /// * `p2` - The subtrahend.
-    pub fn sub(e: &Env, p1: &Point, p2: &Point) -> Point {
-        Self::add(e, p1, &Self::neg(e, p2))
-    }
-
-    /// Returns `scalar · p` on Grumpkin via double-and-add.
-    ///
-    /// Handles edges cleanly: `0 · p = O` for any `p`, and `scalar · O = O`
-    /// for any `scalar`.
-    ///
-    /// # Arguments
-    ///
-    /// * `e` - Access to the Soroban environment.
-    /// * `p` - The base point.
-    /// * `scalar` - The scalar multiplier. Sized for the on-chain consumers'
-    ///   needs (token amounts and similar bounded quantities); off-chain
-    ///   provers typically use larger scalars and should pre-compute on the
-    ///   prover side rather than calling this function.
-    pub fn mul(e: &Env, p: &Point, scalar: u128) -> Point {
-        if scalar == 0 || Self::is_identity(p) {
-            return Self::identity(e);
-        }
-        let mut k = scalar;
-        let mut result = Self::identity(e);
-        let mut base = p.clone();
-        while k > 0 {
-            if k & 1 == 1 {
-                result = Self::add(e, &result, &base);
-            }
-            k >>= 1;
-            if k > 0 {
-                base = Self::add(e, &base, &base);
-            }
-        }
-        result
-    }
-
-    /// Encodes `(x, y)` as a 64-byte [`Point`].
-    ///
-    /// # Arguments
-    ///
-    /// * `e` - Access to the Soroban environment.
-    /// * `x` - The x-coordinate as a `Bn254Fr` element.
-    /// * `y` - The y-coordinate as a `Bn254Fr` element.
-    pub fn from_xy(e: &Env, x: &Bn254Fr, y: &Bn254Fr) -> Point {
-        let mut bytes = [0u8; 64];
-        bytes[..32].copy_from_slice(&x.to_bytes().to_array());
-        bytes[32..].copy_from_slice(&y.to_bytes().to_array());
-        BytesN::from_array(e, &bytes)
-    }
-
-    /// Decodes `(x, y)` from a 64-byte [`Point`].
-    ///
-    /// # Arguments
-    ///
-    /// * `e` - Access to the Soroban environment.
-    /// * `p` - The encoded point to decode.
-    pub fn coordinates(e: &Env, p: &Point) -> (Bn254Fr, Bn254Fr) {
-        let bytes = p.to_array();
-        let mut x = [0u8; 32];
-        let mut y = [0u8; 32];
-        x.copy_from_slice(&bytes[..32]);
-        y.copy_from_slice(&bytes[32..]);
-        (
-            Bn254Fr::from_bytes(BytesN::from_array(e, &x)),
-            Bn254Fr::from_bytes(BytesN::from_array(e, &y)),
-        )
     }
 }
 

--- a/packages/contract-utils/src/crypto/test/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/test/grumpkin.rs
@@ -503,3 +503,165 @@ fn is_on_curve_rejects_x_equal_to_modulus() {
     let p = BytesN::from_array(&e, &bytes);
     assert!(!Grumpkin::is_on_curve(&e, &p));
 }
+
+// ################## UNIT TESTS — arithmetic input validation
+// ##################
+
+/// `(1, 2)`: `2² = 4 ≠ 1³ − 17 (mod r)`, so canonical but off-curve.
+fn off_curve_point(e: &Env) -> Point {
+    let mut bytes = [0u8; 64];
+    bytes[31] = 1;
+    bytes[63] = 2;
+    BytesN::from_array(e, &bytes)
+}
+
+/// `be(r) || be(r)` — decodes to `(0, 0)` under the host's mod-`r` reduction
+/// but is bytewise distinct from the canonical all-zero identity encoding.
+fn pseudo_identity(e: &Env) -> Point {
+    let mut bytes = [0u8; 64];
+    bytes[..32].copy_from_slice(&FR_MODULUS_BE);
+    bytes[32..].copy_from_slice(&FR_MODULUS_BE);
+    BytesN::from_array(e, &bytes)
+}
+
+/// A real curve point with `r` added to its x-coordinate: satisfies the curve
+/// equation after mod-`r` reduction, but is a non-canonical encoding.
+fn non_canonical_x_point(e: &Env) -> Point {
+    let mut bytes = rand_point(e, &[0x5A; 32]).to_array();
+    let mut x = [0u8; 32];
+    x.copy_from_slice(&bytes[..32]);
+    let x_plus_r = add_modulus_be(&x).expect("canonical x < r, so x + r < 2r < 2^256");
+    bytes[..32].copy_from_slice(&x_plus_r);
+    BytesN::from_array(e, &bytes)
+}
+
+#[test]
+fn pseudo_identity_is_not_the_identity() {
+    let e = Env::default();
+    let pseudo = pseudo_identity(&e);
+    assert!(!Grumpkin::is_identity(&pseudo));
+    assert!(!Grumpkin::is_on_curve(&e, &pseudo));
+}
+
+#[test]
+fn sub_handles_identity_operands() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0xEE; 32]);
+    let o = Grumpkin::identity(&e);
+    assert_eq!(Grumpkin::sub(&e, &p, &o).to_array(), p.to_array());
+    assert_eq!(Grumpkin::sub(&e, &o, &p).to_array(), Grumpkin::neg(&e, &p).to_array());
+    assert_eq!(Grumpkin::sub(&e, &o, &o).to_array(), [0u8; 64]);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn add_rejects_off_curve_first_operand() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x11; 32]);
+    let _ = Grumpkin::add(&e, &off_curve_point(&e), &p);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn add_rejects_off_curve_second_operand() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x11; 32]);
+    let _ = Grumpkin::add(&e, &p, &off_curve_point(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn add_rejects_pseudo_identity() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x22; 32]);
+    let _ = Grumpkin::add(&e, &p, &pseudo_identity(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn add_rejects_non_canonical_x() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x33; 32]);
+    let _ = Grumpkin::add(&e, &p, &non_canonical_x_point(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn sub_rejects_off_curve_minuend() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x44; 32]);
+    let _ = Grumpkin::sub(&e, &off_curve_point(&e), &p);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn sub_rejects_off_curve_subtrahend() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x44; 32]);
+    let _ = Grumpkin::sub(&e, &p, &off_curve_point(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn sub_rejects_pseudo_identity() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x55; 32]);
+    let _ = Grumpkin::sub(&e, &p, &pseudo_identity(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn sub_rejects_non_canonical_x() {
+    let e = Env::default();
+    let p = rand_point(&e, &[0x55; 32]);
+    let _ = Grumpkin::sub(&e, &non_canonical_x_point(&e), &p);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn neg_rejects_off_curve_point() {
+    let e = Env::default();
+    let _ = Grumpkin::neg(&e, &off_curve_point(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn neg_rejects_pseudo_identity() {
+    let e = Env::default();
+    let _ = Grumpkin::neg(&e, &pseudo_identity(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn neg_rejects_non_canonical_x() {
+    let e = Env::default();
+    let _ = Grumpkin::neg(&e, &non_canonical_x_point(&e));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn mul_rejects_off_curve_point() {
+    let e = Env::default();
+    let _ = Grumpkin::mul(&e, &off_curve_point(&e), 5);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn mul_rejects_pseudo_identity() {
+    let e = Env::default();
+    let _ = Grumpkin::mul(&e, &pseudo_identity(&e), 3);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn mul_rejects_non_canonical_x() {
+    let e = Env::default();
+    let _ = Grumpkin::mul(&e, &non_canonical_x_point(&e), 7);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1403)")]
+fn mul_rejects_off_curve_point_even_with_zero_scalar() {
+    let e = Env::default();
+    let _ = Grumpkin::mul(&e, &off_curve_point(&e), 0);
+}


### PR DESCRIPTION
Fixes #773

The Grumpkin arithmetic (`add`/`sub`/`neg`/`mul`) never confirmed that an input is a canonical, on-curve point, and `is_identity` compares raw bytes, so a host-reduced pseudo-identity such as `be(r) || be(r)` (which decodes to `(0, 0)`) slipped past the identity check and entered the group law as a "regular" point. Points on a different curve `y² = x³ + b'` were likewise processed silently, since the affine formulas omit the curve constant.

### Design

- Every public arithmetic entry point (`add`, `sub`, `neg`, `mul`) now validates each point input once at entry: the canonical all-zero identity encoding is accepted as `O`; any other input must pass `is_on_curve` (which fuses the canonical-encoding and curve-equation checks); violations panic with the new `CryptoError::InvalidPoint` (`#1403`, continuing the crypto package's 1400s range). A single variant was chosen over `NonCanonicalPoint`/`OffCurvePoint` because the API has a single precondition ("valid group element") and callers cannot act differently on the two failure modes; boundaries that need to distinguish them (e.g. the confidential token) already use their own domain errors.
- The double-and-add loop in `mul` and the internal chaining in `sub` delegate to private `add_unchecked` / `neg_unchecked`, so intermediate results — on the curve by construction — are never re-validated and no input is validated twice.
- `is_identity` stays byte-based with an unchanged signature (it has no `Env` parameter and is used by the confidential token's auditor key validation). With canonicality enforced at entry, non-canonical encodings are rejected rather than silently reduced, so byte comparison is sound within the validated domain; the docs now state this explicitly.
- Module and struct docstrings rewritten: the old "callers must ensure inputs are valid curve points" contract is replaced by the validate-at-entry behavior, with `is_on_curve` / `is_canonical_point` / `is_canonical_field` documented as non-panicking checks for trust boundaries that want a domain-specific error.

Not reachable through the confidential token today (it validates at the verifier boundary and its circuits produce on-curve points by construction) — this is defense-in-depth for the standalone primitive.

**Measured cost overhead (confidential token).** Each validated point input adds one `is_on_curve` — ~7 `Bn254Fr` host ops plus two 64-byte point decodes — measured at **~43k CPU instructions** (soroban-sdk native estimate, fresh-`Env` per op, differential vs. the unchecked baseline; the per-check cost is flat across scalar size, confirming a single fixed validation). `add`/`sub` validate two inputs (+~86k); `mul`/`neg` validate one (+~43k, since the double-and-add loop runs `add_unchecked`). Per confidential-token entry point:

| Operation | Added on-curve checks | Added CPU insns |
|---|---|---|
| `deposit` | 3 (`mul` base + `add` × 2 operands) | ~130k |
| `merge` / `confidential_transfer` / `confidential_transfer_from` | 2 (`add` × 2 operands) | ~86k |
| `withdraw` / `set_spender` / `revoke_spender` / `register` | 0 (storage-only, no `add`/`mul` on balances) | 0 |

The heaviest path (`deposit`) is ≈0.03% of the 400M per-tx CPU budget, and negligible against the UltraHonk `verify_proof` that gates every proof-carrying entry point. When a validated operand is the identity, the guard short-circuits on a byte compare (~1k insns). Native estimates run below WASM in absolute terms, but the checks and the surrounding arithmetic are dominated by the same `Bn254Fr` host ops, so the ratios hold.

### Verification

- `cargo test` — full workspace passes; confidential-token behavior unchanged.
- New rejection tests for each entry point: off-curve `(1, 2)`, the `be(r) || be(r)` pseudo-identity, and a real point malleated by `x → x + r` (on-curve after reduction, non-canonical bytes — caught only by the canonicality check).
- `cargo +nightly fmt --all -- --check` and `cargo clippy --release --locked --all-targets -- -D warnings` pass.

#### PR Checklist

- [x] Tests
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to Grumpkin point arithmetic operations, rejecting invalid, off-curve, and non-canonical point encodings.
  * Ensured pseudo-identity values are not incorrectly treated as the canonical identity.
  * Invalid point inputs now return the dedicated error code `1403`.

* **Tests**
  * Added coverage for invalid points, non-canonical encodings, identity handling, and zero-scalar multiplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->