### PR TITLE
cannot remove/change identity with non-zero balance

### DIFF
--- a/examples/rwa/compliance-country-allow/src/test.rs
+++ b/examples/rwa/compliance-country-allow/src/test.rs
@@ -70,10 +70,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/examples/rwa/compliance-country-restrict/src/test.rs
+++ b/examples/rwa/compliance-country-restrict/src/test.rs
@@ -70,10 +70,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/examples/rwa/compliance-max-balance/src/test.rs
+++ b/examples/rwa/compliance-max-balance/src/test.rs
@@ -63,10 +63,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/examples/rwa/compliance-time-transfers-limits/src/test.rs
+++ b/examples/rwa/compliance-time-transfers-limits/src/test.rs
@@ -70,10 +70,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/examples/rwa/compliance/src/contract.rs
+++ b/examples/rwa/compliance/src/contract.rs
@@ -24,10 +24,6 @@ impl ComplianceContract {
     pub fn bind_tokens(e: &Env, tokens: Vec<Address>, operator: Address) {
         binder::bind_tokens(e, &tokens);
     }
-
-    pub fn get_token_index(e: &Env, token: Address) -> u32 {
-        binder::get_token_index(e, &token)
-    }
 }
 
 #[contractimpl(contracttrait)]

--- a/examples/rwa/identity-registry/src/contract.rs
+++ b/examples/rwa/identity-registry/src/contract.rs
@@ -64,11 +64,6 @@ impl IdentityRegistryStorage for IdentityRegistryContract {
     }
 
     #[only_role(operator, "manager")]
-    fn modify_identity(e: &Env, account: Address, new_identity: Address, operator: Address) {
-        identity_storage::modify_identity(e, &account, &new_identity);
-    }
-
-    #[only_role(operator, "manager")]
     fn remove_identity(e: &Env, account: Address, operator: Address) {
         identity_storage::remove_identity(e, &account);
     }

--- a/examples/rwa/identity-registry/src/contract.rs
+++ b/examples/rwa/identity-registry/src/contract.rs
@@ -25,10 +25,6 @@ impl IdentityRegistryContract {
     pub fn bind_tokens(e: &Env, tokens: Vec<Address>, operator: Address) {
         binder::bind_tokens(e, &tokens);
     }
-
-    pub fn get_token_index(e: &Env, token: Address) -> u32 {
-        binder::get_token_index(e, &token)
-    }
 }
 
 #[contractimpl(contracttrait)]

--- a/examples/rwa/identity-registry/src/test.rs
+++ b/examples/rwa/identity-registry/src/test.rs
@@ -1,7 +1,7 @@
 extern crate std;
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
-use stellar_tokens::rwa::utils::token_binder::BUCKET_SIZE;
+use stellar_tokens::rwa::utils::token_binder::MAX_TOKENS;
 
 use crate::contract::{IdentityRegistryContract, IdentityRegistryContractClient};
 
