### PR TITLE
Pin the circuit toolchain and document proving flags (audit N-01, N-05)

### DIFF
--- a/packages/tokens/src/confidential/circuits/gadgets/assert_on_curve/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/gadgets/assert_on_curve/Nargo.toml
@@ -2,7 +2,9 @@
 name = "gadget_assert_on_curve"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../../lib" }

--- a/packages/tokens/src/confidential/circuits/gadgets/commit/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/gadgets/commit/Nargo.toml
@@ -2,7 +2,9 @@
 name = "gadget_commit"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../../lib" }

--- a/packages/tokens/src/confidential/circuits/gadgets/ecdh/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/gadgets/ecdh/Nargo.toml
@@ -2,7 +2,9 @@
 name = "gadget_ecdh"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../../lib" }

--- a/packages/tokens/src/confidential/circuits/gadgets/encrypt_amount/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/gadgets/encrypt_amount/Nargo.toml
@@ -2,7 +2,9 @@
 name = "gadget_encrypt_amount"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../../lib" }

--- a/packages/tokens/src/confidential/circuits/gadgets/poseidon_with_domain/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/gadgets/poseidon_with_domain/Nargo.toml
@@ -2,7 +2,9 @@
 name = "gadget_poseidon_with_domain"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../../lib" }

--- a/packages/tokens/src/confidential/circuits/gadgets/sponge_squeeze_2/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/gadgets/sponge_squeeze_2/Nargo.toml
@@ -2,7 +2,9 @@
 name = "gadget_sponge_squeeze_2"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../../lib" }

--- a/packages/tokens/src/confidential/circuits/gadgets/vk_from_sk/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/gadgets/vk_from_sk/Nargo.toml
@@ -2,7 +2,9 @@
 name = "gadget_vk_from_sk"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../../lib" }

--- a/packages/tokens/src/confidential/circuits/lib/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/lib/Nargo.toml
@@ -2,4 +2,6 @@
 name = "stellar_confidential_lib"
 type = "lib"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"

--- a/packages/tokens/src/confidential/circuits/register/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/register/Nargo.toml
@@ -2,7 +2,9 @@
 name = "circuit_register"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../lib" }

--- a/packages/tokens/src/confidential/circuits/revoke_spender/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/revoke_spender/Nargo.toml
@@ -2,7 +2,9 @@
 name = "circuit_revoke_spender"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../lib" }

--- a/packages/tokens/src/confidential/circuits/set_spender/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/set_spender/Nargo.toml
@@ -2,7 +2,9 @@
 name = "circuit_set_spender"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../lib" }

--- a/packages/tokens/src/confidential/circuits/spender_transfer/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/spender_transfer/Nargo.toml
@@ -2,7 +2,9 @@
 name = "circuit_spender_transfer"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../lib" }

--- a/packages/tokens/src/confidential/circuits/transfer/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/transfer/Nargo.toml
@@ -2,7 +2,9 @@
 name = "circuit_transfer"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../lib" }

--- a/packages/tokens/src/confidential/circuits/vks/README.md
+++ b/packages/tokens/src/confidential/circuits/vks/README.md
@@ -19,6 +19,28 @@ Reproducible from the circuit sources with the pinned toolchain:
 Both versions are pinned in `.github/workflows/noir.yml`. CI re-runs the
 extraction and diffs against the files here; any drift fails the build.
 
+## Proving
+
+Proofs the deployed verifier accepts must be generated with the same
+pinned toolchain and non-default `bb` flags:
+
+```bash
+nargo execute --package circuit_<name> <witness_name>
+bb prove -s ultra_honk --oracle_hash keccak \
+   -b target/circuit_<name>.json -w target/<witness_name>.gz -o <out_dir>
+```
+
+- `--oracle_hash keccak` is required: the on-chain verifier
+  ([rs-soroban-ultrahonk](https://github.com/NethermindEth/rs-soroban-ultrahonk))
+  reproduces the Fiat-Shamir transcript with Keccak, while `bb` defaults to
+  `poseidon2`. A proof generated with the default transcript is rejected.
+- Do **not** pass `--zk`: the verifier currently implements only the non-zk
+  `ultra_flavor`.
+
+The verifier backend is unfinished (see the module-level warning in
+`../../verifier/mod.rs`). This recipe is provisional and will be finalized
+together with the verifier, including the zero-knowledge setting.
+
 ## Regenerating
 
 ```bash

--- a/packages/tokens/src/confidential/circuits/withdraw/Nargo.toml
+++ b/packages/tokens/src/confidential/circuits/withdraw/Nargo.toml
@@ -2,7 +2,9 @@
 name = "circuit_withdraw"
 type = "bin"
 authors = ["OpenZeppelin"]
-compiler_version = ">=0.30.0"
+# Nargo requirements cannot name prereleases; the supported toolchain is
+# nargo 1.0.0-beta.11 + bb 0.87.0, pinned in .github/workflows/noir.yml.
+compiler_version = "=1.0.0"
 
 [dependencies]
 stellar_confidential_lib = { path = "../lib" }


### PR DESCRIPTION
Fixes #781 (audit findings N-01 and N-05).

**N-01:** All 14 circuit manifests declared `compiler_version = ">=0.30.0"`, which newer nargo releases satisfy and then fail to build against (changed stdlib APIs). Nargo requirement strings **cannot name prerelease versions** (`=1.0.0-beta.11` is rejected with "Requirements may only refer to full releases"), so the exact pin the audit suggests is not expressible. This PR uses the tightest expressible bound, `=1.0.0` (nargo's gate ignores prerelease tags, so `1.0.0-beta.11` satisfies it while `0.x` and `1.0.1+` are rejected), and adds a manifest comment stating the exact supported toolchain (`nargo 1.0.0-beta.11` + `bb 0.87.0`) with a pointer to the CI pin in `.github/workflows/noir.yml`.

**N-05:** Adds a provisional **Proving** section to `vks/README.md` documenting the non-default flags a proof must be generated with to match the verifier (`--oracle_hash keccak`, no `--zk`), explicitly marked to be finalized together with the unfinished UltraHonk backend.

Validated locally: `nargo compile --workspace` passes under the pinned `1.0.0-beta.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added provisional instructions for generating proofs compatible with the deployed UltraHonk verifier.
  * Documented required proving options and clarified that zero-knowledge mode is not currently supported.

* **Chores**
  * Standardized confidential circuit builds on the pinned Noir compiler version 1.0.0 for more consistent toolchain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->