### PR TITLE
eager prune for lockup

### DIFF
--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/mod.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/mod.rs
@@ -40,8 +40,11 @@ use crate::rwa::compliance::modules::ComplianceModule;
 ///
 /// Locks are consumed lazily: expired entries stay on the books until a
 /// transfer or burn dips into the locked region, at which point they are
-/// consumed oldest-first and removed. Mints themselves are never blocked by
-/// this module: they are the operation that creates locks.
+/// consumed oldest-first and removed. Each mint also prunes whatever has
+/// expired by then while appending its new lock, so a wallet's stored lock
+/// entries stay bounded by its active locks no matter how many mints it
+/// receives. Mints themselves are never blocked by this module: they are
+/// the operation that creates locks.
 ///
 /// The module **maintains its own state**: per-wallet lock entries that
 /// record how much of a wallet's balance is still locked. Correct accounting

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/mod.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/mod.rs
@@ -17,6 +17,30 @@
 //! (unlocked) amount is then `balance - locked`, computed afresh on every
 //! hook. No balance is mirrored.
 //!
+//! # Capacity planning
+//!
+//! A wallet's lock entries live in a single contract-data entry, and their
+//! count is capped at [`MAX_LOCKS`]. Expired entries are pruned as mints and
+//! spends rewrite the entry, so the count that matters is the number of
+//! *concurrently active* locks: the mints a wallet receives within one
+//! lockup window, i.e. mint frequency times lockup period. A mint that
+//! would push a wallet past the cap is rejected with
+//! [`crate::rwa::compliance::modules::ComplianceModuleError::LockBoundExceeded`].
+//!
+//! Some schedules against the cap:
+//!
+//! * Monthly dividends, 2-year lockup: at most 24 active locks per wallet. Well
+//!   within the cap.
+//! * Daily rewards, 1-year lockup: at most ~366 active locks. Also within the
+//!   cap.
+//! * Daily rewards, 2-year lockup: ~730 active locks. Over the cap: mints to a
+//!   steadily rewarded wallet start failing about 17 months in.
+//!
+//! The cap is a hard deployment requirement: a token expecting any single
+//! wallet to receive more than [`MAX_LOCKS`] mints within one lockup window
+//! must not use this module as-is; such schedules call for fewer, batched
+//! distributions or a shorter lockup period.
+//!
 //! [trex-src]: https://github.com/TokenySolutions/T-REX/blob/develop/contracts/compliance/modular/modules/InitialLockupPeriodModule.sol
 
 pub mod storage;
@@ -43,8 +67,10 @@ use crate::rwa::compliance::modules::ComplianceModule;
 /// consumed oldest-first and removed. Each mint also prunes whatever has
 /// expired by then while appending its new lock, so a wallet's stored lock
 /// entries stay bounded by its active locks no matter how many mints it
-/// receives. Mints themselves are never blocked by this module: they are
-/// the operation that creates locks.
+/// receives. Mints are blocked by this module only at that bound: a mint
+/// that would push a wallet past [`MAX_LOCKS`] active entries panics
+/// rather than record an oversized schedule (see the module docs for
+/// sizing guidance).
 ///
 /// The module **maintains its own state**: per-wallet lock entries that
 /// record how much of a wallet's balance is still locked. Correct accounting
@@ -125,6 +151,8 @@ pub trait InitialLockupPeriod: ComplianceModule {
     ///   When any lock amount is negative.
     /// * [`crate::rwa::compliance::modules::ComplianceModuleError::PresetAlreadyCompleted`] -
     ///   When the preset phase has already been finalized.
+    /// * [`crate::rwa::compliance::modules::ComplianceModuleError::LockBoundExceeded`] -
+    ///   When `locks` holds more than [`MAX_LOCKS`] entries.
     /// * [`crate::rwa::compliance::modules::ComplianceModuleError::MathOverflow`] -
     ///   When summing the lock amounts overflows.
     ///
@@ -225,6 +253,18 @@ pub trait InitialLockupPeriod: ComplianceModule {
         storage::is_preset_completed(e, &token)
     }
 }
+
+// ################## CONSTANTS ##################
+
+/// Upper bound on the lock entries stored per `(token, wallet)` pair.
+///
+/// Each entry serializes to roughly 80 bytes of XDR and the ledger caps a
+/// single contract-data entry at 64 KiB (`contract_data_entry_size_bytes`),
+/// which fits about 800 entries. 512 keeps the entry comfortably below
+/// that ceiling while accommodating dense issuance schedules: daily mints
+/// under a one-year lockup peak at ~366 active entries. See the module
+/// docs for capacity planning.
+pub const MAX_LOCKS: u32 = 512;
 
 // ################## EVENTS ##################
 

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
@@ -541,10 +541,8 @@ fn prune_expired_locks(e: &Env, details: &mut LockedDetails) {
         }
     }
 
