### PR TITLE
fix: dispatch royalty_info existence check through ContractType

### DIFF
--- a/packages/tokens/src/non_fungible/extensions/royalties/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/royalties/mod.rs
@@ -1,5 +1,5 @@
 mod storage;
-use crate::non_fungible::{Base, NonFungibleToken};
+use crate::non_fungible::{Base, ContractOverrides, NonFungibleToken};
 
 #[cfg(test)]
 mod test;
@@ -142,7 +142,13 @@ pub trait NonFungibleRoyalties: NonFungibleToken {
     /// * [`crate::non_fungible::NonFungibleTokenError::NonExistentToken`] - If
     ///   the token does not exist.
     fn royalty_info(e: &Env, token_id: u32, sale_price: i128) -> (Address, i128) {
-        Base::royalty_info(e, token_id, sale_price)
+        // Establish existence through the contract's own ownership model.
+        // `Base::owner_of` only resolves tokens that have a materialised
+        // `Owner` entry, so calling it directly would reject every token that
+        // `Consecutive` resolves by walking back through its bucket.
+        let _ = Self::ContractType::owner_of(e, token_id);
+
+        Base::royalty_info_unchecked(e, token_id, sale_price)
     }
 }
 

--- a/packages/tokens/src/non_fungible/extensions/royalties/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/royalties/storage.rs
@@ -159,6 +159,29 @@ impl Base {
         // Verify token exists by checking owner
         let _ = Base::owner_of(e, token_id);
 
+        Self::royalty_info_unchecked(e, token_id, sale_price)
+    }
+
+    /// Returns the royalty information for a token **without** verifying that
+    /// the token exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `e` - Access to the Soroban environment.
+    /// * `token_id` - The identifier of the token.
+    /// * `sale_price` - The sale price for which royalties are being
+    ///   calculated.
+    ///
+    /// # Security Warning
+    ///
+    /// **IMPORTANT**: This function does not verify that the token exists.
+    /// Callers must establish existence first, using the ownership model that
+    /// applies to their contract. [`Base::royalty_info`] does so with
+    /// [`Base::owner_of`]; a contract whose `ContractType` stores ownership
+    /// differently, such as
+    /// [`crate::non_fungible::consecutive::Consecutive`], must use its own
+    /// `owner_of` instead.
+    pub fn royalty_info_unchecked(e: &Env, token_id: u32, sale_price: i128) -> (Address, i128) {
         // Check if there's a specific royalty for this token
         let token_key = NFTRoyaltiesStorageKey::TokenRoyalty(token_id);
         if let Some(royalty_info) = e.storage().persistent().get::<_, RoyaltyInfo>(&token_key) {

--- a/packages/tokens/src/non_fungible/extensions/royalties/test.rs
+++ b/packages/tokens/src/non_fungible/extensions/royalties/test.rs
@@ -1,8 +1,11 @@
 extern crate std;
 
-use soroban_sdk::{contract, testutils::Address as _, Address, Env};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env, String};
 
-use crate::non_fungible::{extensions::enumerable::Enumerable, Base};
+use crate::non_fungible::{
+    consecutive::Consecutive, extensions::enumerable::Enumerable, royalties::NonFungibleRoyalties,
+    Base, NonFungibleToken,
+};
 
 #[contract]
 struct MockContract;
@@ -217,4 +220,66 @@ fn test_remove_token_royalty_no_default() {
         assert_eq!(royalty_receiver, e.current_contract_address());
         assert_eq!(royalty_amount, 0);
     });
