### PR TITLE
Rename verifier `vk` identifiers to `verification_key` (audit N-02)

### DIFF
--- a/packages/tokens/src/confidential/compliance/test.rs
+++ b/packages/tokens/src/confidential/compliance/test.rs
@@ -104,7 +104,7 @@ impl crate::confidential::verifier::ConfidentialVerifier for MockVerifier {
     fn register_verification_key(
         _e: &Env,
         _ct: crate::confidential::verifier::CircuitType,
-        _vk: Bytes,
+        _verification_key: Bytes,
         _op: Address,
     ) {
     }
@@ -112,7 +112,7 @@ impl crate::confidential::verifier::ConfidentialVerifier for MockVerifier {
     fn update_verification_key(
         _e: &Env,
         _ct: crate::confidential::verifier::CircuitType,
-        _vk: Bytes,
+        _verification_key: Bytes,
         _op: Address,
     ) {
     }

--- a/packages/tokens/src/confidential/test.rs
+++ b/packages/tokens/src/confidential/test.rs
@@ -75,9 +75,16 @@ struct MockVerifier;
 
 #[contractimpl(contracttrait)]
 impl ConfidentialVerifier for MockVerifier {
-    fn register_verification_key(_e: &Env, _ct: CircuitType, _vk: Bytes, _op: Address) {}
+    fn register_verification_key(
+        _e: &Env,
+        _ct: CircuitType,
+        _verification_key: Bytes,
+        _op: Address,
+    ) {
+    }
 
-    fn update_verification_key(_e: &Env, _ct: CircuitType, _vk: Bytes, _op: Address) {}
+    fn update_verification_key(_e: &Env, _ct: CircuitType, _verification_key: Bytes, _op: Address) {
+    }
 
     fn verify_proof(_e: &Env, _ct: CircuitType, _pi: Bytes, _proof: Bytes) -> bool {
         true
@@ -89,9 +96,16 @@ struct AlwaysFailVerifier;
 
 #[contractimpl(contracttrait)]
 impl ConfidentialVerifier for AlwaysFailVerifier {
-    fn register_verification_key(_e: &Env, _ct: CircuitType, _vk: Bytes, _op: Address) {}
+    fn register_verification_key(
+        _e: &Env,
+        _ct: CircuitType,
+        _verification_key: Bytes,
+        _op: Address,
+    ) {
+    }
 
-    fn update_verification_key(_e: &Env, _ct: CircuitType, _vk: Bytes, _op: Address) {}
+    fn update_verification_key(_e: &Env, _ct: CircuitType, _verification_key: Bytes, _op: Address) {
+    }
 
     fn verify_proof(_e: &Env, _ct: CircuitType, _pi: Bytes, _proof: Bytes) -> bool {
         false

--- a/packages/tokens/src/confidential/verifier/mod.rs
+++ b/packages/tokens/src/confidential/verifier/mod.rs
@@ -127,7 +127,7 @@ pub trait ConfidentialVerifier {
     ///
     /// * `e` - Access to the Soroban environment.
     /// * `circuit_type` - The circuit to register the key under.
-    /// * `vk` - The serialized UltraHonk verification key.
+    /// * `verification_key` - The serialized UltraHonk verification key.
     /// * `operator` - The address authorizing the invocation.
     ///
     /// # Errors
@@ -138,7 +138,7 @@ pub trait ConfidentialVerifier {
     /// # Events
     ///
     /// * topics - `["verification_key_registered", circuit_type: CircuitType]`
-    /// * data - `[vk: Bytes]`
+    /// * data - `[verification_key: Bytes]`
     ///
     /// # Notes
     ///
@@ -146,7 +146,12 @@ pub trait ConfidentialVerifier {
     /// operation that requires custom access control. Access control should
     /// be enforced on `operator` before calling
     /// [`storage::register_verification_key`] for the implementation.
-    fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: Bytes, operator: Address);
+    fn register_verification_key(
+        e: &Env,
+        circuit_type: CircuitType,
+        verification_key: Bytes,
+        operator: Address,
+    );
 
     /// Replaces the UltraHonk verification key registered under `circuit_type`.
     ///
@@ -174,7 +179,8 @@ pub trait ConfidentialVerifier {
     ///
     /// * `e` - Access to the Soroban environment.
     /// * `circuit_type` - The circuit whose key is being updated.
-    /// * `new_vk` - The new serialized UltraHonk verification key.
+    /// * `new_verification_key` - The new serialized UltraHonk verification
+    ///   key.
     /// * `operator` - The address authorizing the invocation.
     ///
     /// # Errors
@@ -185,7 +191,7 @@ pub trait ConfidentialVerifier {
     /// # Events
     ///
     /// * topics - `["verification_key_updated", circuit_type: CircuitType]`
-    /// * data - `[old_vk: Bytes, new_vk: Bytes]`
+    /// * data - `[old_verification_key: Bytes, new_verification_key: Bytes]`
     ///
     /// # Notes
     ///
@@ -196,7 +202,7 @@ pub trait ConfidentialVerifier {
     fn update_verification_key(
         e: &Env,
         circuit_type: CircuitType,
-        new_vk: Bytes,
+        new_verification_key: Bytes,
         operator: Address,
     );
 
@@ -265,7 +271,7 @@ pub enum VerifierError {
 pub struct VerificationKeyRegistered {
     #[topic]
     pub circuit_type: CircuitType,
-    pub vk: Bytes,
+    pub verification_key: Bytes,
 }
 
 /// Emits an event indicating a verification key has been registered.
@@ -274,9 +280,14 @@ pub struct VerificationKeyRegistered {
 ///
 /// * `e` - Access to the Soroban environment.
 /// * `circuit_type` - The circuit the key was registered under.
-/// * `vk` - The serialized UltraHonk verification key.
-pub fn emit_verification_key_registered(e: &Env, circuit_type: CircuitType, vk: &Bytes) {
-    VerificationKeyRegistered { circuit_type, vk: vk.clone() }.publish(e);
+/// * `verification_key` - The serialized UltraHonk verification key.
+pub fn emit_verification_key_registered(
+    e: &Env,
+    circuit_type: CircuitType,
+    verification_key: &Bytes,
+) {
+    VerificationKeyRegistered { circuit_type, verification_key: verification_key.clone() }
+        .publish(e);
 }
 
 /// Event emitted when a verification key is updated.
@@ -285,8 +296,8 @@ pub fn emit_verification_key_registered(e: &Env, circuit_type: CircuitType, vk: 
 pub struct VerificationKeyUpdated {
     #[topic]
     pub circuit_type: CircuitType,
-    pub old_vk: Bytes,
-    pub new_vk: Bytes,
+    pub old_verification_key: Bytes,
+    pub new_verification_key: Bytes,
 }
 
 /// Emits an event indicating a verification key has been updated.
@@ -295,14 +306,18 @@ pub struct VerificationKeyUpdated {
 ///
 /// * `e` - Access to the Soroban environment.
 /// * `circuit_type` - The circuit whose key was updated.
-/// * `old_vk` - The previously registered verification key.
-/// * `new_vk` - The newly registered verification key.
+/// * `old_verification_key` - The previously registered verification key.
+/// * `new_verification_key` - The newly registered verification key.
 pub fn emit_verification_key_updated(
     e: &Env,
     circuit_type: CircuitType,
-    old_vk: &Bytes,
-    new_vk: &Bytes,
+    old_verification_key: &Bytes,
+    new_verification_key: &Bytes,
 ) {
-    VerificationKeyUpdated { circuit_type, old_vk: old_vk.clone(), new_vk: new_vk.clone() }
-        .publish(e);
+    VerificationKeyUpdated {
+        circuit_type,
+        old_verification_key: old_verification_key.clone(),
+        new_verification_key: new_verification_key.clone(),
+    }
+    .publish(e);
 }

--- a/packages/tokens/src/confidential/verifier/storage.rs
+++ b/packages/tokens/src/confidential/verifier/storage.rs
@@ -8,7 +8,7 @@ use crate::confidential::verifier::{
 #[contracttype]
 pub enum VerifierStorageKey {
     /// Maps [`CircuitType`] to its serialized UltraHonk verification key.
-    Vk(CircuitType),
+    VerificationKey(CircuitType),
 }
 
 // ################## QUERY STATE ##################
@@ -27,7 +27,7 @@ pub enum VerifierStorageKey {
 pub fn get_verification_key(e: &Env, circuit_type: CircuitType) -> Bytes {
     e.storage()
         .instance()
-        .get(&VerifierStorageKey::Vk(circuit_type))
+        .get(&VerifierStorageKey::VerificationKey(circuit_type))
         .unwrap_or_else(|| panic_with_error!(e, VerifierError::VerificationKeyNotRegistered))
 }
 
@@ -39,7 +39,7 @@ pub fn get_verification_key(e: &Env, circuit_type: CircuitType) -> Bytes {
 ///
 /// * `e` - Access to the Soroban environment.
 /// * `circuit_type` - The circuit to register the key under.
-/// * `vk` - The serialized UltraHonk verification key.
+/// * `verification_key` - The serialized UltraHonk verification key.
 ///
 /// # Errors
 ///
@@ -49,7 +49,7 @@ pub fn get_verification_key(e: &Env, circuit_type: CircuitType) -> Bytes {
 /// # Events
 ///
 /// * topics - `["verification_key_registered", circuit_type: CircuitType]`
-/// * data - `[vk: Bytes]`
+/// * data - `[verification_key: Bytes]`
 ///
 /// # Security Warning
 ///
@@ -60,14 +60,14 @@ pub fn get_verification_key(e: &Env, circuit_type: CircuitType) -> Bytes {
 ///
 /// Using this function in public-facing methods may create significant
 /// security risks as it could allow unauthorized modifications.
-pub fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: &Bytes) {
-    let key = VerifierStorageKey::Vk(circuit_type);
+pub fn register_verification_key(e: &Env, circuit_type: CircuitType, verification_key: &Bytes) {
+    let key = VerifierStorageKey::VerificationKey(circuit_type);
     if e.storage().instance().has(&key) {
         panic_with_error!(e, VerifierError::VerificationKeyAlreadyRegistered);
     }
 
-    e.storage().instance().set(&key, vk);
-    emit_verification_key_registered(e, circuit_type, vk);
+    e.storage().instance().set(&key, verification_key);
+    emit_verification_key_registered(e, circuit_type, verification_key);
 }
 
 /// Replaces the UltraHonk verification key registered under `circuit_type`.
@@ -78,10 +78,10 @@ pub fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: &Bytes)
 /// treated as an emergency response, not a maintenance task. Concretely:
 ///
 /// - **A wrong VK silently breaks soundness.** This function writes the
-///   `new_vk` bytes verbatim; nothing here checks that they correspond to the
-///   audited circuit. A corrupted, misderived, or maliciously crafted
-///   replacement will happily verify forged proofs — minting tokens, draining
-///   accounts, impersonating registered users.
+///   `new_verification_key` bytes verbatim; nothing here checks that they
+///   correspond to the audited circuit. A corrupted, misderived, or maliciously
+///   crafted replacement will happily verify forged proofs — minting tokens,
+///   draining accounts, impersonating registered users.
 /// - **The update invalidates every in-flight proof for the affected circuit.**
 ///   Any proof generated against the previous VK fails the instant the new VK
 ///   is activated; wallets must regenerate against the new VK and resubmit.
@@ -98,7 +98,7 @@ pub fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: &Bytes)
 ///
 /// * `e` - Access to the Soroban environment.
 /// * `circuit_type` - The circuit whose key is being updated.
-/// * `new_vk` - The new serialized UltraHonk verification key.
+/// * `new_verification_key` - The new serialized UltraHonk verification key.
 ///
 /// # Errors
 ///
@@ -108,7 +108,7 @@ pub fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: &Bytes)
 /// # Events
 ///
 /// * topics - `["verification_key_updated", circuit_type: CircuitType]`
-/// * data - `[old_vk: Bytes, new_vk: Bytes]`
+/// * data - `[old_verification_key: Bytes, new_verification_key: Bytes]`
 ///
 /// # Security Warning
 ///
@@ -119,14 +119,14 @@ pub fn register_verification_key(e: &Env, circuit_type: CircuitType, vk: &Bytes)
 ///
 /// Using this function in public-facing methods may create significant
 /// security risks as it could allow unauthorized modifications.
-pub fn update_verification_key(e: &Env, circuit_type: CircuitType, new_vk: &Bytes) {
-    let key = VerifierStorageKey::Vk(circuit_type);
-    let old_vk: Bytes = e
+pub fn update_verification_key(e: &Env, circuit_type: CircuitType, new_verification_key: &Bytes) {
+    let key = VerifierStorageKey::VerificationKey(circuit_type);
+    let old_verification_key: Bytes = e
         .storage()
         .instance()
         .get(&key)
         .unwrap_or_else(|| panic_with_error!(e, VerifierError::VerificationKeyNotRegistered));
 
-    e.storage().instance().set(&key, new_vk);
-    emit_verification_key_updated(e, circuit_type, &old_vk, new_vk);
+    e.storage().instance().set(&key, new_verification_key);
+    emit_verification_key_updated(e, circuit_type, &old_verification_key, new_verification_key);
 }

--- a/packages/tokens/src/confidential/verifier/test.rs
+++ b/packages/tokens/src/confidential/verifier/test.rs
@@ -13,7 +13,7 @@ use crate::confidential::verifier::{
 #[contract]
 struct MockContract;
 
-fn vk_bytes(e: &Env, seed: u8) -> Bytes {
+fn verification_key_bytes(e: &Env, seed: u8) -> Bytes {
     Bytes::from_array(e, &[seed; 32])
 }
 
@@ -21,12 +21,12 @@ fn vk_bytes(e: &Env, seed: u8) -> Bytes {
 fn register_and_get_verification_key_works() {
     let e = Env::default();
     let address = e.register(MockContract, ());
-    let vk = vk_bytes(&e, 0xab);
+    let verification_key = verification_key_bytes(&e, 0xab);
 
     e.as_contract(&address, || {
-        register_verification_key(&e, CircuitType::Register, &vk);
+        register_verification_key(&e, CircuitType::Register, &verification_key);
 
-        assert_eq!(get_verification_key(&e, CircuitType::Register), vk);
+        assert_eq!(get_verification_key(&e, CircuitType::Register), verification_key);
 
         assert_eq!(e.events().all().events().len(), 1);
     });
@@ -49,9 +49,9 @@ fn register_each_circuit_round_trips() {
         .into_iter()
         .enumerate()
         {
-            let vk = vk_bytes(&e, i as u8);
-            register_verification_key(&e, circuit, &vk);
-            assert_eq!(get_verification_key(&e, circuit), vk);
+            let verification_key = verification_key_bytes(&e, i as u8);
+            register_verification_key(&e, circuit, &verification_key);
+            assert_eq!(get_verification_key(&e, circuit), verification_key);
         }
     });
 }
@@ -63,8 +63,8 @@ fn register_twice_panics_with_already_registered() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        register_verification_key(&e, CircuitType::Withdraw, &vk_bytes(&e, 0x01));
-        register_verification_key(&e, CircuitType::Withdraw, &vk_bytes(&e, 0x02));
+        register_verification_key(&e, CircuitType::Withdraw, &verification_key_bytes(&e, 0x01));
+        register_verification_key(&e, CircuitType::Withdraw, &verification_key_bytes(&e, 0x02));
     });
 }
 
@@ -85,8 +85,8 @@ fn update_verification_key_replaces_in_place() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        let old = vk_bytes(&e, 0x10);
-        let new = vk_bytes(&e, 0x20);
+        let old = verification_key_bytes(&e, 0x10);
+        let new = verification_key_bytes(&e, 0x20);
 
         register_verification_key(&e, CircuitType::Transfer, &old);
         update_verification_key(&e, CircuitType::Transfer, &new);
@@ -102,7 +102,7 @@ fn update_unregistered_panics_with_not_registered() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        update_verification_key(&e, CircuitType::SetSpender, &vk_bytes(&e, 0xff));
+        update_verification_key(&e, CircuitType::SetSpender, &verification_key_bytes(&e, 0xff));
     });
 }
 
@@ -112,8 +112,8 @@ fn update_emits_update_event() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        let old = vk_bytes(&e, 0x10);
-        let new = vk_bytes(&e, 0x20);
+        let old = verification_key_bytes(&e, 0x10);
+        let new = verification_key_bytes(&e, 0x20);
 
         register_verification_key(&e, CircuitType::SpenderTransfer, &old);
         update_verification_key(&e, CircuitType::SpenderTransfer, &new);
@@ -129,14 +129,14 @@ fn storage_key_round_trip() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        let vk = vk_bytes(&e, 0x77);
-        register_verification_key(&e, CircuitType::RevokeSpender, &vk);
+        let verification_key = verification_key_bytes(&e, 0x77);
+        register_verification_key(&e, CircuitType::RevokeSpender, &verification_key);
 
         let stored: Bytes = e
             .storage()
             .instance()
-            .get(&VerifierStorageKey::Vk(CircuitType::RevokeSpender))
+            .get(&VerifierStorageKey::VerificationKey(CircuitType::RevokeSpender))
             .unwrap();
-        assert_eq!(stored, vk);
+        assert_eq!(stored, verification_key);
     });
 }


### PR DESCRIPTION
Fixes #784 (audit finding N-02).

`vk` named two unrelated objects: the per-account viewing-key scalar in the circuits (`vk_from_sk`, `pvk_from_vk`) and the UltraHonk verification key in the verifier registry. The collision sits on the VK-registration path, exactly where conflating the two could mask a verification-key-to-circuit binding gap.

All verifier-side code identifiers now use `verification_key`:

- `register_verification_key` / `update_verification_key` trait and storage params (`vk` → `verification_key`, `new_vk` → `new_verification_key`)
- event fields (`VerificationKeyRegistered.vk`, `VerificationKeyUpdated.{old_vk,new_vk}`) and the emit helpers
- `VerifierStorageKey::Vk` → `VerifierStorageKey::VerificationKey`
- test helper/locals and mock-impl param names

`vk`/`pvk` remain reserved for the viewing key (circuits and `confidential/storage.rs` docstrings are untouched — they already use it correctly). The docs (`vks/README.md`, DESIGN) never used the bare `vk` identifier for the verification key, so no doc changes were needed.

**Wire-format note:** the event field renames and the storage-key variant rename change the emitted event encoding and the VK storage-key encoding. Acceptable pre-production per the module's not-production-ready status.

`cargo +nightly fmt`, `cargo clippy -D warnings`, and `cargo test -p stellar-tokens` (676 passed) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified verification-key naming across confidential verification APIs, events, and storage references.
  * Updated verification-key records and emitted event details for more consistent terminology.

* **Tests**
  * Updated verification-key tests and mock implementations to use the revised terminology.
  * Confirmed verification-key registration, updates, retrieval, and storage behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->