### PR TITLE
doc burn behavior for lock and frozen

### DIFF
--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/mod.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/mod.rs
@@ -60,6 +60,14 @@ use crate::rwa::compliance::modules::ComplianceModule;
 /// preserved, so the investor's remaining lockup follows the balance onto
 /// the new wallet.
 ///
+/// Burns have no such privileged variant: the `Destroyed` hook does not
+/// distinguish who issued the burn, so a burn that dips into still-locked
+/// tokens is always rejected and a locked position cannot be destroyed in
+/// place. Note that this differs from partially frozen tokens, which the
+/// token unfreezes automatically to cover a burn. Destroying a locked
+/// position is a two-step operation: a forced transfer to a treasury wallet
+/// (which consumes the locks) followed by a burn from that treasury.
+///
 /// The wallet's balance is never mirrored: the token passes it into each
 /// hook via [`crate::rwa::compliance::AccountSnapshot`], and the module
 /// derives the spendable amount as `balance - still_locked` on the spot. A

--- a/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/initial_lockup_period/storage.rs
@@ -313,6 +313,11 @@ pub fn on_created(e: &Env, to: &Address, amount: i128, token: &Address) {
 /// the locked region. Panics when `from`'s unlocked holdings do not cover
 /// `amount`.
 ///
+/// Unlike [`on_transfer`], there is no privileged variant: the token's
+/// `Destroyed` hook carries no transfer kind, so every burn is held to the
+/// unlocked rule. A locked position is destroyed by a forced transfer to a
+/// treasury wallet followed by a burn from that treasury.
+///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.

--- a/packages/tokens/src/rwa/storage.rs
+++ b/packages/tokens/src/rwa/storage.rs
@@ -361,12 +361,36 @@ impl RWA {
     ///
     /// # Errors
     ///
+    /// * [`RWAError::InsufficientBalance`] - When `amount` exceeds the total
+    ///   balance of `user_address`.
+    /// * [`RWAError::ComplianceNotSet`] - When the compliance contract is not
+    ///   configured.
+    /// * refer to
+    ///   [`Compliance::destroyed`](crate::rwa::compliance::Compliance::destroyed)
+    ///   errors.
     /// * refer to [`Base::update`] errors.
     ///
     /// # Events
     ///
     /// * topics - `["burn", user_address: Address]`
     /// * data - `[amount: i128]`
+    ///
+    /// # Notes
+    ///
+    /// This function bypasses freezing restrictions and can unfreeze tokens
+    /// as needed: when `amount` exceeds the free (unfrozen) balance, the
+    /// difference is unfrozen first, so a partially frozen balance is
+    /// destroyed in place.
+    ///
+    /// Locked tokens are not given the same treatment. The `Destroyed` hook
+    /// carries no notion of a privileged burn, so a compliance module can
+    /// reject the burn by panicking regardless of who issued it. In
+    /// particular, with the
+    /// [`initial_lockup_period`](crate::rwa::compliance::modules::initial_lockup_period)
+    /// module registered, a burn that dips into still-locked tokens is
+    /// rejected; destroying a locked position takes a forced transfer to a
+    /// treasury wallet (which consumes the locks) followed by a burn from
+    /// that treasury.
     ///
     /// # Security Warning
     ///


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

Burn operation does bypass frozen, but does not bypass locked tokens. This PR explicitly documents that behavior.

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #817 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [ ] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified burn behavior for locked and frozen tokens.
  * Documented that burns cannot bypass lock restrictions.
  * Added guidance for destroying locked positions through a forced transfer followed by a treasury burn.
  * Expanded documentation of possible burn errors and compliance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->