+}
+
+// A contract that pairs the royalties extension with `Consecutive`, whose
+// ownership is stored sparsely: only the last token of a batch gets a
+// materialised `Owner` entry, and the rest are resolved by walking back
+// through the bucket. `royalty_info` must therefore establish existence
+// through `Self::owner_of` rather than `Base::owner_of`.
+#[contract]
+struct ConsecutiveRoyaltiesContract;
+
+#[contractimpl(contracttrait)]
+impl NonFungibleToken for ConsecutiveRoyaltiesContract {
+    type ContractType = Consecutive;
+}
+
+#[contractimpl(contracttrait)]
+impl NonFungibleRoyalties for ConsecutiveRoyaltiesContract {
+    fn set_default_royalty(e: &Env, receiver: Address, basis_points: u32, _operator: Address) {
+        Base::set_default_royalty(e, &receiver, basis_points);
+    }
+
+    fn set_token_royalty(
+        e: &Env,
+        token_id: u32,
+        receiver: Address,
+        basis_points: u32,
+        _operator: Address,
+    ) {
+        Base::set_token_royalty(e, token_id, &receiver, basis_points);
+    }
+
+    fn remove_token_royalty(e: &Env, token_id: u32, _operator: Address) {
+        Base::remove_token_royalty(e, token_id);
+    }
+}
+
+#[test]
+fn test_royalty_info_resolves_every_token_under_consecutive() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let address = e.register(ConsecutiveRoyaltiesContract, ());
+    let client = ConsecutiveRoyaltiesContractClient::new(&e, &address);
+
+    let owner = Address::generate(&e);
+    let receiver = Address::generate(&e);
+
+    e.as_contract(&address, || {
+        Consecutive::batch_mint(&e, &owner, 10);
+        Base::set_default_royalty(&e, &receiver, 500); // 5%
+    });
+
+    // Every token in the batch exists and resolves an owner, so every token
+    // must also resolve royalty information. Before this was fixed, only
+    // token 9 answered: it is the batch boundary and therefore the only id
+    // with a materialised `Owner` entry.
+    for token_id in 0..10u32 {
+        assert_eq!(client.owner_of(&token_id), owner);
+
+        let (royalty_receiver, royalty_amount) = client.royalty_info(&token_id, &1_000_000);
+        assert_eq!(royalty_receiver, receiver);
+        assert_eq!(royalty_amount, 50_000); // 5% of 1_000_000
+    }
 }


### PR DESCRIPTION
Fixes #845

### Problem

`NonFungibleRoyalties::royalty_info`'s default body called `Base::royalty_info`, which establishes existence with `Base::owner_of`. Under `ContractType = Consecutive` ownership is stored sparsely: only the last token of a batch has a materialised `Owner` entry, and the rest are resolved by walking back through the bucket. Every non-boundary token was therefore rejected with `#200 NonExistentToken`.

The library documents the correct pattern in `non_fungible/overrides.rs`, and every sibling default body follows it. `royalty_info` was the exception, which looks like it was missed when the default bodies landed in #604.

### Change

The existence check now goes through `Self::ContractType::owner_of`, matching how every other default body in this library dispatches.

The lookup itself moves into `Base::royalty_info_unchecked`, so `Base::royalty_info` keeps its current behaviour exactly: it still calls `Base::owner_of` and then the same lookup.

**This adds public API to a published crate**, which is worth flagging up front. The `_unchecked` suffix follows `credit_identity_unchecked` in `rwa/compliance/modules/max_balance/storage.rs`, and the new function carries a `# Security Warning` section as that precedent does. If you would rather not grow the surface, the alternative is to put `royalty_info` on `ContractOverrides` with the `Base` behaviour as the default and override it in `Consecutive`. Say the word and I will redo it that way.

### Evidence

`test_royalty_info_resolves_every_token_under_consecutive` batch-mints ten tokens and asserts that each one resolves both an owner and royalty information.

Reverting only the two source hunks and keeping the test gives:

```
test ...resolves_every_token_under_consecutive ... FAILED
HostError: Error(Contract, #200)
  data: ["contract call failed", royalty_info, [0, 1000000]]
```

The test also asserts `owner_of` answers for all ten. That is the control: the tokens demonstrably exist and `Consecutive` resolves them, so the failure is in the dispatch rather than the token.

### Checks

- `cargo +nightly fmt --all -- --check` clean
- `cargo +stable clippy --release --locked --all-targets -- -D warnings` exit 0
- `cargo test -p stellar-tokens` passes: 714 tests, 713 before plus this one. `nft-royalties-example` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Royalty information now works correctly for tokens issued through consecutive token batches.
  * Royalty lookups validate token ownership before returning royalty details.

* **Tests**
  * Added regression coverage for royalty resolution across all tokens in a consecutive batch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->