### PR TITLE
fix: cap spending history at the reachable ledger entry limit

### DIFF
--- a/packages/accounts/src/policies/spending_limit.rs
+++ b/packages/accounts/src/policies/spending_limit.rs
@@ -158,14 +158,15 @@ pub const SPENDING_LIMIT_TTL_THRESHOLD: u32 = SPENDING_LIMIT_EXTEND_AMOUNT - DAY
 ///
 /// # Notes
 ///
-/// This cap is currently **unreachable**. A `SpendingLimitData` holding 816
-/// entries serializes to 65,592 bytes, past the mainnet
-/// `contractDataEntrySizeBytes` limit of 65,536, so [`enforce`] fails with a
-/// host budget error at 816 and [`SpendingLimitError::HistoryCapacityExceeded`]
-/// is never returned. The measured ceiling is 815 entries.
-/// `spending_history_ledger_entry_ceiling` in the test module pins both
-/// boundaries.
-pub const MAX_HISTORY_ENTRIES: u32 = 1000;
+/// The cap is the largest history that still fits in a single ledger entry. A
+/// `SpendingLimitData` holding 816 entries serializes to 65,592 bytes, past the
+/// mainnet `contractDataEntrySizeBytes` limit of 65,536, so a higher cap could
+/// never be enforced: [`enforce`] would fail with an untyped host budget error
+/// before [`SpendingLimitError::HistoryCapacityExceeded`] could be returned.
+/// Raising this value therefore requires a smaller entry or a larger network
+/// limit, which
+/// `spending_history_past_the_cap_exceeds_the_ledger_entry_limit` pins.
+pub const MAX_HISTORY_ENTRIES: u32 = 815;
 
 // ################## QUERY STATE ##################
 

--- a/packages/accounts/src/policies/spending_limit.rs
+++ b/packages/accounts/src/policies/spending_limit.rs
@@ -155,6 +155,16 @@ pub const SPENDING_LIMIT_TTL_THRESHOLD: u32 = SPENDING_LIMIT_EXTEND_AMOUNT - DAY
 
 /// Maximum number of spending entries to keep in history.
 /// This prevents storage DoS by capping the vector size.
+///
+/// # Notes
+///
+/// This cap is currently **unreachable**. A `SpendingLimitData` holding 816
+/// entries serializes to 65,592 bytes, past the mainnet
+/// `contractDataEntrySizeBytes` limit of 65,536, so [`enforce`] fails with a
+/// host budget error at 816 and [`SpendingLimitError::HistoryCapacityExceeded`]
+/// is never returned. The measured ceiling is 815 entries.
+/// `spending_history_ledger_entry_ceiling` in the test module pins both
+/// boundaries.
 pub const MAX_HISTORY_ENTRIES: u32 = 1000;
 
 // ################## QUERY STATE ##################

--- a/packages/accounts/src/policies/test/spending_limit.rs
+++ b/packages/accounts/src/policies/test/spending_limit.rs
@@ -905,3 +905,63 @@ fn enforce_create_contract_context_with_signers_errors() {
         enforce(&e, &context, &context_rule.signers, &context_rule, &smart_account);
     });
 }
+
+/// The number of `SpendingEntry` items that fit in one ledger entry under the
+/// mainnet `contractDataEntrySizeBytes` limit of 65,536. Measured: 816 entries
+/// serialize to 65,592 bytes.
+const MEASURED_ENTRY_CEILING: u32 = 815;
+
+/// Fill `spending_history` with `count` entries, one per ledger, through the
+/// real `enforce` path and with resource limits left at their mainnet
+/// defaults.
+fn fill_history(e: &Env, address: &Address, smart_account: &Address, count: u32) {
+    let context_rule = create_context_rule(e);
+    let context = create_transfer_context(e, 1);
+
+    e.as_contract(address, || {
+        let params =
+            SpendingLimitAccountParams { spending_limit: i128::MAX, period_ledgers: 1_000_000 };
+        install(e, &params, &context_rule, smart_account);
+    });
+
+    for i in 0..count {
+        e.ledger().with_mut(|li| {
+            li.sequence_number = 1000 + i;
+        });
+        e.as_contract(address, || {
+            enforce(e, &context, &context_rule.signers, &context_rule, smart_account);
+        });
+    }
+}
+
+#[test]
+fn spending_history_ledger_entry_ceiling() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+    let smart_account = Address::generate(&e);
+
+    e.mock_all_auths();
+
+    // Filling to the measured ceiling succeeds. This is well below
+    // MAX_HISTORY_ENTRIES, so the capacity guard never participates.
+    fill_history(&e, &address, &smart_account, MEASURED_ENTRY_CEILING);
+
+    let data = e.as_contract(&address, || get_spending_limit_data(&e, 1, &smart_account));
+    assert_eq!(data.spending_history.len(), MEASURED_ENTRY_CEILING);
+}
+
+#[test]
+#[should_panic(expected = "Error(Budget, ExceededLimit)")]
+fn spending_history_one_past_the_ceiling_exceeds_the_ledger_entry_limit() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+    let smart_account = Address::generate(&e);
+
+    e.mock_all_auths();
+
+    // One entry past the ceiling, the write of the whole SpendingLimitData
+    // exceeds contractDataEntrySizeBytes and the host rejects it. This is the
+    // reason MAX_HISTORY_ENTRIES is unreachable: the failure arrives as an
+    // untyped budget error rather than HistoryCapacityExceeded.
+    fill_history(&e, &address, &smart_account, MEASURED_ENTRY_CEILING + 1);
+}

