### PR TITLE
fix: preserve the SEP-41 muxed id in RWA transfer events

### DIFF
--- a/packages/tokens/src/rwa/storage.rs
+++ b/packages/tokens/src/rwa/storage.rs
@@ -33,7 +33,7 @@ pub struct RWA;
 
 impl ContractOverrides for RWA {
     fn transfer(e: &Env, from: &Address, to: &MuxedAddress, amount: i128) {
-        RWA::transfer(e, from, &to.address(), amount);
+        RWA::transfer_with_muxed_id(e, from, &to.address(), to.id(), amount);
     }
 
     fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, amount: i128) {
@@ -771,6 +771,32 @@ impl RWA {
     /// Please refer to [`Base::update`] and [`Self::validate_transfer`] for the
     /// inline documentation.
     pub fn transfer(e: &Env, from: &Address, to: &Address, amount: i128) {
+        Self::transfer_with_muxed_id(e, from, to, None, amount);
+    }
+
+    /// `transfer` override that additionally carries the SEP-41 multiplexing
+    /// identifier of the destination into the emitted event.
+    ///
+    /// Identity verification, compliance and balance updates all operate on
+    /// the base `to` address; `to_muxed_id` only reaches the event, so that
+    /// off-chain consumers can attribute the transfer to the correct
+    /// sub-account.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `from` - The address holding the tokens.
+    /// * `to` - The base address receiving the tokens.
+    /// * `to_muxed_id` - The multiplexing identifier of the destination, if the
+    ///   caller supplied a muxed address.
+    /// * `amount` - The amount of tokens to be transferred.
+    fn transfer_with_muxed_id(
+        e: &Env,
+        from: &Address,
+        to: &Address,
+        to_muxed_id: Option<u64>,
+        amount: i128,
+    ) {
         from.require_auth();
 
         // Snapshot before the update so the hook observes the pre-transfer
@@ -790,7 +816,7 @@ impl RWA {
             &TransferKind::Standard,
             &e.current_contract_address(),
         );
-        emit_transfer(e, from, to, None, amount);
+        emit_transfer(e, from, to, to_muxed_id, amount);
     }
 
     /// `transfer_from` override with added compliance and identity verification

--- a/packages/tokens/src/rwa/test.rs
+++ b/packages/tokens/src/rwa/test.rs
@@ -2,13 +2,13 @@ extern crate std;
 
 use soroban_sdk::{
     contract, contractimpl, panic_with_error, symbol_short,
-    testutils::{Address as _, Events},
-    Address, Env, Event, String,
+    testutils::{Address as _, Events, MuxedAddress as _},
+    Address, Env, Event, MuxedAddress, String,
 };
 use stellar_contract_utils::pausable;
 
 use crate::{
-    fungible::{ContractOverrides, Transfer},
+    fungible::{ContractOverrides, MuxedTransfer, Transfer},
     rwa::{
         compliance::{AccountSnapshot, TransferKind},
         storage::RWAStorageKey,
@@ -633,6 +633,48 @@ fn contract_overrides_transfer() {
 
         assert_eq!(RWA::balance(&e, &from), 70);
         assert_eq!(RWA::balance(&e, &to), 30);
+    });
+}
+
+#[test]
+fn contract_overrides_transfer_preserves_muxed_id() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(MockRWAContract, ());
+    let from = Address::generate(&e);
+    let to_muxed_base = MuxedAddress::generate(&e);
+    let to = to_muxed_base.address();
+    let to_muxed = MuxedAddress::new(to_muxed_base.clone(), 42u64);
+
+    e.as_contract(&address, || {
+        setup_all_contracts(&e);
+
+        RWA::mint(&e, &from, 100);
+
+        <RWA as ContractOverrides>::transfer(&e, &from, &to_muxed, 30);
+
+        // Balances settle on the base address, exactly as for a plain
+        // transfer.
+        assert_eq!(RWA::balance(&e, &from), 70);
+        assert_eq!(RWA::balance(&e, &to), 30);
+
+        // The multiplexing identifier must survive into the event, so that
+        // off-chain consumers can attribute the transfer to the correct
+        // sub-account. `Base` already does this; RWA used to drop it.
+        //
+        // 1 IdentityVerifierSet + 1 ComplianceSet + 1 Minted + 1 MuxedTransfer
+        let events = e.events().all();
+        assert_eq!(events.events().len(), 4);
+        assert_eq!(
+            events.events().get(3).unwrap(),
+            &MuxedTransfer {
+                from: from.clone(),
+                to: to.clone(),
+                to_muxed_id: Some(42),
+                amount: 30,
+            }
+            .to_xdr(&e, &address)
+        );
     });
 }
 


### PR DESCRIPTION
Fixes #842

### Problem

#646 added muxed transfer events to the fungible token so off-chain consumers can attribute a transfer to the correct sub-account. It touched `packages/tokens/src/fungible/` and the event-assertion helper only. `Base`, `AllowList`, `BlockList` and `FungibleVotes` all emit `to.id()`; RWA collapsed the destination to its base address on the first line of its `ContractOverrides::transfer` and passed `None` at every emit site.

### Change

The transfer body moves into a private `RWA::transfer_with_muxed_id` that takes `Option<u64>` and threads it to `emit_transfer`. `ContractOverrides::transfer` passes `to.id()`; the public `RWA::transfer` keeps its exact signature and passes `None`.

Identity verification, the compliance hook and `Base::update` all still receive the base `Address`.

For a muxed destination the emitted event does change wire shape, from `Transfer` with a bare `i128` payload to `MuxedTransfer` with a map payload. That is the intended fix, but it is downstream-visible and may warrant a release note. It only affects calls that pass a muxed address, which are mis-emitted today. That is a deliberate choice and it is the open design question here: if you want the muxed id visible to `validate_transfer` or to the compliance hook as well, that is a larger change and I would rather you decide it than assume.

`transfer_from`, `mint`, `burn`, `forced_transfer` and `recover_balance` all take a plain `Address` and are untouched; their emit sites still pass `None`, which is correct.

### Evidence

`contract_overrides_transfer_preserves_muxed_id` sends 30 units to a `MuxedAddress` with id 42 and asserts the emitted event.

Reverting only the source hunk and keeping the test gives:

```
left:  data: I128(30)
right: data: Map([ amount: I128(30), to_muxed_id: U64(42) ])
```

The test also asserts balances land on the base address, unchanged at 70 and 30, so the change is visibly confined to the event payload.

### Checks

- `cargo +nightly fmt --all -- --check` clean
- `cargo +stable clippy --release --locked --all-targets -- -D warnings` exit 0
- `cargo test -p stellar-tokens` passes: 714 tests, 713 before plus this one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RWA transfers to preserve destination IDs when sending to muxed addresses.
  * Transfer events now report the correct muxed destination ID.
  * Balances continue settling against the underlying base address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->