-    if pruned > 0 {
-        details.total_locked = sub_i128_or_panic(e, details.total_locked, pruned);
-        details.locks = remaining;
-    }
+    details.total_locked = sub_i128_or_panic(e, details.total_locked, pruned);
+    details.locks = remaining;
 }
 
 /// Consumes `amount` from the expired entries in `details`, oldest-first:

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{contracttype, panic_with_error, Address, Env, Vec};
 use crate::rwa::compliance::{
     modules::{
         initial_lockup_period::{
-            emit_lockup_period_set, emit_lockup_state_preset, emit_preset_completed,
+            emit_lockup_period_set, emit_lockup_state_preset, emit_preset_completed, MAX_LOCKS,
         },
         storage::{add_i128_or_panic, require_non_negative_amount, sub_i128_or_panic},
         ComplianceModuleError, MODULE_EXTEND_AMOUNT, MODULE_TTL_THRESHOLD,
@@ -170,6 +170,8 @@ pub fn set_lockup_period(e: &Env, token: &Address, period: u32) {
 ///   negative.
 /// * [`ComplianceModuleError::PresetAlreadyCompleted`] - When the preset phase
 ///   has already been finalized.
+/// * [`ComplianceModuleError::LockBoundExceeded`] - When `locks` holds more
+///   than [`MAX_LOCKS`] entries.
 /// * [`ComplianceModuleError::MathOverflow`] - When summing the lock amounts
 ///   overflows.
 ///
@@ -184,6 +186,9 @@ pub fn set_lockup_period(e: &Env, token: &Address, period: u32) {
 pub fn preset_locks(e: &Env, token: &Address, wallet: &Address, locks: &Vec<LockedTokens>) {
     if is_preset_completed(e, token) {
         panic_with_error!(e, ComplianceModuleError::PresetAlreadyCompleted);
+    }
+    if locks.len() > MAX_LOCKS {
+        panic_with_error!(e, ComplianceModuleError::LockBoundExceeded);
     }
 
     let mut total_locked = 0;
@@ -276,10 +281,9 @@ pub fn on_transfer(
 
 /// Records a mint to `to`: when a lockup period is configured, appends a lock
 /// entry releasing after that period. Expired entries are pruned in the same
-/// write, so the stored vector tracks the wallet's active locks rather than
-/// its lifetime mint count and cannot grow past the ledger-entry size limit
-/// under repeated issuance. The wallet's balance is owned by the token, so
-/// nothing else is tracked.
+/// write, keeping the stored vector bounded by the wallet's concurrently
+/// active locks rather than its lifetime mint count. The wallet's balance is
+/// owned by the token, so nothing else is tracked.
 ///
 /// # Arguments
 ///
@@ -291,6 +295,8 @@ pub fn on_transfer(
 /// # Errors
 ///
 /// * [`ComplianceModuleError::InvalidAmount`] - When `amount` is negative.
+/// * [`ComplianceModuleError::LockBoundExceeded`] - When the wallet already
+///   holds [`MAX_LOCKS`] unexpired lock entries.
 /// * [`ComplianceModuleError::MathOverflow`] - When the lock aggregate
 ///   overflows.
 ///
@@ -304,6 +310,9 @@ pub fn on_created(e: &Env, to: &Address, amount: i128, token: &Address) {
     if period > 0 && amount > 0 {
         let mut details = get_locked_details(e, token, to);
         prune_expired_locks(e, &mut details);
+        if details.locks.len() >= MAX_LOCKS {
+            panic_with_error!(e, ComplianceModuleError::LockBoundExceeded);
+        }
         details.locks.push_back(LockedTokens {
             amount,
             release_ledger: e.ledger().sequence().saturating_add(period),

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
@@ -23,8 +23,8 @@ pub struct LockedTokens {
 /// The lock entries tracked for one `(token, wallet)` pair, together with
 /// their running aggregate. `total_locked` always equals the sum of the
 /// `locks` amounts, including entries whose release time has already
-/// passed: expired entries are consumed lazily by transfers and burns, not
-/// by the passage of time.
+/// passed: expired entries are consumed lazily by transfers and burns and
+/// pruned by subsequent mints, not by the passage of time.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LockedDetails {
@@ -275,8 +275,11 @@ pub fn on_transfer(
 }
 
 /// Records a mint to `to`: when a lockup period is configured, appends a lock
-/// entry releasing after that period. The wallet's balance is owned by the
-/// token, so nothing else is tracked.
+/// entry releasing after that period. Expired entries are pruned in the same
+/// write, so the stored vector tracks the wallet's active locks rather than
+/// its lifetime mint count and cannot grow past the ledger-entry size limit
+/// under repeated issuance. The wallet's balance is owned by the token, so
+/// nothing else is tracked.
 ///
 /// # Arguments
 ///
@@ -300,6 +303,7 @@ pub fn on_created(e: &Env, to: &Address, amount: i128, token: &Address) {
     let period = get_lockup_period(e, token);
     if period > 0 && amount > 0 {
         let mut details = get_locked_details(e, token, to);
+        prune_expired_locks(e, &mut details);
         details.locks.push_back(LockedTokens {
             amount,
             release_ledger: e.ledger().sequence().saturating_add(period),
@@ -508,6 +512,30 @@ fn expired_amount(e: &Env, locks: &Vec<LockedTokens>) -> i128 {
         }
     }
     expired
+}
+
+/// Drops the entries in `details` whose release time has passed, reducing
+/// `total_locked` by the dropped amounts. Expired entries are already
+/// spendable ([`get_locked_amount`] subtracts them), so dropping them
+/// changes nothing about what the wallet can move; it only keeps the
+/// stored vector bounded by the number of active locks.
+fn prune_expired_locks(e: &Env, details: &mut LockedDetails) {
+    let now = e.ledger().sequence();
+    let mut pruned = 0;
+    let mut remaining = Vec::new(e);
+
+    for lock in details.locks.iter() {
+        if lock.release_ledger <= now {
+            pruned = add_i128_or_panic(e, pruned, lock.amount);
+        } else {
+            remaining.push_back(lock);
+        }
+    }
+
+    if pruned > 0 {
+        details.total_locked = sub_i128_or_panic(e, details.total_locked, pruned);
+        details.locks = remaining;
+    }
 }
 
 /// Consumes `amount` from the expired entries in `details`, oldest-first:

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/test.rs
@@ -192,6 +192,33 @@ fn on_created_at_lock_bound_succeeds_after_pruning() {
 }
 
 #[test]
+fn on_created_prunes_expired_zero_amount_locks() {
+    let e = Env::default();
+    let module_id = e.register(TestInitialLockupPeriodContract, ());
+    let token = Address::generate(&e);
+    let wallet = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        // A wallet seeded to the bound with zero-amount locks: nothing to
+        // subtract from `total_locked`, but the entries must still be
+        // dropped once expired or the wallet could never mint again.
+        let mut locks = Vec::new(&e);
+        for _ in 0..MAX_LOCKS {
+            locks.push_back(LockedTokens { amount: 0, release_ledger: 10 });
+        }
+        preset_locks(&e, &token, &wallet, &locks);
+
+        e.ledger().with_mut(|li| li.sequence_number = 10);
+        set_lockup_period(&e, &token, 100);
+        on_created(&e, &wallet, 10, &token);
+
+        let details = get_locked_details(&e, &token, &wallet);
+        assert_eq!(details.total_locked, 10);
+        assert_eq!(details.locks, vec![&e, LockedTokens { amount: 10, release_ledger: 110 }]);
+    });
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #407)")]
 fn preset_locks_panics_above_lock_bound() {
     let e = Env::default();

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/test.rs
@@ -84,6 +84,61 @@ fn on_created_zero_amount_creates_no_lock() {
 }
 
 #[test]
+fn on_created_prunes_expired_locks() {
+    let e = Env::default();
+    let module_id = e.register(TestInitialLockupPeriodContract, ());
+    let token = Address::generate(&e);
+    let wallet = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        set_lockup_period(&e, &token, 100);
+        on_created(&e, &wallet, 50, &token); // releases at t=100
+
+        // The first lock has expired by the second mint: instead of letting
+        // the entry grow, the mint drops it while appending the new lock.
+        e.ledger().with_mut(|li| li.sequence_number = 100);
+        on_created(&e, &wallet, 30, &token); // releases at t=200
+
+        let details = get_locked_details(&e, &token, &wallet);
+        assert_eq!(details.total_locked, 30);
+        assert_eq!(details.locks, vec![&e, LockedTokens { amount: 30, release_ledger: 200 }]);
+        assert_eq!(get_locked_amount(&e, &token, &wallet), 30);
+    });
+}
+
+#[test]
+fn on_created_pruning_keeps_active_locks() {
+    let e = Env::default();
+    let module_id = e.register(TestInitialLockupPeriodContract, ());
+    let token = Address::generate(&e);
+    let wallet = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        set_lockup_period(&e, &token, 100);
+        on_created(&e, &wallet, 50, &token); // releases at t=100
+        e.ledger().with_mut(|li| li.sequence_number = 50);
+        on_created(&e, &wallet, 40, &token); // releases at t=150
+
+        // Only the first lock has expired: the mint prunes it and carries
+        // the still-active one over untouched.
+        e.ledger().with_mut(|li| li.sequence_number = 120);
+        on_created(&e, &wallet, 30, &token); // releases at t=220
+
+        let details = get_locked_details(&e, &token, &wallet);
+        assert_eq!(details.total_locked, 70);
+        assert_eq!(
+            details.locks,
+            vec![
+                &e,
+                LockedTokens { amount: 40, release_ledger: 150 },
+                LockedTokens { amount: 30, release_ledger: 220 },
+            ]
+        );
+        assert_eq!(get_locked_amount(&e, &token, &wallet), 70);
+    });
+}
+
+#[test]
 fn on_transfer_allows_free_portion_only() {
     let e = Env::default();
     let module_id = e.register(TestInitialLockupPeriodContract, ());

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/test.rs
@@ -7,10 +7,13 @@ use soroban_sdk::{
 };
 
 use crate::rwa::compliance::{
-    modules::initial_lockup_period::storage::{
-        debit_forced, get_locked_amount, get_locked_details, get_lockup_period,
-        is_preset_completed, mark_preset_completed, migrate_locks, on_created, on_destroyed,
-        on_transfer, preset_locks, set_lockup_period, LockedTokens,
+    modules::initial_lockup_period::{
+        storage::{
+            debit_forced, get_locked_amount, get_locked_details, get_lockup_period,
+            is_preset_completed, mark_preset_completed, migrate_locks, on_created, on_destroyed,
+            on_transfer, preset_locks, set_lockup_period, LockedTokens,
+        },
+        MAX_LOCKS,
     },
     TransferKind,
 };
@@ -135,6 +138,73 @@ fn on_created_pruning_keeps_active_locks() {
             ]
         );
         assert_eq!(get_locked_amount(&e, &token, &wallet), 70);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #407)")]
+fn on_created_panics_at_lock_bound() {
+    let e = Env::default();
+    let module_id = e.register(TestInitialLockupPeriodContract, ());
+    let token = Address::generate(&e);
+    let wallet = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        let mut locks = Vec::new(&e);
+        for _ in 0..MAX_LOCKS {
+            locks.push_back(LockedTokens { amount: 1, release_ledger: 1_000_000 });
+        }
+        preset_locks(&e, &token, &wallet, &locks);
+
+        // Every seeded lock is still active, so the mint cannot make room
+        // by pruning and must reject instead.
+        set_lockup_period(&e, &token, 100);
+        on_created(&e, &wallet, 10, &token);
+    });
+}
+
+#[test]
+fn on_created_at_lock_bound_succeeds_after_pruning() {
+    let e = Env::default();
+    let module_id = e.register(TestInitialLockupPeriodContract, ());
+    let token = Address::generate(&e);
+    let wallet = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        // The wallet sits at the bound, but its oldest lock releases at
+        // t=10.
+        let mut locks = vec![&e, LockedTokens { amount: 1, release_ledger: 10 }];
+        for _ in 1..MAX_LOCKS {
+            locks.push_back(LockedTokens { amount: 1, release_ledger: 1_000_000 });
+        }
+        preset_locks(&e, &token, &wallet, &locks);
+
+        // Once that lock expires, the mint prunes it and the append fits
+        // within the bound again.
+        e.ledger().with_mut(|li| li.sequence_number = 10);
+        set_lockup_period(&e, &token, 100);
+        on_created(&e, &wallet, 10, &token);
+
+        let details = get_locked_details(&e, &token, &wallet);
+        assert_eq!(details.locks.len(), MAX_LOCKS);
+        assert_eq!(details.total_locked, i128::from(MAX_LOCKS) - 1 + 10);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #407)")]
+fn preset_locks_panics_above_lock_bound() {
+    let e = Env::default();
+    let module_id = e.register(TestInitialLockupPeriodContract, ());
+    let token = Address::generate(&e);
+    let wallet = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        let mut locks = Vec::new(&e);
+        for _ in 0..=MAX_LOCKS {
+            locks.push_back(LockedTokens { amount: 1, release_ledger: 1_000_000 });
+        }
+        preset_locks(&e, &token, &wallet, &locks);
     });
 }
 

--- a/packages/tokens/src/rwa/compliance/modules/mod.rs
+++ b/packages/tokens/src/rwa/compliance/modules/mod.rs
@@ -298,6 +298,9 @@ pub enum ComplianceModuleError {
     CountryRestricted = 405,
     /// Neither transfer party is on the allowlist.
     UserNotAllowed = 406,
+    /// A mint or preset would push a wallet's lock entries above the
+    /// per-wallet bound.
+    LockBoundExceeded = 407,
 }
 
 // ################## CONSTANTS ##################


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #809 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maximum capacity of 512 active lock entries per token and wallet.
  * Expired lock entries are automatically removed before new locks are recorded.
  * Added clear error reporting when minting or presetting locks exceeds the capacity limit.

* **Bug Fixes**
  * Prevented expired locks from incorrectly contributing to capacity limits.
  * Added coverage for lock pruning, capacity enforcement, and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->