### PR TITLE
Match the on-chain Poseidon2 sponge on empty input (audit L-04)

### DIFF
--- a/packages/tokens/src/confidential/circuits/lib/src/lib.nr
+++ b/packages/tokens/src/confidential/circuits/lib/src/lib.nr
@@ -179,6 +179,11 @@ pub fn assert_on_curve_non_identity(p: EmbeddedCurvePoint) {
 /// Poseidon2 sponge with rate=3, capacity=1, matching Noir stdlib's hasher and
 /// Barretenberg's Poseidon2 sponge. IV = `len * 2^64` placed at the capacity
 /// position; absorb `RATE` field elements per permutation; squeeze `state[0]`.
+/// The empty input still applies the squeeze permutation, returning
+/// `poseidon2_permutation([0, 0, 0, 0], 4)[0]` -- the same convention as the
+/// on-chain sponge, which always permutes before squeezing. That branch is
+/// comptime-dead for every `M >= 1` instantiation, and `poseidon_with_domain`
+/// guarantees `M >= 1` on every reachable path.
 fn sponge<let M: u32>(inputs: [Field; M]) -> Field {
     let iv: Field = (M as Field) * POSEIDON2_IV_BASE;
     let mut state: [Field; 4] = [0, 0, 0, iv];
@@ -192,7 +197,7 @@ fn sponge<let M: u32>(inputs: [Field; M]) -> Field {
     }
 
     let remainder: u32 = M - full * 3;
-    if remainder != 0 {
+    if (remainder != 0) | (M == 0) {
         for i in 0..remainder {
             state[i] += inputs[full * 3 + i];
         }

--- a/packages/tokens/src/confidential/circuits/lib/src/tests.nr
+++ b/packages/tokens/src/confidential/circuits/lib/src/tests.nr
@@ -1,11 +1,11 @@
 use crate::{
     assert_on_curve_non_identity, commit, derive_allow_r, derive_spend_r, derive_tx_blind, domain,
     dvk_from_vk_op, ecdh, encrypt_allowance, encrypt_amount, encrypt_auditor_sender_balance,
-    encrypt_balance, encrypt_esc_dvk, G, H, poseidon_with_domain, pvk_from_vk, scalar_mul,
+    encrypt_balance, encrypt_esc_dvk, G, H, poseidon_with_domain, pvk_from_vk, scalar_mul, sponge,
     sponge_squeeze_2, vk_from_sk,
 };
 use std::embedded_curve_ops::EmbeddedCurvePoint;
-use std::hash::{derive_generators, pedersen_commitment};
+use std::hash::{derive_generators, pedersen_commitment, poseidon2_permutation};
 
 /// Provenance check: reproduces G and H from Barretenberg's `derive_generators`
 /// at run time. If this test fails, the hardcoded constants above have drifted
@@ -196,6 +196,16 @@ fn encrypt_decrypt_round_trip() {
     let b_tilde_aud_s = encrypt_auditor_sender_balance(v, s, sigma);
     let mask_aud_s = poseidon_with_domain(domain::AUDITOR_SENDER, [s, sigma]);
     assert(b_tilde_aud_s - mask_aud_s == v);
+}
+
+#[test]
+fn sponge_empty_input_applies_squeeze_permutation() {
+    // The on-chain sponge always applies the final squeeze permutation, even
+    // over an empty absorb (IV = 0 for length 0). The in-circuit sponge must
+    // agree at the boundary rather than return the initial rate cell (0).
+    let h = sponge::<0>([]);
+    assert(h == poseidon2_permutation([0, 0, 0, 0], 4)[0]);
+    assert(h != 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #772

The in-circuit Poseidon2 `sponge` in `lib.nr` and the on-chain sponge disagreed on the empty input: for `M == 0` the in-circuit version skipped both the block loop and the remainder branch, applying no permutation and returning the initial rate cell `state[0] = 0`, while the on-chain sponge always performs the final squeeze permutation and returns `P(0, 0, 0, 0)[0]` (the IV is also 0 for length 0). For every input of length >= 1 the two already agree.

The inconsistency is latent, not exploitable: `poseidon_with_domain` is the only Poseidon entry point and it always prepends the domain tag, so `sponge` is only ever instantiated with `M >= 1` — no reachable path hashes an empty vector through both layers.

**Fix:** the in-circuit `sponge` now applies the squeeze permutation on the empty input as well (the remainder condition gains `| (M == 0)`), so `sponge::<0>([]) == poseidon2_permutation([0, 0, 0, 0], 4)[0]`, matching the on-chain convention. A new lib test pins this equality (and non-zeroness, as a regression guard against the old behavior).

**Artifact neutrality (verified):** `M` is a comptime generic, so the added branch is constant-folded away for every `M >= 1` instantiation — i.e. for every real circuit. Verified locally with the CI-pinned toolchain (nargo 1.0.0-beta.11, bb 0.87.0):

- `./scripts/extract_vks.sh` regenerated all six VKs **byte-identical** (`git status` clean apart from the two source files);
- `LC_ALL=C nargo info` normalized output diffs **empty** against the committed `constraints.baseline` (file untouched);
- `nargo test` fully green (154 tests across all packages), warning-free.

No testdata JSON fixture is added: the empty input is unreachable from any exported primitive (`poseidon_with_domain` absorbs `N + 1 >= 1` elements), so it is not part of the cross-language contract with the SDK — the in-crate test pinning `sponge::<0>` against the permutation is the boundary check.

Composes cleanly with #778: that PR touches `ecdh` (a disjoint function in the same file) and regenerates VKs/baseline, while this PR intentionally changes no artifacts.

#### PR Checklist

- [x] Tests
- [x] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected empty-input Poseidon2 sponge processing to apply the final permutation, aligning results with on-chain behavior.
  * Ensured empty-input hashing returns the expected non-zero output.

* **Tests**
  * Added coverage verifying the corrected empty-input sponge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->