### PR TITLE
exp wad boundaries

### DIFF
--- a/packages/contract-utils/src/math/exp_ln.rs
+++ b/packages/contract-utils/src/math/exp_ln.rs
@@ -26,10 +26,20 @@ use soroban_sdk::{Env, I256, U256};
 
 /// Input threshold at/below which `exp_wad(x)` returns 0.
 ///
-/// For `x` this small, `e^x * 10^18` evaluates to less than `0.5`, which
-/// truncates to `0` in WAD precision. The exact value is
-/// `floor(ln(0.5 * 10^-18) * 10^18)` ≈ `-42.139 * 10^18`.
-const EXP_INPUT_MIN: i128 = -42_139_678_854_452_767_551;
+/// Solmate's cutoff is `floor(ln(0.5 * 10^-18) * 10^18)` ≈ `-42.139 * 10^18`
+/// (where `e^x * 10^18` drops below `0.5`), and inputs just above it flow
+/// through the algorithm to the final `>> (195 - k)` scaling. In that band
+/// the range-reduction exponent `k` reaches `-61`, making the shift amount
+/// exactly 256, which the EVM defines as 0 but soroban's `U256::shr` rejects
+/// as out of domain. The same inputs must therefore be caught by this early
+/// return instead.
+///
+/// The value is `floor(-60.5 * ln(2) * 10^18)`: the largest input for which
+/// `k = round(x / ln(2))` reaches `-61`. Everything at/below it is exactly
+/// the set of inputs Solmate zeroes via EVM shift semantics, and returning 0
+/// remains the correct truncated result, since `e^x * 10^18` only reaches 1
+/// at `x = -18 * ln(10) * 10^18` ≈ `-41.446 * 10^18`, well above this cutoff.
+const EXP_INPUT_MIN: i128 = -41_935_404_423_876_691_220;
 
 /// Input threshold at/above which `exp_wad(x)` overflows.
 ///
@@ -229,6 +239,8 @@ pub(super) fn exp_wad(e: &Env, x: i128) -> Option<i128> {
 
     // k is i32-sized after range reduction; narrow via to_i128.
     let k_i128 = k.to_i128()?;
+    // The `EXP_INPUT_MIN` early return guarantees `k >= -60`, keeping this
+    // below 256 (the EVM yields 0 for shifts >= 256; `U256::shr` traps).
     let shr_amount = (195_i128 - k_i128) as u32;
 
     let result_bytes = r_u256.mul(&final_mul).shr(shr_amount).to_be_bytes();

--- a/packages/contract-utils/src/math/test/wad.rs
+++ b/packages/contract-utils/src/math/test/wad.rs
@@ -983,6 +983,36 @@ fn test_checked_exp_underflow_returns_zero() {
 }
 
 #[test]
+fn test_checked_exp_underflow_band_returns_zero() {
+    // Regression: inputs in (-42.139..., -41.935...] drive the final scaling
+    // shift to exactly 256, which the EVM defines as 0 but soroban's
+    // `U256::shr` rejects. They must take the `EXP_INPUT_MIN` early return
+    // instead of trapping.
+    let e = Env::default();
+    for raw in [
+        -42_139_678_854_452_767_550, // just above Solmate's cutoff
+        -42_000_000_000_000_000_000,
+        -41_935_404_423_876_691_220, // EXP_INPUT_MIN: largest input with k = -61
+    ] {
+        assert_eq!(Wad::from_raw(raw).checked_exp(&e), Some(Wad::from_raw(0)));
+    }
+    // Just above EXP_INPUT_MIN: runs the full algorithm (k = -60, shift 255)
+    // and still truncates to 0.
+    assert_eq!(Wad::from_raw(-41_935_404_423_876_691_219).checked_exp(&e), Some(Wad::from_raw(0)));
+}
+
+#[test]
+fn test_powf_underflow_band_returns_zero() {
+    // 0.5^60.7: the intermediate y * ln(x) ≈ -42.07 lands in the band that
+    // used to trap (see test_checked_exp_underflow_band_returns_zero).
+    let e = Env::default();
+    let half = Wad::from_raw(500_000_000_000_000_000);
+    let exponent = Wad::from_raw(60_700_000_000_000_000_000);
+    assert_eq!(half.checked_powf(&e, exponent), Some(Wad::from_raw(0)));
+    assert_eq!(half.powf(&e, exponent), Wad::from_raw(0));
+}
+
+#[test]
 fn test_exp_ln_roundtrip() {
     let e = Env::default();
     // exp(ln(x)) ≈ x for various positive x. Tolerance is per-magnitude

--- a/packages/contract-utils/src/math/test/wad.rs
+++ b/packages/contract-utils/src/math/test/wad.rs
@@ -952,10 +952,25 @@ fn test_exp_underflow_returns_zero() {
 }
 
 #[test]
-fn test_exp_at_lower_bound_returns_zero() {
+fn test_exp_at_solmate_cutoff_returns_zero() {
     let e = Env::default();
-    let bound = Wad::from_raw(-42_139_678_854_452_767_551);
-    assert_eq!(bound.exp(&e), Wad::from_raw(0));
+    // Solmate's original underflow cutoff, floor(ln(0.5e-18) * 1e18). It sits
+    // well below EXP_INPUT_MIN nowadays, but stays pinned to keep the port
+    // aligned with the reference implementation.
+    let cutoff = Wad::from_raw(-42_139_678_854_452_767_551);
+    assert_eq!(cutoff.exp(&e), Wad::from_raw(0));
+}
+
+#[test]
+fn test_exp_near_underflow_crossing_is_nonzero() {
+    // Guards EXP_INPUT_MIN against being raised too far: results only
+    // truncate to 0 below ≈ -41.446 (where e^x * 1e18 drops under 1), so
+    // inputs just above that must keep producing nonzero values.
+    let e = Env::default();
+    // e^-41 * 1e18 ≈ 1.56
+    assert_eq!(Wad::from_integer(&e, -41).exp(&e), Wad::from_raw(1));
+    // e^-40 * 1e18 ≈ 4.25
+    assert_eq!(Wad::from_integer(&e, -40).exp(&e), Wad::from_raw(4));
 }
 
 #[test]

--- a/packages/contract-utils/src/math/wad.rs
+++ b/packages/contract-utils/src/math/wad.rs
@@ -520,8 +520,8 @@ impl Wad {
     /// This is **not** a generic power function — for `x^y` with an arbitrary
     /// base, use [`Wad::powf`]. `Wad::exp` is the inverse of [`Wad::ln`]
     ///
-    /// Returns `0` for inputs at or below `≈ -42.139` (the result rounds to 0
-    /// in WAD precision). Panics for inputs at or above `≈ 135.305` (overflow).
+    /// Returns `0` for inputs below `≈ -41.446` (the result truncates to 0 in
+    /// WAD precision). Panics for inputs at or above `≈ 135.305` (overflow).
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #807 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exponentiation underflow handling for very small negative inputs, preventing potential calculation traps.
  * Ensured exponential and power calculations return `0` consistently near the underflow boundary.

* **Documentation**
  * Clarified the input ranges where exponential calculations underflow to `0` or overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->