### PR TITLE
fix broken rustdoc links across the workspace

### DIFF
--- a/packages/accounts/src/smart_account/mod.rs
+++ b/packages/accounts/src/smart_account/mod.rs
@@ -122,8 +122,9 @@ pub use storage::{
     add_context_rule, add_policy, add_signer, authenticate, batch_add_signer, do_check_auth,
     get_context_rule, get_context_rules_count, get_validated_context_by_id, remove_context_rule,
     remove_policy, remove_signer, update_context_rule_name, update_context_rule_valid_until,
-    validate_no_canonical_duplicates, validate_signer_key_size, AuthPayload, ContextRule,
-    ContextRuleEntry, ContextRuleType, Signer, SmartAccountStorageKey,
+    validate_context_rule_name, validate_no_canonical_duplicates, validate_signer_key_size,
+    validate_signers_and_policies, AuthPayload, ContextRule, ContextRuleEntry, ContextRuleType,
+    Signer, SmartAccountStorageKey,
 };
 
 /// Core trait for smart account functionality, extending Soroban's

--- a/packages/governance/src/governor/mod.rs
+++ b/packages/governance/src/governor/mod.rs
@@ -510,7 +510,7 @@ pub trait Governor {
     /// identifier.
     ///
     /// This function is only relevant when queuing is enabled, i.e., when
-    /// [`Self::proposals_need_queuing`] is overridden to return `true`. If
+    /// [`Governor::proposals_need_queuing`] is overridden to return `true`. If
     /// queuing is not enabled, calling this function will revert with
     /// [`GovernorError::QueueNotEnabled`].
     ///
@@ -526,7 +526,7 @@ pub trait Governor {
     ///
     /// The default implementation uses **open queueing**: any account can
     /// queue a succeeded proposal without authentication. To enable it,
-    /// override [`Self::proposals_need_queuing`] to return `true`:
+    /// override [`Governor::proposals_need_queuing`] to return `true`:
     ///
     /// ```ignore
     /// #[contractimpl(contracttrait)]

--- a/packages/governance/src/governor/storage.rs
+++ b/packages/governance/src/governor/storage.rs
@@ -214,7 +214,8 @@ pub fn get_proposal_core(e: &Env, proposal_id: &BytesN<32>) -> ProposalCore {
 /// * `e` - Access to the Soroban environment.
 /// * `proposal_id` - The unique identifier of the proposal.
 /// * `quorum` - The quorum threshold, evaluated at the proposal's
-///   `vote_snapshot` ledger via [`Governor::quorum`].
+///   `vote_snapshot` ledger via
+///   [`Governor::quorum`](crate::governor::Governor::quorum).
 ///
 /// # Errors
 ///
@@ -560,7 +561,8 @@ pub fn propose(
 /// * `queue_enabled` - Whether queueing is enabled (i.e., whether the proposal
 ///   must be in the `Queued` state to execute).
 /// * `quorum` - The quorum threshold, evaluated at the proposal's
-///   `vote_snapshot` ledger via [`Governor::quorum`].
+///   `vote_snapshot` ledger via
+///   [`Governor::quorum`](crate::governor::Governor::quorum).
 ///
 /// # Errors
 ///
@@ -645,7 +647,8 @@ pub fn execute(
 /// * `eta` - The estimated ledger sequence for execution. Emitted in the event
 ///   only; not stored or enforced by the governor.
 /// * `quorum` - The quorum threshold, evaluated at the proposal's
-///   `vote_snapshot` ledger via [`Governor::quorum`].
+///   `vote_snapshot` ledger via
+///   [`Governor::quorum`](crate::governor::Governor::quorum).
 ///
 /// # Errors
 ///
@@ -793,7 +796,8 @@ pub fn hash_proposal(
 /// * `e` - Access to the Soroban environment.
 /// * `proposal_id` - The unique identifier of the proposal.
 /// * `quorum` - The quorum threshold, evaluated at the proposal's
-///   `vote_snapshot` ledger via [`Governor::quorum`].
+///   `vote_snapshot` ledger via
+///   [`Governor::quorum`](crate::governor::Governor::quorum).
 ///
 /// # Errors
 ///
@@ -850,7 +854,8 @@ pub fn check_proposal_state(e: &Env, proposal_id: &BytesN<32>, quorum: u128) -> 
 /// * `proposal_id` - The unique identifier of the proposal.
 /// * `core` - The proposal's stored core data.
 /// * `quorum` - The quorum threshold, evaluated at the proposal's
-///   `vote_snapshot` ledger via [`Governor::quorum`].
+///   `vote_snapshot` ledger via
+///   [`Governor::quorum`](crate::governor::Governor::quorum).
 ///
 /// # Errors
 ///
@@ -1007,7 +1012,8 @@ fn get_quorum_checkpoint(e: &Env, index: u32) -> QuorumCheckpoint {
 /// * `e` - Access to the Soroban environment.
 /// * `proposal_id` - The unique identifier of the proposal.
 /// * `quorum` - The quorum threshold, evaluated at the proposal's
-///   `vote_snapshot` ledger via [`Governor::quorum`].
+///   `vote_snapshot` ledger via
+///   [`Governor::quorum`](crate::governor::Governor::quorum).
 ///
 /// # Errors
 ///
@@ -1200,7 +1206,8 @@ pub fn count_vote(
 /// * `reason` - An optional explanation for the vote.
 /// * `voter` - The address casting the vote.
 /// * `quorum` - The quorum threshold, evaluated at the proposal's
-///   `vote_snapshot` ledger via [`Governor::quorum`].
+///   `vote_snapshot` ledger via
+///   [`Governor::quorum`](crate::governor::Governor::quorum).
 ///
 /// # Errors
 ///

--- a/packages/tokens/src/confidential/compliance/mod.rs
+++ b/packages/tokens/src/confidential/compliance/mod.rs
@@ -3,7 +3,7 @@
 //! Deployer-configurable controls layered on top of the
 //! [`ConfidentialToken`]: per-account freezing,
 //! SAC `authorized()` passthrough, and a pluggable external
-//! authorization policy. See [`docs/COMPLIANCE.md`] for the
+//! authorization policy. See `docs/COMPLIANCE.md` for the
 //! specification.
 //!
 //! ## Surface
@@ -55,7 +55,9 @@ pub trait Policy {
 ///
 /// ## Why the write methods have no default body
 ///
-/// The write methods ([`freeze`], [`unfreeze`], [`set_compliance_config`])
+/// The write methods ([`ConfidentialCompliance::freeze`],
+/// [`ConfidentialCompliance::unfreeze`],
+/// [`ConfidentialCompliance::set_compliance_config`])
 /// accept an `operator: Address` and intentionally ship without a default
 /// implementation. Because the choice of access-control module is the contract
 /// author's, the trait forces an explicit override. The override typically:
@@ -187,7 +189,7 @@ pub trait ConfidentialCompliance: ConfidentialToken {
 ///   (registration predates the account entry) but passes policy and SAC.
 /// * [`on_register`](Hooks::on_register) does not restrict the caller-selected
 ///   `auditor_id`. Deployments that must limit which auditors an account may
-///   bind to override it with a custom gate (see [`docs/COMPLIANCE.md`] §4.3).
+///   bind to override it with a custom gate (see `docs/COMPLIANCE.md` §4.3).
 /// * [`on_spender_transfer`](Hooks::on_spender_transfer): `from` and `to` pass
 ///   all three gates; `spender` passes only the policy gate.
 /// * [`on_set_spender`](Hooks::on_set_spender): the delegating `account` passes
@@ -204,7 +206,7 @@ pub trait ConfidentialCompliance: ConfidentialToken {
 ///
 /// Deployments that need additional behaviour (audit mirroring, rate
 /// limiting, or alternative deposit semantics — see
-/// [`docs/COMPLIANCE.md`] §4) can write a custom `Hooks` impl that
+/// `docs/COMPLIANCE.md` §4) can write a custom `Hooks` impl that
 /// calls the same primitives.
 pub struct ComplianceHooks;
 

--- a/packages/tokens/src/confidential/mod.rs
+++ b/packages/tokens/src/confidential/mod.rs
@@ -6,7 +6,7 @@
 //! accompanied by an UltraHonk proof that the contract verifies via a separate
 //! verifier contract. Auditor keys are read from a separate registry contract
 //! and dual auditor ciphertexts are emitted in each transfer event. See
-//! [`docs/DESIGN.md`] (§1–§7) and [`docs/DESIGN_cont.md`] (§8–§13) for the
+//! `docs/DESIGN.md` (§1–§7) and `docs/DESIGN_cont.md` (§8–§13) for the
 //! full specification.
 //!
 //! # ⚠️ Not Production Ready
@@ -52,7 +52,9 @@
 //!
 //! The contract closes this gap at the verifier boundary. The append
 //! helpers in [`storage`] (`append_field`, `append_point`) call
-//! [`Grumpkin::is_canonical_field`] / [`Grumpkin::is_canonical_point`]. By the
+//! [`Grumpkin::is_canonical_field`](stellar_contract_utils::crypto::grumpkin::Grumpkin::is_canonical_field)
+//! / [`Grumpkin::is_canonical_point`](stellar_contract_utils::crypto::grumpkin::Grumpkin::is_canonical_point).
+//! By the
 //! time `verify_proof` is invoked, every caller-supplied scalar and Grumpkin
 //! coordinate is guaranteed to be the unique canonical big-endian
 //! representative of its field element, and values the contract subsequently

--- a/packages/tokens/src/fungible/extensions/allowlist/mod.rs
+++ b/packages/tokens/src/fungible/extensions/allowlist/mod.rs
@@ -58,8 +58,8 @@ pub trait FungibleAllowList: FungibleToken<ContractType = AllowList> {
     ///
     /// No default implementation is provided because this is a privileged
     /// operation that requires custom access control. Access control should be
-    /// enforced on `operator` before calling [`storage::allow_user`] for the
-    /// implementation.
+    /// enforced on `operator` before calling [`AllowList::allow_user`] for
+    /// the implementation.
     fn allow_user(e: &Env, user: Address, operator: Address);
 
     /// Disallows a user from receiving and transferring tokens.
@@ -80,7 +80,7 @@ pub trait FungibleAllowList: FungibleToken<ContractType = AllowList> {
     /// No default implementation is provided because this is a privileged
     /// operation that requires custom access control. Access control should be
     /// enforced on `operator` before calling
-    /// [`storage::disallow_user`] for the implementation.
+    /// [`AllowList::disallow_user`] for the implementation.
     fn disallow_user(e: &Env, user: Address, operator: Address);
 }
 

--- a/packages/tokens/src/fungible/extensions/blocklist/mod.rs
+++ b/packages/tokens/src/fungible/extensions/blocklist/mod.rs
@@ -58,8 +58,8 @@ pub trait FungibleBlockList: FungibleToken<ContractType = BlockList> {
     ///
     /// No default implementation is provided because this is a privileged
     /// operation that requires custom access control. Access control should be
-    /// enforced on `operator` before calling [`storage::block_user`] for the
-    /// implementation.
+    /// enforced on `operator` before calling [`BlockList::block_user`] for
+    /// the implementation.
     fn block_user(e: &Env, user: Address, operator: Address);
 
     /// Unblocks a user, allowing them to receive and transfer tokens.
@@ -79,8 +79,8 @@ pub trait FungibleBlockList: FungibleToken<ContractType = BlockList> {
     ///
     /// No default implementation is provided because this is a privileged
     /// operation that requires custom access control. Access control should be
-    /// enforced on `operator` before calling [`storage::unblock_user`] for the
-    /// implementation.
+    /// enforced on `operator` before calling [`BlockList::unblock_user`] for
+    /// the implementation.
     fn unblock_user(e: &Env, user: Address, operator: Address);
 }
 

--- a/packages/tokens/src/non_fungible/extensions/royalties/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/royalties/mod.rs
@@ -60,7 +60,7 @@ pub trait NonFungibleRoyalties: NonFungibleToken {
     /// No default implementation is provided because this is a privileged
     /// operation that requires custom access control. Access control should be
     /// enforced on `operator` before calling
-    /// [`storage::set_default_royalty`] for the implementation.
+    /// [`Base::set_default_royalty`] for the implementation.
     fn set_default_royalty(e: &Env, receiver: Address, basis_points: u32, operator: Address);
 
     /// Sets the royalty information for a specific token.
@@ -91,7 +91,7 @@ pub trait NonFungibleRoyalties: NonFungibleToken {
     /// No default implementation is provided because this is a privileged
     /// operation that requires custom access control. Access control should be
     /// enforced on `operator` before calling
-    /// [`storage::set_token_royalty`] for the implementation.
+    /// [`Base::set_token_royalty`] for the implementation.
     fn set_token_royalty(
         e: &Env,
         token_id: u32,
@@ -124,7 +124,7 @@ pub trait NonFungibleRoyalties: NonFungibleToken {
     /// No default implementation is provided because this is a privileged
     /// operation that requires custom access control. Access control should be
     /// enforced on `operator` before calling
-    /// [`storage::remove_token_royalty`] for the implementation.
+    /// [`Base::remove_token_royalty`] for the implementation.
     fn remove_token_royalty(e: &Env, token_id: u32, operator: Address);
 
     /// Returns `(Address, i128)` - A tuple containing the receiver address and

--- a/packages/tokens/src/rwa/compliance/modules/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/storage.rs
@@ -111,7 +111,7 @@ pub fn get_irs_country_data_entries(
 /// # Security Warning
 ///
 /// This function performs no authorization checks. Callers must gate access
-/// (e.g. with [`stellar_macros::only_admin`]) before invoking it.
+/// (e.g. with `stellar_macros::only_admin`) before invoking it.
 pub fn set_compliance_address(e: &Env, token: &Address, compliance: &Address) {
     let key = ComplianceModuleStorageKey::Compliance(token.clone());
     e.storage().persistent().set(&key, compliance);
@@ -132,7 +132,7 @@ pub fn set_compliance_address(e: &Env, token: &Address, compliance: &Address) {
 /// # Security Warning
 ///
 /// This function performs no authorization checks. Callers must gate access
-/// (e.g. with [`stellar_macros::only_admin`]) before invoking it.
+/// (e.g. with `stellar_macros::only_admin`) before invoking it.
 pub fn set_irs_address(e: &Env, token: &Address, irs: &Address) {
     let key = ComplianceModuleStorageKey::Registry(token.clone());
     e.storage().persistent().set(&key, irs);

--- a/packages/tokens/src/rwa/identity_verification/claim_issuer/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/claim_issuer/mod.rs
@@ -175,11 +175,10 @@ pub trait ClaimIssuer {
     /// is entirely application-specific — each claim issuer defines its own
     /// supported verification schemes, key management strategy, and
     /// validation pipeline. There is no single storage function to call;
-    /// instead, compose the optional helpers from the [`storage`] module
-    /// (e.g., [`storage::is_key_allowed_for_topic`],
-    /// [`storage::is_claim_expired`], [`storage::is_claim_revoked`]) and a
-    /// [`SignatureVerifier`] implementation. See the [module-level
-    /// documentation](self) for a full example.
+    /// instead, compose the optional helpers exported from this module
+    /// (e.g., [`is_key_allowed_for_topic`], [`is_claim_expired`],
+    /// [`is_claim_revoked`]) and a [`SignatureVerifier`] implementation. See
+    /// the [module-level documentation](self) for a full example.
     fn is_claim_valid(
         e: &Env,
         identity: Address,
@@ -216,8 +215,8 @@ pub trait SignatureVerifier {
     ///
     /// No default implementation is provided because each signature scheme
     /// has a unique data layout. See [`Ed25519Verifier`],
-    /// [`Secp256k1Verifier`], and [`Secp256r1Verifier`] in the [`storage`]
-    /// module for reference implementations.
+    /// [`Secp256k1Verifier`], and [`Secp256r1Verifier`] for reference
+    /// implementations.
     fn extract_signature_data(e: &Env, sig_data: &Bytes) -> Self::SignatureData;
 
     /// Builds the message to verify for claim signature validation.
@@ -235,8 +234,9 @@ pub trait SignatureVerifier {
     /// # Notes
     ///
     /// No default implementation is provided because the message format may
-    /// vary between signature schemes. See the built-in
-    /// verifiers in the [`storage`] module for reference implementations.
+    /// vary between signature schemes. See the built-in verifiers
+    /// ([`Ed25519Verifier`], [`Secp256k1Verifier`], [`Secp256r1Verifier`])
+    /// for reference implementations.
     fn build_message(e: &Env, identity: &Address, claim_topic: u32, claim_data: &Bytes) -> Bytes;
 
     /// Validates a claim signature using the parsed signature data and panics
@@ -251,8 +251,9 @@ pub trait SignatureVerifier {
     /// # Notes
     ///
     /// No default implementation is provided because cryptographic
-    /// verification is scheme-specific. See the built-in
-    /// verifiers in the [`storage`] module for reference implementations.
+    /// verification is scheme-specific. See the built-in verifiers
+    /// ([`Ed25519Verifier`], [`Secp256k1Verifier`], [`Secp256r1Verifier`])
+    /// for reference implementations.
     fn verify(e: &Env, message: &Bytes, signature_data: &Self::SignatureData);
 
     /// Returns the expected signature data length for this scheme.

--- a/packages/zk-email/src/dkim_registry/storage.rs
+++ b/packages/zk-email/src/dkim_registry/storage.rs
@@ -90,7 +90,8 @@ pub fn is_key_hash_revoked(e: &Env, public_key_hash: &BytesN<32>) -> bool {
 ///
 /// # Events
 ///
-/// Emits [`KeyHashRegistered`] with the domain and public key hashes.
+/// Emits [`KeyHashRegistered`](crate::dkim_registry::KeyHashRegistered) with
+/// the domain and public key hashes.
 ///
 /// # Security Warning
 ///
@@ -156,7 +157,8 @@ pub fn set_dkim_public_key_hashes(
 ///
 /// # Events
 ///
-/// Emits [`KeyHashRevoked`] with the public key hash.
+/// Emits [`KeyHashRevoked`](crate::dkim_registry::KeyHashRevoked) with the
+/// public key hash.
 ///
 /// # Security Warning
 ///


### PR DESCRIPTION
All intra-doc links now resolve; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` passes. Includes one small API addition: `validate_context_rule_name` and `validate_signers_and_policies` join the smart_account re-export list, matching their already-exported sibling validators, so the canonical "refer to [...] errors" doc form resolves.

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #805 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [ ] Tests
- [ ] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to additional smart-account validation helpers through the public API, enabling broader validation workflows for integrators.

- **Documentation**
  - Improved API documentation across governance, token, compliance, identity, royalty, and DKIM functionality.
  - Clarified references to privileged operations, validation helpers, event emissions, configuration methods, and security requirements.
  - Reformatted technical references and links for more consistent, readable documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->