--- a/packages/accounts/src/policies/test/spending_limit.rs
+++ b/packages/accounts/src/policies/test/spending_limit.rs
@@ -709,7 +709,6 @@ fn enforce_negative_amount_errors() {
 #[should_panic(expected = "Error(Contract, #3224)")]
 fn enforce_history_capacity_exceeded() {
     let e = Env::default();
-    e.cost_estimate().disable_resource_limits();
     let address = e.register(MockContract, ());
     let smart_account = Address::generate(&e);
     let context_rule = create_context_rule(&e);
@@ -906,62 +905,29 @@ fn enforce_create_contract_context_with_signers_errors() {
     });
 }
 
-/// The number of `SpendingEntry` items that fit in one ledger entry under the
-/// mainnet `contractDataEntrySizeBytes` limit of 65,536. Measured: 816 entries
-/// serialize to 65,592 bytes.
-const MEASURED_ENTRY_CEILING: u32 = 815;
-
-/// Fill `spending_history` with `count` entries, one per ledger, through the
-/// real `enforce` path and with resource limits left at their mainnet
-/// defaults.
-fn fill_history(e: &Env, address: &Address, smart_account: &Address, count: u32) {
-    let context_rule = create_context_rule(e);
-    let context = create_transfer_context(e, 1);
-
-    e.as_contract(address, || {
-        let params =
-            SpendingLimitAccountParams { spending_limit: i128::MAX, period_ledgers: 1_000_000 };
-        install(e, &params, &context_rule, smart_account);
-    });
-
-    for i in 0..count {
-        e.ledger().with_mut(|li| {
-            li.sequence_number = 1000 + i;
-        });
-        e.as_contract(address, || {
-            enforce(e, &context, &context_rule.signers, &context_rule, smart_account);
-        });
-    }
-}
-
-#[test]
-fn spending_history_ledger_entry_ceiling() {
-    let e = Env::default();
-    let address = e.register(MockContract, ());
-    let smart_account = Address::generate(&e);
-
-    e.mock_all_auths();
-
-    // Filling to the measured ceiling succeeds. This is well below
-    // MAX_HISTORY_ENTRIES, so the capacity guard never participates.
-    fill_history(&e, &address, &smart_account, MEASURED_ENTRY_CEILING);
-
-    let data = e.as_contract(&address, || get_spending_limit_data(&e, 1, &smart_account));
-    assert_eq!(data.spending_history.len(), MEASURED_ENTRY_CEILING);
-}
-
 #[test]
 #[should_panic(expected = "Error(Budget, ExceededLimit)")]
-fn spending_history_one_past_the_ceiling_exceeds_the_ledger_entry_limit() {
+fn spending_history_past_the_cap_exceeds_the_ledger_entry_limit() {
     let e = Env::default();
     let address = e.register(MockContract, ());
     let smart_account = Address::generate(&e);
 
-    e.mock_all_auths();
-
-    // One entry past the ceiling, the write of the whole SpendingLimitData
-    // exceeds contractDataEntrySizeBytes and the host rejects it. This is the
-    // reason MAX_HISTORY_ENTRIES is unreachable: the failure arrives as an
-    // untyped budget error rather than HistoryCapacityExceeded.
-    fill_history(&e, &address, &smart_account, MEASURED_ENTRY_CEILING + 1);
+    // Bypass `enforce` and its capacity guard, writing a history one entry past
+    // the cap straight to storage. The write exceeds
+    // `contractDataEntrySizeBytes` and the host rejects it, which is why
+    // MAX_HISTORY_ENTRIES cannot be raised on its own.
+    e.as_contract(&address, || {
+        let mut spending_history = Vec::new(&e);
+        for i in 0..=MAX_HISTORY_ENTRIES {
+            spending_history.push_back(SpendingEntry { amount: 1, ledger_sequence: 1000 + i });
+        }
+        let data = SpendingLimitData {
+            spending_limit: i128::MAX,
+            period_ledgers: 1_000_000,
+            spending_history,
+            cached_total_spent: i128::from(MAX_HISTORY_ENTRIES) + 1,
+        };
+        let key = SpendingLimitStorageKey::AccountContext(smart_account.clone(), 1);
+        e.storage().persistent().set(&key, &data);
+    });
 }


### PR DESCRIPTION
Fixes #847

### What this does

Caps `spending_history` at the value that is actually reachable, so the guard fires and callers get `HistoryCapacityExceeded` instead of an untyped host budget error.

```diff
-pub const MAX_HISTORY_ENTRIES: u32 = 1000;
+pub const MAX_HISTORY_ENTRIES: u32 = 815;
```

### Why 815

A `SpendingLimitData` holding 816 entries serializes to 65,592 bytes, past the mainnet `contractDataEntrySizeBytes` of 65,536. At 1000 the guard could never fire: `enforce` died with `Error(Budget, ExceededLimit)` 185 entries early and `HistoryCapacityExceeded` was unreachable.

### On `disable_resource_limits`

`enforce_history_capacity_exceeded` was only green because it called `e.cost_estimate().disable_resource_limits()`. With limits off the entry size ceiling never applies, which is probably why the unreachable cap went unnoticed. I dropped that one line, so the test now fills the history under mainnet defaults and still gets `#3224`. The other 7 uses of the idiom elsewhere in the repo are untouched. Can put it back if you'd rather keep it.

### Tests

- `enforce_history_capacity_exceeded` now runs under mainnet limits and still expects `#3224`.
- `spending_history_past_the_cap_exceeds_the_ledger_entry_limit` writes one entry past the cap straight to storage, bypassing the guard, so the ceiling is pinned by a test rather than a comment. It asserts `Error(Budget, ExceededLimit)` rather than a contract error code, which is deliberate: the failure genuinely is a host rejection and that is the point being pinned.

### Checks

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p stellar-accounts --all-targets -- -D warnings` exit 0
- `cargo test -p stellar-accounts`: 182 passed, 0 failed
