### PR TITLE
refresh recipient TTL on every transfer (N-16)

### DIFF
--- a/packages/tokens/src/rwa/compliance/modules/transfer_allow/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/transfer_allow/storage.rs
@@ -41,6 +41,10 @@ pub fn is_user_allowed(e: &Env, token: &Address, user: &Address) -> bool {
 /// and recovery) transfers are exempt from the policy, and no bookkeeping
 /// exists in this module, so they pass through untouched.
 ///
+/// Both parties' allowlist entries are looked up unconditionally so that the
+/// read-time TTL extension in [`is_user_allowed`] refreshes each allowlisted
+/// party on every transfer, regardless of the other party's status.
+///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.
@@ -58,7 +62,9 @@ pub fn on_transfer(e: &Env, from: &Address, to: &Address, kind: &TransferKind, t
         TransferKind::Forced | TransferKind::Recovery => return,
         TransferKind::Standard | TransferKind::Delegated(_) => {}
     }
-    if !is_user_allowed(e, token, from) && !is_user_allowed(e, token, to) {
+    let from_allowed = is_user_allowed(e, token, from);
+    let to_allowed = is_user_allowed(e, token, to);
+    if !from_allowed && !to_allowed {
         panic_with_error!(e, ComplianceModuleError::UserNotAllowed);
     }
 }

--- a/packages/tokens/src/rwa/compliance/modules/transfer_allow/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/transfer_allow/storage.rs
@@ -43,7 +43,8 @@ pub fn is_user_allowed(e: &Env, token: &Address, user: &Address) -> bool {
 ///
 /// Both parties' allowlist entries are looked up unconditionally so that the
 /// read-time TTL extension in [`is_user_allowed`] refreshes each allowlisted
-/// party on every transfer, regardless of the other party's status.
+/// party on every allowlist-checked (standard or delegated) transfer,
+/// regardless of the other party's status.
 ///
 /// # Arguments
 ///

--- a/packages/tokens/src/rwa/compliance/modules/transfer_allow/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/transfer_allow/storage.rs
@@ -41,11 +41,6 @@ pub fn is_user_allowed(e: &Env, token: &Address, user: &Address) -> bool {
 /// and recovery) transfers are exempt from the policy, and no bookkeeping
 /// exists in this module, so they pass through untouched.
 ///
-/// Both parties' allowlist entries are looked up unconditionally so that the
-/// read-time TTL extension in [`is_user_allowed`] refreshes each allowlisted
-/// party on every allowlist-checked (standard or delegated) transfer,
-/// regardless of the other party's status.
-///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.
@@ -63,6 +58,9 @@ pub fn on_transfer(e: &Env, from: &Address, to: &Address, kind: &TransferKind, t
         TransferKind::Forced | TransferKind::Recovery => return,
         TransferKind::Standard | TransferKind::Delegated(_) => {}
     }
+    // Look up both parties unconditionally (no short-circuit) so the
+    // read-time TTL extension in `is_user_allowed` refreshes each allowlisted
+    // party regardless of the other's status.
     let from_allowed = is_user_allowed(e, token, from);
     let to_allowed = is_user_allowed(e, token, to);
     if !from_allowed && !to_allowed {

--- a/packages/tokens/src/rwa/compliance/modules/transfer_allow/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/transfer_allow/test.rs
@@ -2,14 +2,17 @@ extern crate std;
 
 use soroban_sdk::{
     contract,
-    testutils::{Address as _, Events as _},
+    testutils::{storage::Persistent as _, Address as _, Events as _, Ledger as _},
     vec, Address, Env,
 };
 
 use crate::rwa::compliance::{
-    modules::transfer_allow::storage::{
-        allow_user, batch_allow_users, batch_disallow_users, disallow_user, is_user_allowed,
-        on_transfer, remove_user_allowed, set_user_allowed,
+    modules::{
+        transfer_allow::storage::{
+            allow_user, batch_allow_users, batch_disallow_users, disallow_user, is_user_allowed,
+            on_transfer, remove_user_allowed, set_user_allowed, TransferAllowStorageKey,
+        },
+        MODULE_EXTEND_AMOUNT,
     },
     TransferKind,
 };
@@ -62,6 +65,34 @@ fn on_transfer_allows_allowlisted_recipient() {
         allow_user(&e, &token, &to);
 
         on_transfer(&e, &from, &to, &TransferKind::Standard, &token);
+    });
+}
+
+#[test]
+fn on_transfer_refreshes_recipient_ttl_when_sender_allowlisted() {
+    let e = Env::default();
+    let module_id = e.register(TestTransferAllowContract, ());
+    let token = Address::generate(&e);
+    let from = Address::generate(&e);
+    let to = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        allow_user(&e, &token, &from);
+        allow_user(&e, &token, &to);
+
+        // Age the recipient entry to the brink of expiry.
+        let to_key = TransferAllowStorageKey::AllowedUser(token.clone(), to.clone());
+        let ttl = e.storage().persistent().get_ttl(&to_key);
+        e.ledger().with_mut(|l| {
+            l.sequence_number += ttl;
+        });
+
+        // The sender is allowlisted, so the check no longer short-circuits
+        // before touching the recipient: the read-time extension must still
+        // refresh the recipient entry.
+        on_transfer(&e, &from, &to, &TransferKind::Standard, &token);
+
+        assert_eq!(e.storage().persistent().get_ttl(&to_key), MODULE_EXTEND_AMOUNT);
     });
 }
 

--- a/packages/tokens/src/rwa/compliance/modules/transfer_allow/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/transfer_allow/test.rs
@@ -97,6 +97,34 @@ fn on_transfer_refreshes_recipient_ttl_when_sender_allowlisted() {
 }
 
 #[test]
+fn on_transfer_refreshes_sender_ttl_when_recipient_allowlisted() {
+    let e = Env::default();
+    let module_id = e.register(TestTransferAllowContract, ());
+    let token = Address::generate(&e);
+    let from = Address::generate(&e);
+    let to = Address::generate(&e);
+
+    e.as_contract(&module_id, || {
+        allow_user(&e, &token, &from);
+        allow_user(&e, &token, &to);
+
+        // Age the sender entry to the brink of expiry.
+        let from_key = TransferAllowStorageKey::AllowedUser(token.clone(), from.clone());
+        let ttl = e.storage().persistent().get_ttl(&from_key);
+        e.ledger().with_mut(|l| {
+            l.sequence_number += ttl;
+        });
+
+        // The recipient is allowlisted, so a short-circuit on the `from`-read
+        // would skip the sender lookup: the read-time extension must still
+        // refresh the sender entry.
+        on_transfer(&e, &from, &to, &TransferKind::Standard, &token);
+
+        assert_eq!(e.storage().persistent().get_ttl(&from_key), MODULE_EXTEND_AMOUNT);
+    });
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #406)")]
 fn on_transfer_panics_when_neither_party_allowlisted() {
     let e = Env::default();


### PR DESCRIPTION
Addresses audit finding **N-16 — "Allowlist Check Short-Circuits and Skips the Recipient TTL Extension"** (Stellar Contracts RC v0.8.0 audit).

### Problem

`transfer_allow::on_transfer` combined both parties with a short-circuiting `&&`:

```rust
if !is_user_allowed(e, token, from) && !is_user_allowed(e, token, to) {
    panic_with_error!(e, ComplianceModuleError::UserNotAllowed);
}
```

`is_user_allowed` extends an entry's TTL as a side effect of the read. Because of the short-circuit, whenever the sender is already allowlisted the left operand is `false` and `is_user_allowed(to)` is never called — so the recipient's entry is refreshed only on the (rare) transfers where the *sender* is not allowlisted. Receive-only addresses (treasuries, settlement accounts) therefore never get their allowlist entry refreshed through inbound activity and can be allowed to archive, defeating the purpose of the read-time TTL extension for that class of entries.

The allow/deny decision is unaffected, and persistent membership is never lost (archived entries restore on next access), which is why the finding is informational (Notes).

### Fix

Evaluate both predicates before combining them, so a transfer refreshes each allowlisted party regardless of the other's status. This matches the read-extends-TTL convention already followed by the `blocklist` module (whose `||` guard evaluates both parties on the committed happy path). Cost is one extra storage access on the path where the sender is already allowed — negligible for a live entry.

#### PR Checklist

- [x] Tests — added `on_transfer_refreshes_recipient_ttl_when_sender_allowlisted`, which fails against the pre-fix short-circuit (`left: 0, right: 518400`) and passes with the fix
- [x] Documentation — documented the unconditional-lookup behavior on `on_transfer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved allowlist handling during transfers so active entries are refreshed reliably, even when the other party’s entry is nearing expiration.
  * Prevented valid allowlist entries from expiring unexpectedly during transfer checks.

* **Tests**
  * Added coverage for allowlist refresh behavior when sender or recipient entries approach expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->