@@ -24,8 +24,8 @@ fn bind_max() {
     let client = create_client(&e, &admin, &manager);
     e.mock_all_auths();
 
-    // The largest batch a single `bind_tokens` call accepts.
-    let max_batch = BUCKET_SIZE * 2;
+    // The full capacity can be bound in a single call.
+    let max_batch = MAX_TOKENS;
     let mut tokens = vec![&e];
     for _ in 0..max_batch {
         let token = Address::generate(&e);

--- a/examples/rwa/identity-registry/src/test.rs
+++ b/examples/rwa/identity-registry/src/test.rs
@@ -1,6 +1,7 @@
 extern crate std;
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use stellar_tokens::rwa::utils::token_binder::BUCKET_SIZE;
 
 use crate::contract::{IdentityRegistryContract, IdentityRegistryContractClient};
 
@@ -23,12 +24,14 @@ fn bind_max() {
     let client = create_client(&e, &admin, &manager);
     e.mock_all_auths();
 
+    // The largest batch a single `bind_tokens` call accepts.
+    let max_batch = BUCKET_SIZE * 2;
     let mut tokens = vec![&e];
-    for _ in 0..200 {
+    for _ in 0..max_batch {
         let token = Address::generate(&e);
         tokens.push_back(token.clone());
     }
 
     client.bind_tokens(&tokens, &manager);
-    assert_eq!(client.linked_tokens().len(), 200)
+    assert_eq!(client.linked_tokens().len(), max_batch)
 }

--- a/packages/tokens/src/rwa/compliance/modules/country_allow/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/country_allow/test.rs
@@ -65,10 +65,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/packages/tokens/src/rwa/compliance/modules/country_restrict/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/country_restrict/test.rs
@@ -65,10 +65,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
@@ -64,10 +64,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/packages/tokens/src/rwa/compliance/modules/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/test.rs
@@ -58,10 +58,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/packages/tokens/src/rwa/compliance/modules/time_transfers_limits/mod.rs
+++ b/packages/tokens/src/rwa/compliance/modules/time_transfers_limits/mod.rs
@@ -33,6 +33,14 @@ use crate::rwa::compliance::modules::ComplianceModule;
 /// not raise the effective cap. Each counter starts with the first
 /// transfer after its window elapsed and resets once the window passes.
 ///
+/// Counters follow the identity, not the wallet. A wallet re-registered
+/// under a different identity (remove and re-add in the registry, allowed
+/// only at zero balance) accrues subsequent transfers against the new
+/// identity's windows, while consumed allowances stay with the old
+/// identity. An identity replacement for the same investor should
+/// therefore wait out open transfer windows, since counters are not
+/// migrated.
+///
 /// Only outgoing transfers are counted and checked. Mints and burns are
 /// exempt, as are forced (admin/recovery) transfers: those are not investor
 /// activity, so they neither consume the window allowance nor get rejected

--- a/packages/tokens/src/rwa/compliance/modules/time_transfers_limits/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/time_transfers_limits/test.rs
@@ -66,10 +66,6 @@ impl IdentityRegistryStorage for MockIRSContract {
         unreachable!("remove_identity is not used in these tests");
     }
 
-    fn modify_identity(_e: &Env, _account: Address, _identity: Address, _operator: Address) {
-        unreachable!("modify_identity is not used in these tests");
-    }
-
     fn recover_identity(
         _e: &Env,
         _old_account: Address,

--- a/packages/tokens/src/rwa/identity_verification/claim_issuer/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/claim_issuer/mod.rs
@@ -19,6 +19,11 @@
 //! The trait is intentionally minimal and unopinionated, allowing maximum
 //! flexibility in implementation.
 //!
+//! Claims are re-validated through this entry point on every identity
+//! verification, so validity is a live answer rather than a stored fact.
+//! Revoking a claim therefore requires no change on the identity contract:
+//! the issuer simply stops validating it.
+//!
 //! ## Verification Schemes
 //!
 //! A claim issuer contract can support one or multiple verification schemes,

--- a/packages/tokens/src/rwa/identity_verification/claim_topics_and_issuers/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/claim_topics_and_issuers/mod.rs
@@ -7,6 +7,12 @@ use soroban_sdk::{contracterror, contractevent, contracttrait, Address, Env, Map
 
 /// Trait for managing claim topics and trusted issuers for RWA tokens.
 ///
+/// This contract is the requirement side of identity verification: it states
+/// which claim topics a holder's identity must carry (for example KYC, AML),
+/// and which claim issuers are trusted to attest each topic. Verification
+/// checks these requirements against the claims found on the holder's
+/// identity contract.
+///
 /// [`ClaimTopicsAndIssuers`] trait is not expected to be an extension to a RWA
 /// smart contract, but it is a separate contract on its own. This design allows
 /// it to be shared across many RWA tokens. Note that, there is no `RWA` bound

--- a/packages/tokens/src/rwa/identity_verification/identity_claims/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_claims/mod.rs
@@ -1,3 +1,27 @@
+//! # Identity Claims Module
+//!
+//! An identity contract is an investor's on-chain persona: one instance,
+//! implementing the [`IdentityClaims`] trait, is deployed per investor, and
+//! the address stored in the identity registry for each of the investor's
+//! wallets points to it. What it stores is claims: attestations signed by
+//! trusted issuers about the identity, such as "KYC passed" or "accredited
+//! investor". Each claim is keyed by `claim_id = hash(issuer, topic)`, so an
+//! issuer holds at most one claim per topic on a given identity.
+//!
+//! Two properties are easy to miss:
+//!
+//! - Claims are bound to the identity contract's address. An issuer validates a
+//!   claim with the identity address as part of the attested payload (see
+//!   [`crate::rwa::identity_verification::storage::validate_claim`]), so claims
+//!   cannot be carried over to another identity contract. Replacing an
+//!   investor's identity contract means re-attestation by every issuer.
+//! - A stored claim proves nothing by itself. Claims are re-validated against
+//!   their issuer on every verification, which is how revocation works without
+//!   touching the identity contract.
+//!
+//! Claim management (`add_claim` / `remove_claim`) carries no default access
+//! control; who may write claims (the identity owner, issuers, a manager) is
+//! deployment-specific.
 mod storage;
 #[cfg(test)]
 mod test;

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
@@ -309,8 +309,8 @@ use soroban_sdk::{contracterror, contractevent, contracttrait, Address, Env, Int
 pub use storage::{
     add_country_data_entries, add_identity, delete_country_data, get_country_data,
     get_country_data_entries, get_identity_profile, get_recovered_to, modify_country_data,
-    modify_identity, recover_identity, remove_identity, stored_identity, validate_country_data,
-    CountryData, CountryRelation, IdentityProfile, IdentityType, IndividualCountryRelation,
+    recover_identity, remove_identity, stored_identity, validate_country_data, CountryData,
+    CountryRelation, IdentityProfile, IdentityType, IndividualCountryRelation,
     OrganizationCountryRelation,
 };
 
@@ -376,30 +376,12 @@ pub trait IdentityRegistryStorage: TokenBinder {
     /// operation that requires custom access control. Access control should be
     /// enforced on `operator` before calling [`remove_identity`] for the
     /// implementation.
+    ///
+    /// The library-provided [`remove_identity`] rejects removal while
+    /// `account` holds a non-zero balance in any linked token, so that
+    /// identity-keyed compliance state is never orphaned; refer to its
+    /// documentation.
     fn remove_identity(e: &Env, account: Address, operator: Address);
-
-    /// Modifies an existing identity.
-    ///
-    /// # Arguments
-    ///
-    /// * `e` - The Soroban environment.
-    /// * `account` - The account address whose identity is being modified.
-    /// * `new_identity` - The new identity address.
-    /// * `operator` - The address authorizing the invocation.
-    ///
-    /// # Events
-    ///
-    /// * topics - `["identity_modified", old_identity: Address, new_identity:
-    ///   Address]`
-    /// * data - `[]`
-    ///
-    /// # Notes
-    ///
-    /// No default implementation is provided because this is a privileged
-    /// operation that requires custom access control. Access control should be
-    /// enforced on `operator` before calling [`modify_identity`] for the
-    /// implementation.
-    fn modify_identity(e: &Env, account: Address, identity: Address, operator: Address);
 
     /// Recovers an identity by transferring it from an old account to a new
     /// account.
@@ -586,6 +568,8 @@ pub enum IRSError {
     MetadataTooManyEntries = 326,
     /// Metadata string value is too long (exceeds MAX_METADATA_STRING_LEN).
     MetadataStringTooLong = 327,
+    /// The account still holds a balance in a linked token.
+    AccountHasBalance = 328,
 }
 
 // ################## CONSTANTS ##################
@@ -652,28 +636,6 @@ pub struct IdentityUnstored {
 /// * `identity` - The identity address that was removed.
 pub fn emit_identity_unstored(e: &Env, account: &Address, identity: &Address) {
     IdentityUnstored { account: account.clone(), identity: identity.clone() }.publish(e);
-}
-
-/// Event emitted when an identity is modified for an account.
-#[contractevent]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct IdentityModified {
-    #[topic]
-    pub old_identity: Address,
-    #[topic]
-    pub new_identity: Address,
-}
-
-/// Emits an event when an identity is modified for an account.
-///
-/// # Arguments
-///
-/// * `e` - The Soroban environment.
-/// * `old_identity` - The previous identity address.
-/// * `new_identity` - The new identity address.
-pub fn emit_identity_modified(e: &Env, old_identity: &Address, new_identity: &Address) {
-    IdentityModified { old_identity: old_identity.clone(), new_identity: new_identity.clone() }
-        .publish(e);
 }
 
 /// Event emitted when an identity is recovered for a new account.

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
@@ -37,7 +37,8 @@
 //!   the pointer is rewritten: neither identity contract is touched, and claims
 //!   do not carry over, since issuer attestations bind to the identity address.
 //!   It exists for replacing a compromised or obsolete identity contract, or
-//!   fixing a mis-registration; the new identity needs its own attestations.
+//!   fixing an erroneous registration; the new identity needs its own
+//!   attestations.
 //! - `remove_identity` deletes a wallet's registration and profile.
 //! - `recover_identity` handles wallet loss: the same identity moves to a new
 //!   wallet, and the old wallet is tombstoned. This is the mirror image of

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
@@ -14,6 +14,42 @@
 //! Instead of simple country codes, it uses a sophisticated model that pairs
 //! relationship types with country codes.
 //!
+//! ## What Is Stored, and For Whom
+//!
+//! Three families of entries are kept, all keyed by the wallet (account)
+//! address:
+//!
+//! - `Identity(wallet) -> Address`: the pointer to the wallet's identity
+//!   contract, an external contract implementing
+//!   [`crate::rwa::identity_verification::identity_claims::IdentityClaims`]
+//!   that holds the investor's claims. Several wallets may point to the same
+//!   identity: the identity represents the investor, the wallets are its keys.
+//! - `IdentityProfile(wallet)`: registry-side metadata, an [`IdentityType`]
+//!   plus the country data entries. This is kept per wallet, not per identity,
+//!   so two wallets of the same investor each carry their own copy.
+//! - `RecoveredTo(old_wallet) -> new_wallet`: a permanent tombstone written by
+//!   account recovery; recovered wallets can never be registered again.
+//!
+//! ## Lifecycle Operations
+//!
+//! - `add_identity` registers a wallet under an identity contract.
+//! - `modify_identity` swaps which identity contract a wallet points to. Only
+//!   the pointer is rewritten: neither identity contract is touched, and claims
+//!   do not carry over, since issuer attestations bind to the identity address.
+//!   It exists for replacing a compromised or obsolete identity contract, or
+//!   fixing a mis-registration; the new identity needs its own attestations.
+//! - `remove_identity` deletes a wallet's registration and profile.
+//! - `recover_identity` handles wallet loss: the same identity moves to a new
+//!   wallet, and the old wallet is tombstoned. This is the mirror image of
+//!   `modify_identity` (same identity, new wallet, instead of same wallet, new
+//!   identity).
+//!
+//! The identity address does double duty downstream: compliance modules key
+//! their per-investor accounting (aggregate balances, transfer counters) by
+//! the resolved identity. Repointing or removing the identity of a wallet
+//! that still holds tokens re-keys that accounting, so these are privileged
+//! operations that must be sequenced with care.
+//!
 //! ## Flexible Country Relations
 //!
 //! The system supports flexible mixing of country relationship types to

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
@@ -33,23 +33,35 @@
 //! ## Lifecycle Operations
 //!
 //! - `add_identity` registers a wallet under an identity contract.
-//! - `modify_identity` swaps which identity contract a wallet points to. Only
-//!   the pointer is rewritten: neither identity contract is touched, and claims
-//!   do not carry over, since issuer attestations bind to the identity address.
-//!   It exists for replacing a compromised or obsolete identity contract, or
-//!   fixing an erroneous registration; the new identity needs its own
-//!   attestations.
-//! - `remove_identity` deletes a wallet's registration and profile.
+//! - `remove_identity` deletes a wallet's registration and profile. It is
+//!   rejected while the wallet still holds a balance in any linked token.
 //! - `recover_identity` handles wallet loss: the same identity moves to a new
-//!   wallet, and the old wallet is tombstoned. This is the mirror image of
-//!   `modify_identity` (same identity, new wallet, instead of same wallet, new
-//!   identity).
+//!   wallet, and the old wallet is tombstoned.
 //!
-//! The identity address does double duty downstream: compliance modules key
-//! their per-investor accounting (aggregate balances, transfer counters) by
-//! the resolved identity. Repointing or removing the identity of a wallet
-//! that still holds tokens re-keys that accounting, so these are privileged
-//! operations that must be sequenced with care.
+//! ## Replacing an Identity
+//!
+//! There is deliberately no in-place pointer swap: ERC-3643's
+//! `updateIdentity` has no equivalent here. The identity address does double
+//! duty downstream: besides locating the claims, it is the key under which
+//! compliance modules aggregate per-investor accounting (aggregate balances,
+//! transfer counters). Swapping the pointer under a funded wallet would
+//! silently re-key that accounting, and would amount to changing the tokens'
+//! beneficial owner without a transfer, bypassing every compliance check. An
+//! in-place swap also would not save anything real: issuer attestations bind
+//! to the identity address, so claims never carry over to a replacement
+//! contract, and re-attestation is required regardless.
+//!
+//! Replacing a wallet's identity contract (compromise, provider migration,
+//! erroneous registration) is therefore a two-step operation on an emptied
+//! wallet: the balance leaves first through regular or forced transfers, so
+//! every token movement passes through the compliance hooks, then
+//! `remove_identity` followed by `add_identity` with the new identity.
+//!
+//! One caveat remains: time-windowed transfer counters are keyed by identity
+//! and are not balance-backed, so re-registration starts fresh windows. That
+//! is correct when the wallet genuinely changes investors; a replacement for
+//! the same investor should wait out open transfer windows, since counters
+//! are not migrated.
 //!
 //! ## Flexible Country Relations
 //!

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/storage.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/storage.rs
@@ -420,10 +420,18 @@ pub fn add_identity(
 ///
 /// # Notes
 ///
-/// One cross-contract `balance` call is made per linked token. The zero
-/// balance check is only as complete as the token binder registry: a token
-/// that resolves identities through this contract without being bound to it
-/// is not checked.
+/// One cross-contract `balance` call is made per linked token; the token
+/// binder's `MAX_TOKENS` cap is sized so this sweep fits within a single
+/// transaction. The zero balance check is only as complete as the token
+/// binder registry: a token that resolves identities through this contract
+/// without being bound to it is not checked.
+///
+/// The check covers balance-backed module state. Time-windowed transfer
+/// counters are flow-based and stay keyed to the old identity: a wallet
+/// re-registered under a new identity starts fresh windows. That is correct
+/// when the wallet genuinely changes investors; an identity replacement for
+/// the same investor should wait out open transfer windows, since counters
+/// are not migrated.
 ///
 /// # Security Warning
 ///

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/storage.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/storage.rs
@@ -125,14 +125,17 @@
 ///   sequence: `recover_identity` must be called before `recovery_balance` to
 ///   ensure identity verification precedes asset transfer.
 use soroban_sdk::{
-    contracttype, panic_with_error, Address, Env, IntoVal, Map, String, Symbol, TryFromVal, Val,
-    Vec,
+    contracttype, panic_with_error, token::TokenClient, Address, Env, IntoVal, Map, String, Symbol,
+    TryFromVal, Val, Vec,
 };
 
-use crate::rwa::identity_verification::identity_registry_storage::{
-    emit_country_data_event, emit_identity_modified, emit_identity_recovered, emit_identity_stored,
-    emit_identity_unstored, CountryDataEvent, IRSError, IDENTITY_EXTEND_AMOUNT,
-    IDENTITY_TTL_THRESHOLD, MAX_COUNTRY_ENTRIES, MAX_METADATA_ENTRIES, MAX_METADATA_STRING_LEN,
+use crate::rwa::{
+    identity_verification::identity_registry_storage::{
+        emit_country_data_event, emit_identity_recovered, emit_identity_stored,
+        emit_identity_unstored, CountryDataEvent, IRSError, IDENTITY_EXTEND_AMOUNT,
+        IDENTITY_TTL_THRESHOLD, MAX_COUNTRY_ENTRIES, MAX_METADATA_ENTRIES, MAX_METADATA_STRING_LEN,
+    },
+    utils::token_binder::linked_tokens,
 };
 
 /// Represents the type of identity holder
@@ -384,46 +387,15 @@ pub fn add_identity(
     }
 }
 
-/// Modifies an existing identity.
-///
-/// # Arguments
-///
-/// * `e` - The Soroban environment.
-/// * `account` - The account address whose identity is being modified.
-/// * `new_identity` - The new identity address.
-///
-/// # Errors
-///
-/// * [`IRSError::IdentityNotFound`] - If no identity is found for the
-///   `account`.
-///
-/// # Events
-///
-/// * topics - `["identity_modified", old_identity: Address, new_identity:
-///   Address]`
-/// * data - `[]`
-///
-/// # Security Warning
-///
-/// **IMPORTANT**: This function bypasses authorization checks and should only
-/// be used:
-/// - During contract initialization/construction
-/// - In admin functions that implement their own authorization logic
-///
-/// Using this function in public-facing methods may create significant security
-/// risks as it could allow unauthorized modifications.
-pub fn modify_identity(e: &Env, account: &Address, new_identity: &Address) {
-    let key = IRSStorageKey::Identity(account.clone());
-
-    let old_identity = get_persistent_entry(e, &key)
-        .unwrap_or_else(|| panic_with_error!(e, IRSError::IdentityNotFound));
-
-    e.storage().persistent().set(&key, new_identity);
-
-    emit_identity_modified(e, &old_identity, new_identity);
-}
-
 /// Removes an identity and all associated country data.
+///
+/// The account must not hold a balance in any linked token. Compliance
+/// modules key their per-investor state (aggregate balances, transfer
+/// counters) by the identity resolved through this registry; removing the
+/// identity of a funded account, and later re-registering the account under
+/// another identity, would orphan that state. A funded account is expected
+/// to be emptied first, through regular or forced transfers, so that every
+/// token movement passes through the compliance hooks.
 ///
 /// # Arguments
 ///
@@ -434,6 +406,8 @@ pub fn modify_identity(e: &Env, account: &Address, new_identity: &Address) {
 ///
 /// * [`IRSError::IdentityNotFound`] - If no identity is found for the
 ///   `account`.
+/// * [`IRSError::AccountHasBalance`] - If `account` holds a non-zero balance in
+///   any linked token.
 ///
 /// # Events
 ///
@@ -443,6 +417,13 @@ pub fn modify_identity(e: &Env, account: &Address, new_identity: &Address) {
 /// Emits for each country data removed:
 /// * topics - `["country_data_removed", account: Address]`
 /// * data - `[country_data: Val]`
+///
+/// # Notes
+///
+/// One cross-contract `balance` call is made per linked token. The zero
+/// balance check is only as complete as the token binder registry: a token
+/// that resolves identities through this contract without being bound to it
+/// is not checked.
 ///
 /// # Security Warning
 ///
@@ -461,6 +442,13 @@ pub fn remove_identity(e: &Env, account: &Address) {
         .persistent()
         .get(&identity_key)
         .unwrap_or_else(|| panic_with_error!(e, IRSError::IdentityNotFound));
+
+    for token in linked_tokens(e).iter() {
+        if TokenClient::new(e, &token).balance(account) != 0 {
+            panic_with_error!(e, IRSError::AccountHasBalance);
+        }
+    }
+
     e.storage().persistent().remove(&identity_key);
 
     emit_identity_unstored(e, account, &identity);

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/test.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/test.rs
@@ -1,24 +1,40 @@
 extern crate std;
 
 use soroban_sdk::{
-    contract,
+    contract, contractimpl,
     testutils::{Address as _, Events},
     vec, Address, Env, FromVal, IntoVal, Map, String, Symbol, Val, Vec,
 };
 
-use crate::rwa::identity_verification::identity_registry_storage::{
-    storage::{
-        add_country_data_entries, add_identity, delete_country_data, get_country_data,
-        get_country_data_entries, get_identity_profile, get_recovered_to, modify_country_data,
-        modify_identity, recover_identity, remove_identity, stored_identity, validate_country_data,
-        CountryData, CountryRelation, IdentityType, IndividualCountryRelation,
-        OrganizationCountryRelation,
+use crate::rwa::{
+    identity_verification::identity_registry_storage::{
+        storage::{
+            add_country_data_entries, add_identity, delete_country_data, get_country_data,
+            get_country_data_entries, get_identity_profile, get_recovered_to, modify_country_data,
+            recover_identity, remove_identity, stored_identity, validate_country_data, CountryData,
+            CountryRelation, IdentityType, IndividualCountryRelation, OrganizationCountryRelation,
+        },
+        MAX_COUNTRY_ENTRIES, MAX_METADATA_ENTRIES, MAX_METADATA_STRING_LEN,
     },
-    MAX_COUNTRY_ENTRIES, MAX_METADATA_ENTRIES, MAX_METADATA_STRING_LEN,
+    utils::token_binder::bind_token,
 };
 
 #[contract]
 struct MockContract;
+
+#[contract]
+struct MockToken;
+
+#[contractimpl]
+impl MockToken {
+    pub fn balance(e: &Env, id: Address) -> i128 {
+        e.storage().instance().get(&id).unwrap_or(0)
+    }
+
+    pub fn set_balance(e: &Env, id: Address, amount: i128) {
+        e.storage().instance().set(&id, &amount);
+    }
+}
 
 #[test]
 fn add_identity_success() {
@@ -81,49 +97,6 @@ fn add_identity_already_exists() {
             IdentityType::Individual,
             &vec![&e, country_data.clone()],
         );
-    });
-}
-
-#[test]
-fn modify_identity_success() {
-    let e = Env::default();
-    let contract_id = e.register(MockContract, ());
-
-    e.as_contract(&contract_id, || {
-        let account = Address::generate(&e);
-        let old_identity = Address::generate(&e);
-        let new_identity = Address::generate(&e);
-        let country_data = CountryData {
-            country: CountryRelation::Individual(IndividualCountryRelation::Residence(840)), // USA
-            metadata: None,
-        };
-
-        add_identity(
-            &e,
-            &account,
-            &old_identity,
-            IdentityType::Individual,
-            &vec![&e, country_data.clone()],
-        );
-        modify_identity(&e, &account, &new_identity);
-
-        assert_eq!(stored_identity(&e, &account), new_identity);
-        // 1 IdentityStored + 1 CountryDataAdded + 1 IdentityModified
-        assert_eq!(e.events().all().events().len(), 3);
-    });
-}
-
-#[test]
-#[should_panic(expected = "Error(Contract, #321)")] // IdentityNotFound
-fn modify_identity_not_found() {
-    let e = Env::default();
-    let contract_id = e.register(MockContract, ());
-
-    e.as_contract(&contract_id, || {
-        let account = Address::generate(&e);
-        let new_identity = Address::generate(&e);
-
-        modify_identity(&e, &account, &new_identity);
     });
 }
 
@@ -206,6 +179,103 @@ fn remove_identity_not_found() {
     e.as_contract(&contract_id, || {
         let account = Address::generate(&e);
         remove_identity(&e, &account);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #328)")] // AccountHasBalance
+fn remove_identity_with_linked_token_balance_panics() {
+    let e = Env::default();
+    let contract_id = e.register(MockContract, ());
+    let token = e.register(MockToken, ());
+
+    let account = Address::generate(&e);
+    let identity = Address::generate(&e);
+    MockTokenClient::new(&e, &token).set_balance(&account, &100);
+
+    e.as_contract(&contract_id, || {
+        let country_data = CountryData {
+            country: CountryRelation::Individual(IndividualCountryRelation::Residence(840)), // USA
+            metadata: None,
+        };
+
+        bind_token(&e, &token);
+        add_identity(
+            &e,
+            &account,
+            &identity,
+            IdentityType::Individual,
+            &vec![&e, country_data.clone()],
+        );
+
+        remove_identity(&e, &account);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #328)")] // AccountHasBalance
+fn remove_identity_checks_every_linked_token() {
+    let e = Env::default();
+    let contract_id = e.register(MockContract, ());
+    let token1 = e.register(MockToken, ());
+    let token2 = e.register(MockToken, ());
+
+    let account = Address::generate(&e);
+    let identity = Address::generate(&e);
+    // Only the second linked token holds a balance for the account.
+    MockTokenClient::new(&e, &token2).set_balance(&account, &1);
+
+    e.as_contract(&contract_id, || {
+        let country_data = CountryData {
+            country: CountryRelation::Individual(IndividualCountryRelation::Residence(840)), // USA
+            metadata: None,
+        };
+
+        bind_token(&e, &token1);
+        bind_token(&e, &token2);
+        add_identity(
+            &e,
+            &account,
+            &identity,
+            IdentityType::Individual,
+            &vec![&e, country_data.clone()],
+        );
+
+        remove_identity(&e, &account);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #321)")] // IdentityNotFound
+fn remove_identity_with_zero_linked_token_balance_succeeds() {
+    let e = Env::default();
+    let contract_id = e.register(MockContract, ());
+    let token = e.register(MockToken, ());
+
+    let account = Address::generate(&e);
+    let identity = Address::generate(&e);
+
+    e.as_contract(&contract_id, || {
+        let country_data = CountryData {
+            country: CountryRelation::Individual(IndividualCountryRelation::Residence(840)), // USA
+            metadata: None,
+        };
+
+        bind_token(&e, &token);
+        add_identity(
+            &e,
+            &account,
+            &identity,
+            IdentityType::Individual,
+            &vec![&e, country_data.clone()],
+        );
+
+        // The account holds no balance in the linked token, so the removal
+        // goes through.
+        remove_identity(&e, &account);
+
+        // The identity is gone (should panic with IdentityNotFound).
+        stored_identity(&e, &account);
     });
 }
 

--- a/packages/tokens/src/rwa/identity_verification/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/mod.rs
@@ -13,6 +13,51 @@
 //! It also provides the `IdentityVerifier` trait for the contract that ties
 //! the full stack together for token checks.
 //!
+//! ## Contract Topology
+//!
+//! In the default claim-based setup, five contracts cooperate, and the
+//! identity data is spread across three of them:
+//!
+//! ```text
+//! RWA Token ──> IdentityVerifier ──> ClaimTopicsAndIssuers    (what is required)
+//!                     │
+//!                     ├──> Identity Registry Storage (IRS)    (who is this wallet)
+//!                     │        wallet ──> identity address
+//!                     │        wallet ──> IdentityProfile
+//!                     │
+//!                     └──> Identity contract (per investor)   (what has been attested)
+//!                              claims, validated against ──> ClaimIssuer contracts
+//! ```
+//!
+//! - **Identity Registry Storage** links each wallet to its identity contract
+//!   and carries registry-side jurisdiction data. One registry is typically
+//!   shared across all tokens of an issuer.
+//! - The **identity contract** (the [`identity_claims`] module) is the
+//!   investor's on-chain persona: one instance per investor, holding the claims
+//!   issued about them. Several wallets may point to the same identity.
+//! - **ClaimTopicsAndIssuers** holds the requirement configuration: the claim
+//!   topics a holder's identity must carry, and the issuers trusted to attest
+//!   each topic.
+//! - **ClaimIssuer** contracts answer `is_claim_valid` live on every check;
+//!   revocation needs no on-chain claim removal, the issuer simply stops
+//!   answering positively.
+//!
+//! ## How a Verification Walks the Graph
+//!
+//! [`storage::verify_identity`] performs the claim-based check invoked on
+//! every token operation:
+//!
+//! 1. The wallet is resolved to its identity contract through the registry.
+//! 2. The required topics and their trusted issuers are read from the claim
+//!    topics and issuers contract.
+//! 3. For each required topic, the identity contract must hold a claim from one
+//!    of the topic's trusted issuers, and that issuer is asked live whether the
+//!    claim is still valid.
+//!
+//! A wallet with no registered identity fails at step 1, so unregistered
+//! wallets can neither send nor receive. Country data is not part of this
+//! baseline check; it is consumed by the compliance country modules instead.
+//!
 //! ## Architecture & Implementation Approaches
 //!
 //! Identity verification systems can be implemented in various ways depending

--- a/packages/tokens/src/rwa/identity_verification/storage.rs
+++ b/packages/tokens/src/rwa/identity_verification/storage.rs
@@ -57,6 +57,11 @@ pub fn identity_registry_storage(e: &Env) -> Address {
 /// Verifies that the identity of an user address has the required valid
 /// claims.
 ///
+/// The account is resolved to its identity contract through the configured
+/// identity registry storage; for every required claim topic, the identity
+/// contract must hold a claim from one of the topic's trusted issuers, and
+/// that issuer is queried live for the claim's validity.
+///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.

--- a/packages/tokens/src/rwa/utils/token_binder/mod.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/mod.rs
@@ -5,8 +5,7 @@ mod test;
 
 use soroban_sdk::{contracterror, contractevent, contracttrait, Address, Env, Vec};
 pub use storage::{
-    bind_token, bind_tokens, get_token_by_index, get_token_index, is_token_bound,
-    linked_token_count, linked_tokens, unbind_token,
+    bind_token, bind_tokens, is_token_bound, linked_token_count, linked_tokens, unbind_token,
 };
 
 /// Trait for managing token bindings to periphery contracts.
@@ -22,9 +21,9 @@ pub use storage::{
 ///
 /// # Storage Pattern
 ///
-/// The underlying storage uses an enumerable pattern for efficiency:
-/// - Tokens are indexed sequentially (0, 1, 2, ...)
-/// - Swap-remove pattern maintains compact storage when unbinding
+/// - All bound token addresses live in a single `Vec<Address>` ledger entry
+/// - Swap-remove pattern keeps the list compact when unbinding, so the list
+///   order is not stable across unbinds
 ///
 /// Note that the storage module also exposes a batch binding helper
 /// `bind_tokens(e, tokens)` which is not part of this trait, so that client
@@ -39,7 +38,7 @@ pub use storage::{
 ///   for the sizing rationale.
 /// - With Protocol 23, reading live Soroban state is inexpensive. Lookups are
 ///   therefore cheap, and storage remains simple with no reverse mapping;
-///   functions like `get_token_index()` linearly scan the list.
+///   membership checks (`is_token_bound()`) linearly scan the list.
 #[contracttrait]
 pub trait TokenBinder {
     /// Returns all currently bound token addresses.

--- a/packages/tokens/src/rwa/utils/token_binder/mod.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/mod.rs
@@ -31,14 +31,15 @@ pub use storage::{
 /// contracts can decide how to expose batch semantics in their own interfaces.
 ///
 /// Implementation notes:
-/// - Token addresses are stored in buckets of 100 addresses each (`BUCKET_SIZE
-///   = 100`).
-/// - Up to 100 buckets are supported (`MAX_BUCKETS = 100`), allowing at most
-///   10,000 tokens bound to a single contract.
-/// - With Protocol 23, reading live Soroban state is inexpensive and read-entry
-///   limits per transaction have been removed. Lookups are therefore cheap, and
-///   storage remains simple with no reverse mapping; functions like
-///   `get_token_index()` linearly scan buckets.
+/// - Token addresses are stored in buckets of 20 addresses each (`BUCKET_SIZE =
+///   20`).
+/// - Up to 5 buckets are supported (`MAX_BUCKETS = 5`), allowing at most 100
+///   tokens bound to a single contract. The cap is deliberately small enough
+///   that a sweep making one cross-contract call per bound token fits in a
+///   single transaction; refer to [`MAX_TOKENS`] for the sizing rationale.
+/// - With Protocol 23, reading live Soroban state is inexpensive. Lookups are
+///   therefore cheap, and storage remains simple with no reverse mapping;
+///   functions like `get_token_index()` linearly scan buckets.
 #[contracttrait]
 pub trait TokenBinder {
     /// Returns all currently bound token addresses.
@@ -109,11 +110,21 @@ pub const TOKEN_BINDER_EXTEND_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
 pub const TOKEN_BINDER_TTL_THRESHOLD: u32 = TOKEN_BINDER_EXTEND_AMOUNT - DAY_IN_LEDGERS;
 
 /// Number of Token addresses in bucket
-pub const BUCKET_SIZE: u32 = 100;
+pub const BUCKET_SIZE: u32 = 20;
 /// Max. number of buckets
-pub const MAX_BUCKETS: u32 = 100;
-/// Max. number of Token addresses
-pub const MAX_TOKENS: u32 = BUCKET_SIZE * MAX_BUCKETS; // 10_000
+pub const MAX_BUCKETS: u32 = 5;
+/// Max. number of Token addresses.
+///
+/// The cap is sized so that operations sweeping every bound token with one
+/// cross-contract call each (such as the identity registry's zero-balance
+/// check on `remove_identity`) fit within a single transaction. The binding
+/// constraint on current Mainnet is the 400 footprint entries allowed per
+/// transaction: each swept token touches up to three distinct entries
+/// (contract instance, contract code, one data entry), so 100 tokens consume
+/// at most ~300 entries and leave room for the caller's own footprint. CPU
+/// stays well within budget at this size. Current limits are listed at
+/// <https://lab.stellar.org/network-limits>.
+pub const MAX_TOKENS: u32 = BUCKET_SIZE * MAX_BUCKETS; // 100
 
 // ################## EVENTS ##################
 

--- a/packages/tokens/src/rwa/utils/token_binder/mod.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/mod.rs
@@ -5,8 +5,8 @@ mod test;
 
 use soroban_sdk::{contracterror, contractevent, contracttrait, Address, Env, Vec};
 pub use storage::{
-    bind_token, bind_tokens, get_token_by_index, get_token_index, is_token_bound, linked_tokens,
-    unbind_token,
+    bind_token, bind_tokens, get_token_by_index, get_token_index, is_token_bound,
+    linked_token_count, linked_tokens, unbind_token,
 };
 
 /// Trait for managing token bindings to periphery contracts.
@@ -31,15 +31,15 @@ pub use storage::{
 /// contracts can decide how to expose batch semantics in their own interfaces.
 ///
 /// Implementation notes:
-/// - Token addresses are stored in buckets of 20 addresses each (`BUCKET_SIZE =
-///   20`).
-/// - Up to 5 buckets are supported (`MAX_BUCKETS = 5`), allowing at most 100
-///   tokens bound to a single contract. The cap is deliberately small enough
-///   that a sweep making one cross-contract call per bound token fits in a
-///   single transaction; refer to [`MAX_TOKENS`] for the sizing rationale.
+/// - All token addresses live in a single `Vec<Address>` ledger entry. At most
+///   [`MAX_TOKENS`] = 100 tokens can be bound to a single contract: the cap is
+///   deliberately small enough that a sweep making one cross-contract call per
+///   bound token fits in a single transaction, and it keeps the whole list a
+///   few kilobytes, far below the per-entry size limit. Refer to [`MAX_TOKENS`]
+///   for the sizing rationale.
 /// - With Protocol 23, reading live Soroban state is inexpensive. Lookups are
 ///   therefore cheap, and storage remains simple with no reverse mapping;
-///   functions like `get_token_index()` linearly scan buckets.
+///   functions like `get_token_index()` linearly scan the list.
 #[contracttrait]
 pub trait TokenBinder {
     /// Returns all currently bound token addresses.
@@ -97,8 +97,6 @@ pub enum TokenBinderError {
     TokenAlreadyBound = 331,
     /// Total token capacity (MAX_TOKENS) has been reached.
     MaxTokensReached = 332,
-    /// Batch bind size exceeded.
-    BindBatchTooLarge = 333,
     /// The batch contains duplicates.
     BindBatchDuplicates = 334,
 }
@@ -109,10 +107,6 @@ const DAY_IN_LEDGERS: u32 = 17280;
 pub const TOKEN_BINDER_EXTEND_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
 pub const TOKEN_BINDER_TTL_THRESHOLD: u32 = TOKEN_BINDER_EXTEND_AMOUNT - DAY_IN_LEDGERS;
 
-/// Number of Token addresses in bucket
-pub const BUCKET_SIZE: u32 = 20;
-/// Max. number of buckets
-pub const MAX_BUCKETS: u32 = 5;
 /// Max. number of Token addresses.
 ///
 /// The cap is sized so that operations sweeping every bound token with one
@@ -124,7 +118,10 @@ pub const MAX_BUCKETS: u32 = 5;
 /// at most ~300 entries and leave room for the caller's own footprint. CPU
 /// stays well within budget at this size. Current limits are listed at
 /// <https://lab.stellar.org/network-limits>.
-pub const MAX_TOKENS: u32 = BUCKET_SIZE * MAX_BUCKETS; // 100
+///
+/// The cap also keeps the whole token list viable as a single ledger entry:
+/// 100 addresses take a few kilobytes, far below the 64 KB per-entry limit.
+pub const MAX_TOKENS: u32 = 100;
 
 // ################## EVENTS ##################
 

--- a/packages/tokens/src/rwa/utils/token_binder/storage.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/storage.rs
@@ -1,27 +1,33 @@
 use soroban_sdk::{contracttype, panic_with_error, Address, Env, Map, TryFromVal, Val, Vec};
 
 use crate::rwa::utils::token_binder::{
-    emit_token_bound, emit_token_unbound, TokenBinderError, BUCKET_SIZE, MAX_TOKENS,
-    TOKEN_BINDER_EXTEND_AMOUNT, TOKEN_BINDER_TTL_THRESHOLD,
+    emit_token_bound, emit_token_unbound, TokenBinderError, MAX_TOKENS, TOKEN_BINDER_EXTEND_AMOUNT,
+    TOKEN_BINDER_TTL_THRESHOLD,
 };
 
 /// Storage keys for the token binder system.
 ///
-/// - Tokens are stored in buckets of 100 addresses each
-/// - Each bucket is a `Vec<Address>` stored under its bucket index
-/// - Total count is tracked separately
-/// - When a token is unbound, the last token is moved to fill the gap
-///   (swap-remove pattern)
+/// All bound token addresses are kept in a single `Vec<Address>` entry. With
+/// the capacity capped at [`MAX_TOKENS`], the full list stays a few kilobytes,
+/// far below the ledger's per-entry size limit. When a token is unbound, the
+/// last token is moved to fill the gap (swap-remove pattern).
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TokenBinderStorageKey {
-    /// Maps bucket index to a vector of token addresses (max 100 per bucket)
-    TokenBucket(u32),
-    /// Total count of bound tokens
-    TotalCount,
+    /// The list of all bound token addresses.
+    Tokens,
 }
 
 // ################## QUERY STATE ##################
+
+/// Returns all currently bound token addresses in order.
+///
+/// # Arguments
+///
+/// * `e` - The Soroban environment.
+pub fn linked_tokens(e: &Env) -> Vec<Address> {
+    get_persistent_entry(e, &TokenBinderStorageKey::Tokens).unwrap_or_else(|| Vec::new(e))
+}
 
 /// Returns the total number of tokens currently bound to this contract.
 ///
@@ -29,10 +35,10 @@ pub enum TokenBinderStorageKey {
 ///
 /// * `e` - The Soroban environment.
 pub fn linked_token_count(e: &Env) -> u32 {
-    get_persistent_entry(e, &TokenBinderStorageKey::TotalCount).unwrap_or(0)
+    linked_tokens(e).len()
 }
 
-/// Returns a token address by its global index.
+/// Returns a token address by its index.
 ///
 /// # Arguments
 ///
@@ -43,22 +49,12 @@ pub fn linked_token_count(e: &Env) -> u32 {
 ///
 /// * [`TokenBinderError::TokenNotFound`] - If `index` is out of bounds.
 pub fn get_token_by_index(e: &Env, index: u32) -> Address {
-    let count = linked_token_count(e);
-    if index >= count {
-        panic_with_error!(e, TokenBinderError::TokenNotFound)
-    }
-
-    let bucket_index = index / BUCKET_SIZE;
-    let offset_in_bucket = index % BUCKET_SIZE;
-
-    let bucket: Vec<Address> =
-        get_persistent_entry(e, &TokenBinderStorageKey::TokenBucket(bucket_index))
-            .expect("bucket to be present");
-
-    bucket.get(offset_in_bucket).expect("value in bucket to be present")
+    linked_tokens(e)
+        .get(index)
+        .unwrap_or_else(|| panic_with_error!(e, TokenBinderError::TokenNotFound))
 }
 
-/// Returns the global index of a bound token address.
+/// Returns the index of a bound token address.
 ///
 /// # Arguments
 ///
@@ -71,24 +67,11 @@ pub fn get_token_by_index(e: &Env, index: u32) -> Address {
 ///
 /// # Notes
 ///
-/// Performs a linear scan across all buckets. With Protocol 23, live state
-/// reads are inexpensive and read-entry limits have been removed.
+/// Performs a linear scan of the token list.
 pub fn get_token_index(e: &Env, token: &Address) -> u32 {
-    let count = linked_token_count(e);
-    if count == 0 {
-        panic_with_error!(e, TokenBinderError::TokenNotFound)
-    }
-    let last_bucket = (count - 1) / BUCKET_SIZE;
-    for bucket_idx in 0..=last_bucket {
-        let bucket: Vec<Address> =
-            get_persistent_entry(e, &TokenBinderStorageKey::TokenBucket(bucket_idx))
-                .unwrap_or_else(|| Vec::new(e));
-
-        if let Some(relative_index) = bucket.first_index_of(token) {
-            return bucket_idx * BUCKET_SIZE + relative_index;
-        }
-    }
-    panic_with_error!(e, TokenBinderError::TokenNotFound)
+    linked_tokens(e)
+        .first_index_of(token)
+        .unwrap_or_else(|| panic_with_error!(e, TokenBinderError::TokenNotFound))
 }
 
 /// Checks whether a token address is currently bound.
@@ -100,47 +83,9 @@ pub fn get_token_index(e: &Env, token: &Address) -> u32 {
 ///
 /// # Notes
 ///
-/// Performs a linear scan across all buckets.
+/// Performs a linear scan of the token list.
 pub fn is_token_bound(e: &Env, token: &Address) -> bool {
-    let count = linked_token_count(e);
-    if count == 0 {
-        return false;
-    }
-    let last_bucket = (count - 1) / BUCKET_SIZE;
-    for bucket_idx in 0..=last_bucket {
-        let bucket: Vec<Address> =
-            get_persistent_entry(e, &TokenBinderStorageKey::TokenBucket(bucket_idx))
-                .unwrap_or_else(|| Vec::new(e));
-        if bucket.contains(token.clone()) {
-            return true;
-        }
-    }
-    false
-}
-
-/// Returns all currently bound token addresses in order.
-///
-/// # Arguments
-///
-/// * `e` - The Soroban environment.
-pub fn linked_tokens(e: &Env) -> Vec<Address> {
-    let count = linked_token_count(e);
-    let mut tokens = Vec::new(e);
-
-    if count == 0 {
-        return tokens;
-    }
-
-    let last_bucket = (count - 1) / BUCKET_SIZE;
-    for bucket_idx in 0..=last_bucket {
-        let bucket: Vec<Address> =
-            get_persistent_entry(e, &TokenBinderStorageKey::TokenBucket(bucket_idx))
-                .unwrap_or_else(|| Vec::new(e));
-
-        tokens.append(&bucket);
-    }
-
-    tokens
+    linked_tokens(e).contains(token.clone())
 }
 
 // ################## CHANGE STATE ##################
@@ -174,33 +119,24 @@ pub fn linked_tokens(e: &Env) -> Vec<Address> {
 /// Using this function in public-facing methods may create significant security
 /// risks as it could allow unauthorized modifications.
 pub fn bind_token(e: &Env, token: &Address) {
-    if is_token_bound(e, token) {
+    let mut tokens = linked_tokens(e);
+    if tokens.contains(token.clone()) {
         panic_with_error!(e, TokenBinderError::TokenAlreadyBound)
     }
-
-    let mut count = linked_token_count(e);
-    if count >= MAX_TOKENS {
+    if tokens.len() >= MAX_TOKENS {
         panic_with_error!(e, TokenBinderError::MaxTokensReached)
     }
 
-    let bucket_index = count / BUCKET_SIZE;
-    let key = TokenBinderStorageKey::TokenBucket(bucket_index);
-    let mut bucket: Vec<Address> =
-        e.storage().persistent().get(&key).unwrap_or_else(|| Vec::new(e));
-
-    bucket.push_back(token.clone());
-    e.storage().persistent().set(&key, &bucket);
-
-    count += 1;
-    e.storage().persistent().set(&TokenBinderStorageKey::TotalCount, &count);
+    tokens.push_back(token.clone());
+    e.storage().persistent().set(&TokenBinderStorageKey::Tokens, &tokens);
 
     emit_token_bound(e, token);
 }
 
 /// Binds multiple token addresses to the contract in a single batch.
 ///
-/// Tokens are appended in order across buckets, spilling into up to 3 buckets
-/// as the max. batch size is BUCKET_SIZE * 2.
+/// The batch is appended in order; capacity is bounded by [`MAX_TOKENS`], so
+/// a single call can bind up to the full remaining capacity.
 ///
 /// # Arguments
 ///
@@ -209,8 +145,6 @@ pub fn bind_token(e: &Env, token: &Address) {
 ///
 /// # Errors
 ///
-/// * [`TokenBinderError::BindBatchTooLarge`] - If the batch size exceeds the
-///   allowed limit.
 /// * [`TokenBinderError::MaxTokensReached`] - If capacity is exceeded.
 /// * [`TokenBinderError::BindBatchDuplicates`] - If the batch contains
 ///   duplicate addresses.
@@ -233,21 +167,14 @@ pub fn bind_token(e: &Env, token: &Address) {
 /// Using this function in public-facing methods may create significant security
 /// risks as it could allow unauthorized modifications.
 pub fn bind_tokens(e: &Env, tokens: &Vec<Address>) {
-    let mut count = linked_token_count(e);
-
-    // Enforce batch size and capacity to avoid running out of resources:
-    // max. BUCKET_SIZE * 2 tokens allowed in a batch.
-    if tokens.len() > BUCKET_SIZE * 2 {
-        panic_with_error!(e, TokenBinderError::BindBatchTooLarge)
-    }
-    if count + tokens.len() > MAX_TOKENS {
+    let mut bound = linked_tokens(e);
+    if bound.len() + tokens.len() > MAX_TOKENS {
         panic_with_error!(e, TokenBinderError::MaxTokensReached)
     }
 
     // Check for duplicates using Map for O(n) complexity instead of O(n²)
     let mut seen = Map::<Address, ()>::new(e);
-    for i in 0..tokens.len() {
-        let token = tokens.get_unchecked(i);
+    for token in tokens.iter() {
         if seen.contains_key(token.clone()) {
             panic_with_error!(e, TokenBinderError::BindBatchDuplicates)
         }
@@ -255,42 +182,20 @@ pub fn bind_tokens(e: &Env, tokens: &Vec<Address>) {
     }
 
     // Build a Map of already-bound tokens for O(1) lookups instead of O(n)
-    let already_bound = linked_tokens(e);
     let mut bound_map = Map::<Address, ()>::new(e);
-    for i in 0..already_bound.len() {
-        bound_map.set(already_bound.get_unchecked(i), ());
+    for token in bound.iter() {
+        bound_map.set(token, ());
     }
 
-    // Fill buckets sequentially until all tokens are stored.
-    let mut i: u32 = 0;
-    while i < tokens.len() {
-        let bucket_index = count / BUCKET_SIZE;
-        let key = TokenBinderStorageKey::TokenBucket(bucket_index);
-        let mut bucket: Vec<Address> =
-            e.storage().persistent().get(&key).unwrap_or_else(|| Vec::new(e));
-
-        // Capacity left in this bucket
-        let used = bucket.len();
-        let remaining = BUCKET_SIZE - used;
-        let to_take = core::cmp::min(remaining, tokens.len() - i);
-        let end = i + to_take;
-
-        while i < end {
-            let token = tokens.get(i).expect("value to be present");
-            if bound_map.contains_key(token.clone()) {
-                panic_with_error!(e, TokenBinderError::TokenAlreadyBound)
-            }
-            bucket.push_back(token.clone());
-            emit_token_bound(e, &token);
-            i += 1;
-            count += 1;
+    for token in tokens.iter() {
+        if bound_map.contains_key(token.clone()) {
+            panic_with_error!(e, TokenBinderError::TokenAlreadyBound)
         }
-
-        // Persist this bucket once per fill
-        e.storage().persistent().set(&key, &bucket);
+        bound.push_back(token.clone());
+        emit_token_bound(e, &token);
     }
 
-    e.storage().persistent().set(&TokenBinderStorageKey::TotalCount, &count);
+    e.storage().persistent().set(&TokenBinderStorageKey::Tokens, &bound);
 }
 
 /// Unbinds a single token address from the contract.
@@ -323,38 +228,23 @@ pub fn bind_tokens(e: &Env, tokens: &Vec<Address>) {
 /// Using this function in public-facing methods may create significant security
 /// risks as it could allow unauthorized modifications.
 pub fn unbind_token(e: &Env, token: &Address) {
-    let token_index = get_token_index(e, token);
+    let mut tokens = linked_tokens(e);
+    let index = tokens
+        .first_index_of(token)
+        .unwrap_or_else(|| panic_with_error!(e, TokenBinderError::TokenNotFound));
 
-    let count = linked_token_count(e);
+    // Can't overflow because `first_index_of` would have returned `None` on
+    // an empty list
+    let last_index = tokens.len() - 1;
 
-    // Can't overflow because `get_token_index()` would panic if count == 0
-    let last_index = count - 1;
-
-    if token_index != last_index {
-        let last_token = get_token_by_index(e, last_index);
-
+    if index != last_index {
         // Overwrite the removed slot with the last token
-        let token_bucket_index = token_index / BUCKET_SIZE;
-        let token_offset = token_index % BUCKET_SIZE;
-        let token_key = TokenBinderStorageKey::TokenBucket(token_bucket_index);
-        let mut token_bucket: Vec<Address> =
-            e.storage().persistent().get(&token_key).unwrap_or_else(|| Vec::new(e));
-        token_bucket.set(token_offset, last_token.clone());
-        e.storage().persistent().set(&token_key, &token_bucket);
+        let last_token = tokens.get_unchecked(last_index);
+        tokens.set(index, last_token);
     }
+    tokens.pop_back();
 
-    // Remove the last token from its bucket
-    let last_bucket_index = last_index / BUCKET_SIZE;
-    let last_key = TokenBinderStorageKey::TokenBucket(last_bucket_index);
-    let mut last_bucket: Vec<Address> =
-        e.storage().persistent().get(&last_key).unwrap_or_else(|| Vec::new(e));
-    // if empty pop_back returns None
-    last_bucket.pop_back();
-
-    e.storage().persistent().set(&last_key, &last_bucket);
-
-    // Update total count
-    e.storage().persistent().set(&TokenBinderStorageKey::TotalCount, &last_index);
+    e.storage().persistent().set(&TokenBinderStorageKey::Tokens, &tokens);
 
     emit_token_unbound(e, token);
 }

--- a/packages/tokens/src/rwa/utils/token_binder/storage.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/storage.rs
@@ -38,42 +38,6 @@ pub fn linked_token_count(e: &Env) -> u32 {
     linked_tokens(e).len()
 }
 
-/// Returns a token address by its index.
-///
-/// # Arguments
-///
-/// * `e` - The Soroban environment.
-/// * `index` - The index of the token to retrieve.
-///
-/// # Errors
-///
-/// * [`TokenBinderError::TokenNotFound`] - If `index` is out of bounds.
-pub fn get_token_by_index(e: &Env, index: u32) -> Address {
-    linked_tokens(e)
-        .get(index)
-        .unwrap_or_else(|| panic_with_error!(e, TokenBinderError::TokenNotFound))
-}
-
-/// Returns the index of a bound token address.
-///
-/// # Arguments
-///
-/// * `e` - The Soroban environment.
-/// * `token` - The token address to look up.
-///
-/// # Errors
-///
-/// * [`TokenBinderError::TokenNotFound`] - If the token is not currently bound.
-///
-/// # Notes
-///
-/// Performs a linear scan of the token list.
-pub fn get_token_index(e: &Env, token: &Address) -> u32 {
-    linked_tokens(e)
-        .first_index_of(token)
-        .unwrap_or_else(|| panic_with_error!(e, TokenBinderError::TokenNotFound))
-}
-
 /// Checks whether a token address is currently bound.
 ///
 /// # Arguments

--- a/packages/tokens/src/rwa/utils/token_binder/test.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/test.rs
@@ -3,13 +3,13 @@ extern crate std;
 use soroban_sdk::{
     contract,
     testutils::{Address as _, Events},
-    Address, Env, Vec,
+    vec, Address, Env, Vec,
 };
 
 use crate::rwa::utils::token_binder::{
     storage::{
-        bind_token, bind_tokens, get_token_by_index, get_token_index, is_token_bound,
-        linked_token_count, linked_tokens, unbind_token, TokenBinderStorageKey,
+        bind_token, bind_tokens, is_token_bound, linked_token_count, linked_tokens, unbind_token,
+        TokenBinderStorageKey,
     },
     MAX_TOKENS,
 };
@@ -61,10 +61,7 @@ fn bind_tokens_appends_in_order() {
         bind_tokens(&e, &batch);
 
         // verify
-        assert_eq!(linked_token_count(&e), 10);
-        for i in 0..10u32 {
-            assert_eq!(get_token_by_index(&e, i), batch.get(i).unwrap());
-        }
+        assert_eq!(linked_tokens(&e), batch);
         // one TokenBound per token
         assert_eq!(e.events().all().events().len(), 10);
 
@@ -90,8 +87,7 @@ fn bind_tokens_full_capacity_in_one_call() {
         bind_tokens(&e, &batch);
 
         assert_eq!(linked_token_count(&e), MAX_TOKENS);
-        assert_eq!(get_token_by_index(&e, 0), batch.get(0).unwrap());
-        assert_eq!(get_token_by_index(&e, MAX_TOKENS - 1), batch.get(MAX_TOKENS - 1).unwrap());
+        assert_eq!(linked_tokens(&e), batch);
         assert!(is_token_bound(&e, &batch.get(MAX_TOKENS / 2).unwrap()));
     });
 }
@@ -125,8 +121,7 @@ fn bind_single_token() {
 
         assert_eq!(linked_token_count(&e), 1);
         assert!(is_token_bound(&e, &token));
-        assert_eq!(get_token_by_index(&e, 0), token);
-        assert_eq!(get_token_index(&e, &token), 0);
+        assert_eq!(linked_tokens(&e), vec![&e, token.clone()]);
         assert_eq!(e.events().all().events().len(), 1);
     });
 }
@@ -149,13 +144,7 @@ fn bind_multiple_tokens() {
         assert!(is_token_bound(&e, &token2));
         assert!(is_token_bound(&e, &token3));
 
-        assert_eq!(get_token_by_index(&e, 0), token1);
-        assert_eq!(get_token_by_index(&e, 1), token2);
-        assert_eq!(get_token_by_index(&e, 2), token3);
-
-        assert_eq!(get_token_index(&e, &token1), 0);
-        assert_eq!(get_token_index(&e, &token2), 1);
-        assert_eq!(get_token_index(&e, &token3), 2);
+        assert_eq!(linked_tokens(&e), vec![&e, token1.clone(), token2.clone(), token3.clone()]);
     });
 }
 
@@ -210,11 +199,8 @@ fn unbind_middle_token_swap_remove() {
         assert!(!is_token_bound(&e, &token2));
         assert!(is_token_bound(&e, &token3));
 
-        assert_eq!(get_token_by_index(&e, 0), token1);
-        assert_eq!(get_token_by_index(&e, 1), token3);
-
-        assert_eq!(get_token_index(&e, &token1), 0);
-        assert_eq!(get_token_index(&e, &token3), 1);
+        // The last token (token3) filled the removed slot
+        assert_eq!(linked_tokens(&e), vec![&e, token1.clone(), token3.clone()]);
     });
 }
 
@@ -238,8 +224,7 @@ fn unbind_last_token() {
         assert!(is_token_bound(&e, &token2));
         assert!(!is_token_bound(&e, &token3));
 
-        assert_eq!(get_token_by_index(&e, 0), token1);
-        assert_eq!(get_token_by_index(&e, 1), token2);
+        assert_eq!(linked_tokens(&e), vec![&e, token1.clone(), token2.clone()]);
     });
 }
 
@@ -252,29 +237,6 @@ fn unbind_nonexistent_token() {
 
     e.as_contract(&address, || {
         unbind_token(&e, &token);
-    });
-}
-
-#[test]
-#[should_panic(expected = "Error(Contract, #330)")]
-fn get_token_by_invalid_index() {
-    let e = Env::default();
-    let address = e.register(MockContract, ());
-
-    e.as_contract(&address, || {
-        get_token_by_index(&e, 0);
-    });
-}
-
-#[test]
-#[should_panic(expected = "Error(Contract, #330)")]
-fn get_token_index_nonexistent() {
-    let e = Env::default();
-    let address = e.register(MockContract, ());
-    let token = Address::generate(&e);
-
-    e.as_contract(&address, || {
-        get_token_index(&e, &token);
     });
 }
 
@@ -337,18 +299,14 @@ fn complex_bind_unbind_sequence() {
         assert_eq!(linked_token_count(&e), 3);
 
         unbind_token(&e, &token2);
-        assert_eq!(linked_token_count(&e), 2);
-        assert_eq!(get_token_by_index(&e, 0), token1);
-        assert_eq!(get_token_by_index(&e, 1), token3);
+        assert_eq!(linked_tokens(&e), vec![&e, token1.clone(), token3.clone()]);
 
         bind_token(&e, &token4);
-        assert_eq!(linked_token_count(&e), 3);
-        assert_eq!(get_token_by_index(&e, 2), token4);
+        assert_eq!(linked_tokens(&e), vec![&e, token1.clone(), token3.clone(), token4.clone()]);
 
         unbind_token(&e, &token1);
-        assert_eq!(linked_token_count(&e), 2);
-        assert_eq!(get_token_by_index(&e, 0), token4);
-        assert_eq!(get_token_by_index(&e, 1), token3);
+        // The last token (token4) filled the removed slot
+        assert_eq!(linked_tokens(&e), vec![&e, token4.clone(), token3.clone()]);
     });
 }
 
@@ -386,15 +344,13 @@ fn rebind_after_unbind() {
     e.as_contract(&address, || {
         bind_token(&e, &token);
         assert!(is_token_bound(&e, &token));
-        assert_eq!(get_token_index(&e, &token), 0);
 
         unbind_token(&e, &token);
         assert!(!is_token_bound(&e, &token));
 
         bind_token(&e, &token);
         assert!(is_token_bound(&e, &token));
-        assert_eq!(get_token_index(&e, &token), 0);
-        assert_eq!(linked_token_count(&e), 1);
+        assert_eq!(linked_tokens(&e), vec![&e, token.clone()]);
     });
 }
 
@@ -456,9 +412,8 @@ fn bind_tokens_appends_after_existing() {
         }
         bind_tokens(&e, &batch);
 
-        assert_eq!(linked_token_count(&e), 15);
-        for i in 0..10u32 {
-            assert_eq!(get_token_by_index(&e, 5 + i), batch.get(i).unwrap());
-        }
+        let all = linked_tokens(&e);
+        assert_eq!(all.len(), 15);
+        assert_eq!(all.slice(5..), batch);
     });
 }

--- a/packages/tokens/src/rwa/utils/token_binder/test.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/test.rs
@@ -77,11 +77,11 @@ fn bind_tokens_splits_across_two_buckets() {
 
     e.as_contract(&address, || {
         // Pre-fill current bucket to BUCKET_SIZE - 5
-        for _ in 0..95u32 {
+        for _ in 0..(BUCKET_SIZE - 5) {
             let t = Address::generate(&e);
             bind_token(&e, &t);
         }
-        assert_eq!(linked_token_count(&e), 95);
+        assert_eq!(linked_token_count(&e), BUCKET_SIZE - 5);
 
         // Now bind a batch of 10 which should split: 5 in current, 5 in next
         let mut batch: Vec<Address> = Vec::new(&e);
@@ -92,19 +92,19 @@ fn bind_tokens_splits_across_two_buckets() {
         bind_tokens(&e, &batch);
 
         // Validate counts
-        assert_eq!(linked_token_count(&e), 105);
+        assert_eq!(linked_token_count(&e), BUCKET_SIZE + 5);
 
-        // First 5 go at indices 95..99 (current bucket), next 5 at 100..104 (next
-        // bucket)
+        // First 5 go at the end of the current bucket, next 5 at the start of
+        // the next bucket
         for i in 0..10u32 {
-            assert_eq!(get_token_by_index(&e, 95 + i), batch.get(i).unwrap());
+            assert_eq!(get_token_by_index(&e, BUCKET_SIZE - 5 + i), batch.get(i).unwrap());
         }
 
         // Spot-check full list end ordering
         let all = linked_tokens(&e);
-        assert_eq!(all.len(), 105);
+        assert_eq!(all.len(), BUCKET_SIZE + 5);
         for i in 0..10u32 {
-            assert_eq!(all.get(95 + i).unwrap(), batch.get(i).unwrap());
+            assert_eq!(all.get(BUCKET_SIZE - 5 + i).unwrap(), batch.get(i).unwrap());
         }
     });
 }
@@ -418,33 +418,38 @@ fn bind_tokens_spill_across_three_buckets() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        // Pre-fill 50 tokens in current bucket
-        for _ in 0..50u32 {
+        // Pre-fill half of the current bucket
+        let half = BUCKET_SIZE / 2;
+        for _ in 0..half {
             bind_token(&e, &Address::generate(&e));
         }
-        assert_eq!(linked_token_count(&e), 50);
+        assert_eq!(linked_token_count(&e), half);
 
-        // Batch of 200 should fill: 50 in current, 100 in next, 50 in third
+        // A batch of BUCKET_SIZE * 2 should fill: half in current, a full
+        // bucket in the next, and the remaining half in a third
         let mut batch: Vec<Address> = Vec::new(&e);
-        for _ in 0..200u32 {
+        for _ in 0..(BUCKET_SIZE * 2) {
             batch.push_back(Address::generate(&e));
         }
 
         bind_tokens(&e, &batch);
 
-        assert_eq!(linked_token_count(&e), 250);
+        assert_eq!(linked_token_count(&e), half + BUCKET_SIZE * 2);
 
-        // First 50 of batch at indices 50..99
-        for i in 0..50u32 {
-            assert_eq!(get_token_by_index(&e, 50 + i), batch.get(i).unwrap());
+        // First half of batch fills the current bucket
+        for i in 0..half {
+            assert_eq!(get_token_by_index(&e, half + i), batch.get(i).unwrap());
         }
-        // Next 100 of batch at indices 100..199
-        for i in 0..100u32 {
-            assert_eq!(get_token_by_index(&e, 100 + i), batch.get(50 + i).unwrap());
+        // Next full bucket of batch lands in the second bucket
+        for i in 0..BUCKET_SIZE {
+            assert_eq!(get_token_by_index(&e, BUCKET_SIZE + i), batch.get(half + i).unwrap());
         }
-        // Last 50 of batch at indices 200..249
-        for i in 0..50u32 {
-            assert_eq!(get_token_by_index(&e, 200 + i), batch.get(150 + i).unwrap());
+        // Remaining half of batch lands in the third bucket
+        for i in 0..half {
+            assert_eq!(
+                get_token_by_index(&e, BUCKET_SIZE * 2 + i),
+                batch.get(BUCKET_SIZE + half + i).unwrap()
+            );
         }
     });
 }

--- a/packages/tokens/src/rwa/utils/token_binder/test.rs
+++ b/packages/tokens/src/rwa/utils/token_binder/test.rs
@@ -11,7 +11,7 @@ use crate::rwa::utils::token_binder::{
         bind_token, bind_tokens, get_token_by_index, get_token_index, is_token_bound,
         linked_token_count, linked_tokens, unbind_token, TokenBinderStorageKey,
     },
-    BUCKET_SIZE, MAX_TOKENS,
+    MAX_TOKENS,
 };
 
 #[contract]
@@ -35,7 +35,12 @@ fn bind_token_max_tokens_reached() {
     e.cost_estimate().disable_resource_limits();
     let address = e.register(MockContract, ());
     e.as_contract(&address, || {
-        e.storage().persistent().set(&TokenBinderStorageKey::TotalCount, &MAX_TOKENS);
+        let mut tokens: Vec<Address> = Vec::new(&e);
+        for _ in 0..MAX_TOKENS {
+            tokens.push_back(Address::generate(&e));
+        }
+        e.storage().persistent().set(&TokenBinderStorageKey::Tokens, &tokens);
+
         // Next bind should panic with MaxTokensReached
         let extra = Address::generate(&e);
         bind_token(&e, &extra);
@@ -43,12 +48,11 @@ fn bind_token_max_tokens_reached() {
 }
 
 #[test]
-fn bind_tokens_fits_current_bucket() {
+fn bind_tokens_appends_in_order() {
     let e = Env::default();
     let address = e.register(MockContract, ());
 
     let tokens = e.as_contract(&address, || {
-        // batch smaller than BUCKET_SIZE * 2
         let mut batch: Vec<Address> = Vec::new(&e);
         for _ in 0..10u32 {
             batch.push_back(Address::generate(&e));
@@ -71,41 +75,24 @@ fn bind_tokens_fits_current_bucket() {
 }
 
 #[test]
-fn bind_tokens_splits_across_two_buckets() {
+fn bind_tokens_full_capacity_in_one_call() {
     let e = Env::default();
+    e.cost_estimate().disable_resource_limits();
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        // Pre-fill current bucket to BUCKET_SIZE - 5
-        for _ in 0..(BUCKET_SIZE - 5) {
-            let t = Address::generate(&e);
-            bind_token(&e, &t);
-        }
-        assert_eq!(linked_token_count(&e), BUCKET_SIZE - 5);
-
-        // Now bind a batch of 10 which should split: 5 in current, 5 in next
+        // A single batch can bind up to the full capacity.
         let mut batch: Vec<Address> = Vec::new(&e);
-        for _ in 0..10u32 {
+        for _ in 0..MAX_TOKENS {
             batch.push_back(Address::generate(&e));
         }
 
         bind_tokens(&e, &batch);
 
-        // Validate counts
-        assert_eq!(linked_token_count(&e), BUCKET_SIZE + 5);
-
-        // First 5 go at the end of the current bucket, next 5 at the start of
-        // the next bucket
-        for i in 0..10u32 {
-            assert_eq!(get_token_by_index(&e, BUCKET_SIZE - 5 + i), batch.get(i).unwrap());
-        }
-
-        // Spot-check full list end ordering
-        let all = linked_tokens(&e);
-        assert_eq!(all.len(), BUCKET_SIZE + 5);
-        for i in 0..10u32 {
-            assert_eq!(all.get(BUCKET_SIZE - 5 + i).unwrap(), batch.get(i).unwrap());
-        }
+        assert_eq!(linked_token_count(&e), MAX_TOKENS);
+        assert_eq!(get_token_by_index(&e, 0), batch.get(0).unwrap());
+        assert_eq!(get_token_by_index(&e, MAX_TOKENS - 1), batch.get(MAX_TOKENS - 1).unwrap());
+        assert!(is_token_bound(&e, &batch.get(MAX_TOKENS / 2).unwrap()));
     });
 }
 
@@ -412,56 +399,14 @@ fn rebind_after_unbind() {
 }
 
 #[test]
-fn bind_tokens_spill_across_three_buckets() {
+#[should_panic(expected = "Error(Contract, #332)")]
+fn bind_tokens_exceeding_capacity_panics() {
     let e = Env::default();
     e.cost_estimate().disable_resource_limits();
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        // Pre-fill half of the current bucket
-        let half = BUCKET_SIZE / 2;
-        for _ in 0..half {
-            bind_token(&e, &Address::generate(&e));
-        }
-        assert_eq!(linked_token_count(&e), half);
-
-        // A batch of BUCKET_SIZE * 2 should fill: half in current, a full
-        // bucket in the next, and the remaining half in a third
-        let mut batch: Vec<Address> = Vec::new(&e);
-        for _ in 0..(BUCKET_SIZE * 2) {
-            batch.push_back(Address::generate(&e));
-        }
-
-        bind_tokens(&e, &batch);
-
-        assert_eq!(linked_token_count(&e), half + BUCKET_SIZE * 2);
-
-        // First half of batch fills the current bucket
-        for i in 0..half {
-            assert_eq!(get_token_by_index(&e, half + i), batch.get(i).unwrap());
-        }
-        // Next full bucket of batch lands in the second bucket
-        for i in 0..BUCKET_SIZE {
-            assert_eq!(get_token_by_index(&e, BUCKET_SIZE + i), batch.get(half + i).unwrap());
-        }
-        // Remaining half of batch lands in the third bucket
-        for i in 0..half {
-            assert_eq!(
-                get_token_by_index(&e, BUCKET_SIZE * 2 + i),
-                batch.get(BUCKET_SIZE + half + i).unwrap()
-            );
-        }
-    });
-}
-
-#[test]
-#[should_panic(expected = "Error(Contract, #333)")]
-fn bind_tokens_batch_too_large_should_panic() {
-    let e = Env::default();
-    let address = e.register(MockContract, ());
-
-    e.as_contract(&address, || {
-        let target_len = BUCKET_SIZE * 2 + 1; // strictly greater than allowed
+        let target_len = MAX_TOKENS + 1; // strictly greater than capacity
         let mut batch: Vec<Address> = Vec::new(&e);
         for _ in 0..target_len {
             batch.push_back(Address::generate(&e));
@@ -493,86 +438,27 @@ fn bind_tokens_already_bound_in_storage_should_panic() {
 }
 
 #[test]
-fn unbind_makes_last_bucket_empty() {
+fn bind_tokens_appends_after_existing() {
     let e = Env::default();
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        // Create exactly BUCKET_SIZE + 1 tokens => second bucket has 1 item
-        let mut tokens: Vec<Address> = Vec::new(&e);
-        for _ in 0..(BUCKET_SIZE + 1) {
-            let t = Address::generate(&e);
-            bind_token(&e, &t);
-            tokens.push_back(t);
-        }
-        assert_eq!(linked_token_count(&e), BUCKET_SIZE + 1);
-
-        // Unbind the first token; the single last token moves into index 0,
-        // making the last bucket empty afterwards.
-        let first = tokens.get(0).unwrap();
-        let last_before = tokens.get(BUCKET_SIZE).unwrap();
-        unbind_token(&e, &first);
-
-        assert_eq!(linked_token_count(&e), BUCKET_SIZE);
-        // Index 0 now holds the previous last token
-        assert_eq!(get_token_by_index(&e, 0), last_before);
-
-        // Sanity: full list has exactly BUCKET_SIZE elements now
-        let all = linked_tokens(&e);
-        assert_eq!(all.len(), BUCKET_SIZE);
-    });
-}
-
-#[test]
-fn is_token_bound_across_buckets() {
-    let e = Env::default();
-    let address = e.register(MockContract, ());
-
-    let (t0, t_boundary, t_next) = e.as_contract(&address, || {
-        // Fill first bucket fully and add a few into next
-        let mut first: Option<Address> = None;
-        for i in 0..(BUCKET_SIZE + 5) {
-            let t = Address::generate(&e);
-            bind_token(&e, &t);
-            if i == 0 {
-                first = Some(t.clone());
-            }
-        }
-        let first_token = first.unwrap();
-        let boundary_token = get_token_by_index(&e, BUCKET_SIZE - 1);
-        let next_bucket_token = get_token_by_index(&e, BUCKET_SIZE);
-        (first_token, boundary_token, next_bucket_token)
-    });
-
-    e.as_contract(&address, || {
-        assert!(is_token_bound(&e, &t0));
-        assert!(is_token_bound(&e, &t_boundary));
-        assert!(is_token_bound(&e, &t_next));
-    });
-}
-
-#[test]
-fn bind_tokens_exact_bucket_boundary_start() {
-    let e = Env::default();
-    let address = e.register(MockContract, ());
-
-    e.as_contract(&address, || {
-        // Pre-fill exactly one bucket
-        for _ in 0..BUCKET_SIZE {
+        // Pre-bind a handful of single tokens
+        for _ in 0..5u32 {
             bind_token(&e, &Address::generate(&e));
         }
-        assert_eq!(linked_token_count(&e), BUCKET_SIZE);
+        assert_eq!(linked_token_count(&e), 5);
 
-        // Now bind a batch that fits entirely in the next bucket
+        // A batch appends after the existing entries, in order
         let mut batch: Vec<Address> = Vec::new(&e);
         for _ in 0..10u32 {
             batch.push_back(Address::generate(&e));
         }
         bind_tokens(&e, &batch);
 
-        assert_eq!(linked_token_count(&e), BUCKET_SIZE + 10);
+        assert_eq!(linked_token_count(&e), 15);
         for i in 0..10u32 {
-            assert_eq!(get_token_by_index(&e, BUCKET_SIZE + i), batch.get(i).unwrap());
+            assert_eq!(get_token_by_index(&e, 5 + i), batch.get(i).unwrap());
         }
     });
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #802 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Identity records can no longer be modified through the identity registry storage API.
  - The related identity-modification event is no longer emitted.

- **Bug Fixes**
  - Identity removal now prevents deletion when the account holds a non-zero balance in any linked token.
  - Added a specific `AccountHasBalance` error for blocked removals.

- **Documentation**
  - Clarified identity-removal requirements, balance checks, and linked-token coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->