### PR TITLE
docs(weighted-threshold): document required operation ordering for signer weight and threshold updates

### DIFF
--- a/packages/accounts/src/policies/weighted_threshold.rs
+++ b/packages/accounts/src/policies/weighted_threshold.rs
@@ -40,15 +40,33 @@
 //!
 //! 1. **Review current weights** using `get_signer_weights()` and threshold
 //!    using `get_threshold()`
-//! 2. **Before removing signers**: Update weights using `set_signer_weight()`
-//!    or adjust threshold using `set_threshold()` to ensure it remains
-//!    achievable
+//! 2. **Before removing signers**: Lower the threshold using `set_threshold()`
+//!    or reduce weights using `set_signer_weight()` so it remains achievable
 //! 3. **After adding signers**: Set weights for new signers using
-//!    `set_signer_weight()` and adjust threshold if needed to maintain security
-//!    level
+//!    `set_signer_weight()` and adjust the threshold if needed to maintain the
+//!    security level
 //!
-//! **Failure to follow this process may result in permanent DoS or silent
-//! security degradation.**
+//! ## Required Operation Ordering
+//!
+//! Both `set_threshold()` and `set_signer_weight()` enforce the invariant
+//! `threshold <= total signer weight` on **every individual call**. Because
+//! each call is validated in isolation, reconfiguration is strictly
+//! order-sensitive:
+//!
+//! - **When adding weight and raising the threshold**: call
+//!   `set_signer_weight()` **first** to increase the total weight, then
+//!   `set_threshold()`. Raising the threshold first reverts if the new
+//!   threshold exceeds the current total weight.
+//! - **When removing a signer or reducing weight**: call `set_threshold()`
+//!   **first** to lower the threshold, then `set_signer_weight()`. Reducing the
+//!   weight first reverts if it drops the total weight below the current
+//!   threshold.
+//!
+//! Calls in the wrong order revert with
+//! [`WeightedThresholdError::InvalidThreshold`] (error 3211) mid-sequence.
+//!
+//! **Failure to follow this process may result in permanent DoS, silent
+//! security degradation, or a mid-sequence `InvalidThreshold` revert.**
 //!
 //! ## Example Usage
 //!
@@ -332,6 +350,10 @@ pub fn enforce(
 /// signers to ensure the threshold remains achievable, or AFTER adding signers
 /// to maintain the intended approval percentage.
 ///
+/// The new threshold must not exceed the current total signer weight, so when
+/// raising the threshold and adding weight, call `set_signer_weight()` first.
+/// See the module-level "Required Operation Ordering" section for details.
+///
 /// # Arguments
 ///
 /// * `e` - Access to the Soroban environment.
@@ -341,7 +363,8 @@ pub fn enforce(
 ///
 /// # Errors
 ///
-/// * [`WeightedThresholdError::InvalidThreshold`] - When threshold is 0.
+/// * [`WeightedThresholdError::InvalidThreshold`] - When threshold is 0, or
+///   when it exceeds the current total signer weight.
 /// * [`WeightedThresholdError::SmartAccountNotInstalled`] - When the policy is
 ///   not installed.
 ///
@@ -390,6 +413,10 @@ pub fn set_threshold(e: &Env, threshold: u32, context_rule: &ContextRule, smart_
 /// **Call this function AFTER adding new signers** to the ContextRule to assign
 /// them appropriate weights. Signers without configured weights contribute 0
 /// weight, which may create confusion about the actual security level.
+///
+/// The updated total weight must not drop below the current threshold, so when
+/// removing a signer or reducing weight, call `set_threshold()` first. See the
+/// module-level "Required Operation Ordering" section for details.
 ///
 /// # Arguments
 ///

--- a/packages/accounts/src/policies/weighted_threshold.rs
+++ b/packages/accounts/src/policies/weighted_threshold.rs
@@ -40,8 +40,9 @@
 //!
 //! 1. **Review current weights** using `get_signer_weights()` and threshold
 //!    using `get_threshold()`
-//! 2. **Before removing signers**: Lower the threshold using `set_threshold()`
-//!    or reduce weights using `set_signer_weight()` so it remains achievable
+//! 2. **Before removing signers or reducing weight**: Lower the threshold using
+//!    `set_threshold()` first, then reduce weights using `set_signer_weight()`,
+//!    so the threshold remains achievable
 //! 3. **After adding signers**: Set weights for new signers using
 //!    `set_signer_weight()` and adjust the threshold if needed to maintain the
 //!    security level
@@ -50,8 +51,7 @@
 //!
 //! Both `set_threshold()` and `set_signer_weight()` enforce the invariant
 //! `threshold <= total signer weight` on **every individual call**. Because
-//! each call is validated in isolation, reconfiguration is strictly
-//! order-sensitive:
+//! each call is validated in isolation, reconfiguration is order-sensitive:
 //!
 //! - **When adding weight and raising the threshold**: call
 //!   `set_signer_weight()` **first** to increase the total weight, then
@@ -62,11 +62,15 @@
 //!   weight first reverts if it drops the total weight below the current
 //!   threshold.
 //!
-//! Calls in the wrong order revert with
-//! [`WeightedThresholdError::InvalidThreshold`] (error 3211) mid-sequence.
+//! A call reverts with [`WeightedThresholdError::InvalidThreshold`] (error
+//! 3211) whenever it would leave `threshold > total signer weight`. A
+//! wrong-order sequence therefore fails at the first step whose intermediate
+//! state violates that invariant.
 //!
-//! **Failure to follow this process may result in permanent DoS, silent
-//! security degradation, or a mid-sequence `InvalidThreshold` revert.**
+//! **Failure to keep weights and threshold in sync with the ContextRule's
+//! signer set may result in permanent DoS or silent security degradation.
+//! Performing the updates in the wrong order additionally risks an
+//! `InvalidThreshold` revert mid-sequence.**
 //!
 //! ## Example Usage
 //!


### PR DESCRIPTION
## Summary

Fixes #761.

`set_threshold` and `set_signer_weight` in `packages/accounts/src/policies/weighted_threshold.rs` both enforce the invariant `threshold <= total_weight` on **every individual call**. Because each call is validated in isolation, reconfiguring a signer set is strictly order-sensitive, and doing it in the wrong order reverts mid-sequence with an opaque `InvalidThreshold` (error 3211). This ordering requirement was previously undocumented.

## Changes (documentation only)

- Added a **Required Operation Ordering** section to the module docs spelling out the two cases:
  - Adding weight and raising the threshold → call `set_signer_weight()` first, then `set_threshold()`.
  - Removing a signer or reducing weight → call `set_threshold()` first, then `set_signer_weight()`.
- Tightened the wording of the existing **Required Administrator Actions** steps to reflect the ordering.
- Added a concise ordering note to the `# Security Warning` on both `set_threshold` and `set_signer_weight`, cross-referencing the module section.
- Corrected the `# Errors` section of `set_threshold` to note the second `InvalidThreshold` case (threshold exceeds current total weight), not only `threshold == 0`.

No behavior change.

## Validation

- Confirmed the finding against the code (checks at the two call sites; `InvalidThreshold = 3211`).
- `cargo +nightly fmt --all -- --check` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --package stellar-accounts` — builds clean, all intra-doc links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for safely updating signer weights and approval thresholds.
  * Clarified valid threshold requirements and operation ordering.
  * Documented potential invalid states when reducing signer weight or changing thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->