### PR TITLE
ci: make required check report on docs-only PRs

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -48,6 +48,8 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            # `code` is exposed as steps.changes.outputs.code below and is
+            # true whenever any non-markdown file changed.
             code:
               - '!**.md'
 

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -51,7 +51,7 @@ jobs:
             # `code` is exposed as steps.changes.outputs.code below and is
             # true whenever any non-markdown file changed.
             code:
-              - '!**.md'
+              - '!**/*.md'
 
       - name: Run sccache
         if: steps.changes.outputs.code == 'true'

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
   pull_request:
-    paths-ignore:
-      - "**.md"
   workflow_dispatch:
 
 # If new code is pushed to a PR branch, then cancel in progress workflows for
@@ -41,10 +37,26 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v4
 
+      # This job is a required status check, so it must always run (no
+      # workflow-level path filter) to report on every PR — including
+      # markdown-only ones. Otherwise the required check sits forever at
+      # "Expected — waiting for status to be reported" and blocks the merge.
+      # The heavy steps below are gated on an actual code change instead, so
+      # docs-only PRs finish in seconds while still reporting success.
+      - name: Detect code changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '!**.md'
+
       - name: Run sccache
+        if: steps.changes.outputs.code == 'true'
         uses: mozilla-actions/sccache-action@v0.0.8
 
       - name: install rust toolchain
+        if: steps.changes.outputs.code == 'true'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable, nightly
@@ -52,12 +64,15 @@ jobs:
           target: wasm32v1-none
 
       - name: Install cargo-llvm-cov
+        if: steps.changes.outputs.code == 'true'
         run: cargo install cargo-llvm-cov
 
       - name: Check format
+        if: steps.changes.outputs.code == 'true'
         run: cargo +nightly fmt --all -- --check
 
       - name: Check clippy
+        if: steps.changes.outputs.code == 'true'
         run: cargo +stable clippy --release --locked --all-targets -- -D warnings
 
       # TODO: re-enable this after we find a stable solution to same name functions across multiple contracts
@@ -65,9 +80,11 @@ jobs:
       #   run: cargo build --target wasm32v1-none --release
 
       - name: Run tests with coverage
+        if: steps.changes.outputs.code == 'true'
         run: cargo +stable llvm-cov --workspace --lcov --fail-under-lines 90 --output-path lcov.info
 
       - name: Upload coverage to Codecov
+        if: steps.changes.outputs.code == 'true'
         uses: codecov/codecov-action@v3
         with:
           files: ./lcov.info


### PR DESCRIPTION
## Problem

The `main` ruleset requires the `clippy-fmt-test (ubuntu-latest)` status check, but `generic.yml` was configured with `paths-ignore: "**.md"`. On a docs-only PR the "rust workflow" never triggers, so the required check never reports — GitHub leaves it at *"Expected — waiting for status to be reported"* and the PR stays `BLOCKED` forever even when approved. This affects **every** markdown-only PR (e.g. #794).

`workflow_dispatch` is not a workaround: those check runs land on the commit but GitHub does not count them toward a PR's required status checks.

## Fix

- Drop the workflow-level `paths-ignore` so the required `clippy-fmt-test` job **always runs** and always reports.
- Add a `dorny/paths-filter` step that detects whether any non-`.md` file changed, and gate the heavy steps (toolchain install, `cargo-llvm-cov`, fmt, clippy, tests+coverage, codecov upload) on it.

Net effect: docs-only PRs finish in seconds with a green required check; code PRs run the full pipeline exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation to run for all pull request changes.
  * Markdown-only changes now complete faster by skipping unnecessary code quality and coverage checks.
  * Non-documentation changes continue to receive formatting, linting, testing, and coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->