### PR TITLE
fix(ci): rewrap comments for indent-aware rustfmt

### DIFF
--- a/examples/fungible-governor/token/src/test.rs
+++ b/examples/fungible-governor/token/src/test.rs
@@ -455,8 +455,8 @@ fn voting_power_snapshot_at_proposal_creation() {
     // because the snapshot is at vote_snapshot (ledger 210)
     s.token.mint(&voter, &10000);
 
-    // voter's weight should be based on snapshot at vote_snapshot (210), which was
-    // 600
+    // voter's weight should be based on snapshot at vote_snapshot (210), which
+    // was 600
     let weight = s.governor.cast_vote(&proposal_id, &1, &String::from_str(&s.e, ""), &voter);
     assert_eq!(weight, 600);
 }

--- a/examples/fungible-vault/src/contract.rs
+++ b/examples/fungible-vault/src/contract.rs
@@ -18,7 +18,8 @@ impl ExampleContract {
         asset: Address,
         decimals_offset: u32,
     ) {
-        // Asset and decimal offset should be configured once during initialization.
+        // Asset and decimal offset should be configured once during
+        // initialization.
         Vault::set_asset(e, asset);
         Vault::set_decimals_offset(e, decimals_offset);
         // Vault overrides the decimals function by default.

--- a/examples/fungible-vault/src/test.rs
+++ b/examples/fungible-vault/src/test.rs
@@ -58,7 +58,8 @@ fn create_asset_client<'a>(
 fn test_vault_initialization() {
     let e = Env::default();
     let admin = Address::generate(&e);
-    let initial_supply = 1_000_000_000_000_000_000i128; // 1M tokens with 18 decimals
+    let initial_supply = 1_000_000_000_000_000_000i128; // 1M tokens with 18
+                                                        // decimals
     let decimals_offset = 6;
 
     // Create asset contract
@@ -70,7 +71,8 @@ fn test_vault_initialization() {
 
     // Test vault initialization
     assert_eq!(vault_client.query_asset(), asset_address);
-    assert_eq!(vault_client.decimals(), 18 + decimals_offset); // asset decimals + offset
+    assert_eq!(vault_client.decimals(), 18 + decimals_offset); // asset decimals
+                                                               // + offset
     assert_eq!(vault_client.total_supply(), 0);
     assert_eq!(vault_client.total_assets(), 0);
 }
@@ -306,7 +308,8 @@ fn test_multiple_users_deposit_withdraw() {
     // User1 deposits first
     let shares1 = vault_client.deposit(&deposit_amount, &user1, &user1, &user1);
 
-    // User2 deposits same amount (should get same shares since ratio is still 1:1)
+    // User2 deposits same amount (should get same shares since ratio is still
+    // 1:1)
     let shares2 = vault_client.deposit(&deposit_amount, &user2, &user2, &user2);
 
     assert_eq!(shares1, shares2);

--- a/examples/nft-access-control/src/contract.rs
+++ b/examples/nft-access-control/src/contract.rs
@@ -29,15 +29,16 @@ impl ExampleContract {
         Base::mint(e, &to, token_id)
     }
 
-    // allows either minter or burner role, does not enforce `require_auth` in the
-    // macro
+    // allows either minter or burner role, does not enforce `require_auth` in
+    // the macro
     #[has_any_role(caller, ["minter", "burner"])]
     pub fn multi_role_action(e: &Env, caller: Address) -> String {
         caller.require_auth();
         String::from_str(e, "multi_role_action_success")
     }
 
-    // allows either minter or burner role AND enforces `require_auth` in the macro
+    // allows either minter or burner role AND enforces `require_auth` in the
+    // macro
     #[only_any_role(caller, ["minter", "burner"])]
     pub fn multi_role_auth_action(e: &Env, caller: Address) -> String {
         String::from_str(e, "multi_role_auth_action_success")
@@ -53,8 +54,8 @@ impl NonFungibleToken for ExampleContract {
 // specific people with the `burner` role
 #[contractimpl]
 impl NonFungibleBurnable for ExampleContract {
-    // we DON'T want `require_auth()` provided by the macro, since there is already
-    // `require_auth()` in `Base::burn`
+    // we DON'T want `require_auth()` provided by the macro, since there is
+    // already `require_auth()` in `Base::burn`
     #[has_role(from, "burner")]
     fn burn(e: &Env, from: Address, token_id: u32) {
         Base::burn(e, &from, token_id);

--- a/examples/rwa/claim-issuer/src/test.rs
+++ b/examples/rwa/claim-issuer/src/test.rs
@@ -185,7 +185,8 @@ fn remove_nonexistent_key_panics() {
 fn allow_key_for_unregistered_topic_panics() {
     let e = Env::default();
     e.mock_all_auths();
-    // Registry only knows about topic 1; trying to allow key for topic 99 fails.
+    // Registry only knows about topic 1; trying to allow key for topic 99
+    // fails.
     let (client, registry) = setup(&e, 1u32);
 
     let kp = Ed25519KeyPair::generate([1u8; 32]);
@@ -277,7 +278,8 @@ fn is_claim_valid_expired_claim_panics() {
     let raw = Bytes::from_array(&e, &[1u8, 2, 3]);
     let claim_data = encode_claim_data_expiration(&e, 100, 500, &raw);
 
-    // Build message and sign while ledger is still at the default (0) timestamp.
+    // Build message and sign while ledger is still at the default (0)
+    // timestamp.
     let issuer_addr = client.address.clone();
     let message = e.as_contract(&issuer_addr, || {
         Ed25519Verifier::build_message(&e, &identity, claim_topic, &claim_data)

--- a/examples/sac-admin-generic/src/contract.rs
+++ b/examples/sac-admin-generic/src/contract.rs
@@ -97,7 +97,8 @@ impl CustomAccountInterface for SacAdminExampleContract {
         );
         let caller = signature.public_key.clone();
 
-        // extract from context and check required permissionss for every function
+        // extract from context and check required permissionss for every
+        // function
         for ctx in auth_context.iter() {
             let context = match ctx {
                 Context::Contract(c) => c,
@@ -124,7 +125,8 @@ impl CustomAccountInterface for SacAdminExampleContract {
                     ensure_caller_chief(&e, &caller, &SacDataKey::Chief)?;
                 }
                 SacFn::Unknown => {
-                    // ensure only chief can call other functions such as `assign_operator()`,
+                    // ensure only chief can call other functions such as
+                    // `assign_operator()`,
                     // `remove_operator()` or `set_minting_limit()`
                     ensure_caller_chief(&e, &caller, &SacDataKey::Chief)?
                 }

--- a/examples/sac-admin-generic/src/test.rs
+++ b/examples/sac-admin-generic/src/test.rs
@@ -42,8 +42,8 @@ fn test_sac_generic() {
     let sac = e.register_stellar_asset_contract_v2(issuer.clone());
     let sac_client = StellarAssetClient::new(&e, &sac.address());
 
-    // Register the account contract, passing in the two signers (public keys) to
-    // the constructor.
+    // Register the account contract, passing in the two signers (public keys)
+    // to the constructor.
     let new_admin = e.register(
         SacAdminExampleContract,
         (
@@ -106,9 +106,9 @@ fn test_sac_generic_e2e_mint_and_clawback() {
     ]);
     let operator_pk = operator.verifying_key().to_bytes();
 
-    // Deploy a real SAC. `register_stellar_asset_contract_v2` creates a separate
-    // issuer account internally; enabling clawback on it makes minted balances
-    // clawbackable.
+    // Deploy a real SAC. `register_stellar_asset_contract_v2` creates a
+    // separate issuer account internally; enabling clawback on it makes
+    // minted balances clawbackable.
     let initial_admin = Address::generate(&e);
     let sac = e.register_stellar_asset_contract_v2(initial_admin);
     // `ClawbackEnabledFlag` makes minted balances clawbackable; `RevocableFlag`
@@ -134,12 +134,13 @@ fn test_sac_generic_e2e_mint_and_clawback() {
     e.mock_all_auths();
     sac_client.set_admin(&admin);
 
-    // `Val` -> `ScVal`, matching how the host serializes the recorded call args.
+    // `Val` -> `ScVal`, matching how the host serializes the recorded call
+    // args.
     let sc = |v: Val| ScVal::try_from_val(&e, &v).unwrap();
 
-    // Build a `SorobanAuthorizationEntry` signed by the operator, exactly as the
-    // host presents the SAC invocation to `__check_auth`. `set_auths` also
-    // disables the `mock_all_auths` enabled above.
+    // Build a `SorobanAuthorizationEntry` signed by the operator, exactly as
+    // the host presents the SAC invocation to `__check_auth`. `set_auths`
+    // also disables the `mock_all_auths` enabled above.
     let build_auth = |fn_name: &str, args: std::vec::Vec<ScVal>, nonce: i64| {
         let exp = e.ledger().sequence() + 1000;
         let invocation = SorobanAuthorizedInvocation {
@@ -186,7 +187,8 @@ fn test_sac_generic_e2e_mint_and_clawback() {
     sac_client.mint(&recipient, &1000);
     assert_eq!(sac_client.balance(&recipient), 1000);
 
-    // clawback(recipient, 400) through the real SAC, authorized by `__check_auth`.
+    // clawback(recipient, 400) through the real SAC, authorized by
+    // `__check_auth`.
     e.set_auths(&[build_auth(
         "clawback",
         std::vec![recipient_arg.clone(), sc(400i128.into_val(&e))],

--- a/examples/timelock-controller/src/contract.rs
+++ b/examples/timelock-controller/src/contract.rs
@@ -180,7 +180,8 @@ impl CustomAccountInterface for TimelockController {
                         panic_with_error!(&e, TimelockError::Unauthorized)
                     }
 
-                    // If no accounts have EXECUTOR_ROLE, anyone can execute a ready operation
+                    // If no accounts have EXECUTOR_ROLE, anyone can execute a
+                    // ready operation
                     if get_role_member_count(&e, &EXECUTOR_ROLE) != 0 {
                         // Check the role and the authorization of the executor
                         let args_for_auth = (

--- a/examples/upgradeable/upgrader/src/contract.rs
+++ b/examples/upgradeable/upgrader/src/contract.rs
@@ -33,8 +33,8 @@ impl Upgrader {
         let contract_client = UpgradeableClient::new(e, &contract_address);
 
         contract_client.upgrade(&wasm_hash, &operator);
-        // The types of the arguments to the migrate function are unknown to this
-        // contract, so we need to call it with invoke_contract.
+        // The types of the arguments to the migrate function are unknown to
+        // this contract, so we need to call it with invoke_contract.
         e.invoke_contract::<()>(&contract_address, &MIGRATE, migration_data);
     }
 }

--- a/packages/access/src/access_control/storage.rs
+++ b/packages/access/src/access_control/storage.rs
@@ -670,7 +670,8 @@ pub fn add_to_role_enumeration(e: &Env, account: &Address, role: &Symbol) {
     let count_key = AccessControlStorageKey::RoleAccountsCount(role.clone());
     let count = e.storage().persistent().get(&count_key).unwrap_or(0);
 
-    // If this is the first account with this role, add the role to ExistingRoles
+    // If this is the first account with this role, add the role to
+    // ExistingRoles
     if count == 0 {
         let mut existing_roles = get_existing_roles(e);
 
@@ -733,8 +734,8 @@ pub fn remove_from_role_enumeration(e: &Env, account: &Address, role: &Symbol) {
         index: last_index,
     });
 
-    // Swap the to be removed account with the last account, then delete the last
-    // account
+    // Swap the to be removed account with the last account, then delete the
+    // last account
     if to_be_removed_index != last_index {
         let last_account = e
             .storage()

--- a/packages/access/src/access_control/test.rs
+++ b/packages/access/src/access_control/test.rs
@@ -415,7 +415,8 @@ fn remove_from_role_enumeration_works() {
         let count_after = get_role_member_count(&e, &USER_ROLE);
         assert_eq!(count_after, 1);
 
-        // Only account2 should remain and should be at index 0 (the swap happened)
+        // Only account2 should remain and should be at index 0 (the swap
+        // happened)
         let retrieved = get_role_member(&e, &USER_ROLE, 0);
         assert_eq!(retrieved, account2);
 
@@ -498,14 +499,15 @@ fn ensure_if_admin_or_admin_role_allows_role_admin_without_contract_admin() {
     let manager = Address::generate(&e);
 
     e.as_contract(&address, || {
-        // Set up MANAGER_ROLE as admin for USER_ROLE without setting a contract admin
+        // Set up MANAGER_ROLE as admin for USER_ROLE without setting a contract
+        // admin
         set_role_admin_no_auth(&e, &USER_ROLE, &MANAGER_ROLE);
 
         // Grant MANAGER_ROLE to manager directly
         grant_role_no_auth(&e, &manager, &MANAGER_ROLE, &manager);
 
-        // This should not panic - manager should be authorized for USER_ROLE operations
-        // even though there's no contract admin
+        // This should not panic - manager should be authorized for USER_ROLE
+        // operations even though there's no contract admin
         ensure_if_admin_or_admin_role(&e, &USER_ROLE, &manager);
     });
 }

--- a/packages/accounts/src/policies/spending_limit.rs
+++ b/packages/accounts/src/policies/spending_limit.rs
@@ -246,16 +246,21 @@ pub fn enforce(
                             panic_with_error!(e, SpendingLimitError::LessThanZero)
                         }
 
-                        // A zero-amount transfer moves no funds and has no effect on the
-                        // spending budget, so it is always permitted. Without this guard a
-                        // zero transfer would be rejected whenever `cached_total_spent`
-                        // exceeds `spending_limit` (reachable after `set_spending_limit`
-                        // lowers the limit below the amount already spent in the window).
+                        // A zero-amount transfer moves no funds and has no
+                        // effect on the
+                        // spending budget, so it is always permitted. Without
+                        // this guard a zero transfer
+                        // would be rejected whenever `cached_total_spent`
+                        // exceeds `spending_limit` (reachable after
+                        // `set_spending_limit`
+                        // lowers the limit below the amount already spent in
+                        // the window).
                         if amount == 0 {
                             return;
                         }
 
-                        // Clean up old entries outside the rolling window BEFORE checking limit
+                        // Clean up old entries outside the rolling window
+                        // BEFORE checking limit
                         let removed_amount = cleanup_old_entries(
                             &mut data.spending_history,
                             current_ledger,
@@ -263,7 +268,8 @@ pub fn enforce(
                         );
                         data.cached_total_spent -= removed_amount;
 
-                        // Now check if the transaction exceeds the spending limit using updated
+                        // Now check if the transaction exceeds the spending
+                        // limit using updated
                         // cached total
                         if data.cached_total_spent + amount > data.spending_limit {
                             panic_with_error!(e, SpendingLimitError::SpendingLimitExceeded)

--- a/packages/accounts/src/policies/test/spending_limit.rs
+++ b/packages/accounts/src/policies/test/spending_limit.rs
@@ -466,8 +466,8 @@ fn enforce_zero_amount_allowed_after_limit_reduction() {
     });
 
     // A zero-amount transfer moves no funds and must be permitted even though
-    // `cached_total_spent` now exceeds `spending_limit`. It also must not mutate
-    // the spending history or cached total.
+    // `cached_total_spent` now exceeds `spending_limit`. It also must not
+    // mutate the spending history or cached total.
     e.as_contract(&address, || {
         let context = create_transfer_context(&e, 0);
         enforce(&e, &context, &context_rule.signers, &context_rule, &smart_account);
@@ -574,7 +574,8 @@ fn enforce_non_transfer_context_errors() {
     });
 
     e.as_contract(&address, || {
-        // Try to enforce with a non-transfer context (using a different function name)
+        // Try to enforce with a non-transfer context (using a different
+        // function name)
         let contract_address = Address::generate(&e);
         let args = Vec::new(&e);
         let context = Context::Contract(ContractContext {

--- a/packages/accounts/src/policies/test/weighted_threshold.rs
+++ b/packages/accounts/src/policies/test/weighted_threshold.rs
@@ -509,8 +509,8 @@ fn set_signer_weight_makes_threshold_unreachable_fails() {
     });
 
     e.as_contract(&address, || {
-        // Reduce signer1's weight from 100 to 10, making total weight 60 (10+50)
-        // This makes threshold 75 unreachable
+        // Reduce signer1's weight from 100 to 10, making total weight 60
+        // (10+50) This makes threshold 75 unreachable
         set_signer_weight(&e, &Signer::Delegated(signer1), 10, &context_rule, &smart_account);
     });
 }

--- a/packages/accounts/src/smart_account/storage.rs
+++ b/packages/accounts/src/smart_account/storage.rs
@@ -308,8 +308,8 @@ pub fn get_validated_context_by_id(
     }
 
     let ContextRule { signers: ref rule_signers, ref policies, .. } = context_rule;
-    // Filters rule signers to find which ones are present in the provided signer
-    // list.
+    // Filters rule signers to find which ones are present in the provided
+    // signer list.
     let matched_signers =
         Vec::from_iter(e, rule_signers.iter().filter(|s| all_signers.contains(s)));
 
@@ -482,8 +482,8 @@ pub fn do_check_auth(
 
     let mut allowed_signers = Map::new(e);
     for (rule, _, _) in validated_contexts.iter() {
-        // Collect all signers from the validated rules to check below for signers that
-        // do not belong to any rule.
+        // Collect all signers from the validated rules to check below for
+        // signers that do not belong to any rule.
         for signer in rule.signers.iter() {
             allowed_signers.set(signer, ());
         }
@@ -699,8 +699,8 @@ pub fn add_context_rule(
         id.checked_add(1).unwrap_or_else(|| panic_with_error!(e, SmartAccountError::MathOverflow));
     e.storage().instance().set(&SmartAccountStorageKey::NextId, &next_id);
 
-    // Increment count, overflow will be caught from next_id, next_id is always >=
-    // count
+    // Increment count, overflow will be caught from next_id, next_id is always
+    // >= count
     e.storage().instance().set(&SmartAccountStorageKey::Count, &(count + 1));
 
     context_rule
@@ -861,10 +861,11 @@ pub fn remove_context_rule(e: &Env, id: u32) {
 
     for (policy, policy_id) in policies.iter().zip(&entry.policy_ids) {
         // `try_uninstall` so that if the policy panics (recoverable failure),
-        // context rule removal can still be completed. Note: this is best-effort
-        // — a malicious policy can still cause non-recoverable failures (e.g.,
-        // resource exhaustion) that revert the entire transaction. Policy
-        // contracts are considered a trust dependency.
+        // context rule removal can still be completed. Note: this is
+        // best-effort — a malicious policy can still cause
+        // non-recoverable failures (e.g., resource exhaustion) that
+        // revert the entire transaction. Policy contracts are
+        // considered a trust dependency.
         let _ = PolicyClient::new(e, &policy)
             .try_uninstall(&context_rule, &e.current_contract_address());
 

--- a/packages/accounts/src/smart_account/test/context_rules.rs
+++ b/packages/accounts/src/smart_account/test/context_rules.rs
@@ -399,8 +399,8 @@ fn add_context_rule_multiple_rules() {
         assert_eq!(rule2.policies.len(), 2);
         assert_eq!(rule2.valid_until, None);
 
-        // Events: 2 ContextRuleAdded + 2 SignerRegistered (shared) + 2 PolicyRegistered
-        // = 6
+        // Events: 2 ContextRuleAdded + 2 SignerRegistered (shared) + 2
+        // PolicyRegistered = 6
         assert_eq!(e.events().all().events().len(), 6);
         assert_eq!(get_context_rules_count(&e), 2);
     });
@@ -678,8 +678,8 @@ fn remove_context_rule_success() {
     // Removal succeeds
     e.as_contract(&address, || {
         remove_context_rule(&e, rule.id);
-        // Events: 1 ContextRuleRemoved + 2 SignerDeregistered + 2 PolicyDeregistered =
-        // 5
+        // Events: 1 ContextRuleRemoved + 2 SignerDeregistered + 2
+        // PolicyDeregistered = 5
         assert_eq!(e.events().all().events().len(), 5);
         assert_eq!(get_context_rules_count(&e), 0);
     });

--- a/packages/accounts/src/smart_account/test/signers_and_policies.rs
+++ b/packages/accounts/src/smart_account/test/signers_and_policies.rs
@@ -247,7 +247,8 @@ fn remove_signer_shared_across_rules_decrements_count() {
         let contract_a = Address::generate(&e);
         let contract_b = Address::generate(&e);
 
-        // rule_a has two signers so removing shared_signer leaves one remaining.
+        // rule_a has two signers so removing shared_signer leaves one
+        // remaining.
         let extra_signer_a = Signer::Delegated(Address::generate(&e));
         let rule_a = add_context_rule(
             &e,

--- a/packages/accounts/src/verifiers/test/utils.rs
+++ b/packages/accounts/src/verifiers/test/utils.rs
@@ -276,7 +276,8 @@ fn base64_url_encode_binary_data() {
 fn base64_url_encode_uses_url_safe_alphabet() {
     // Input that produces characters that differ between standard base64 and
     // base64url
-    let input = [0x3E, 0x3F]; // Should produce '+' and '/' in standard base64, but '-' and '_' in base64url
+    let input = [0x3E, 0x3F]; // Should produce '+' and '/' in standard base64,
+                              // but '-' and '_' in base64url
     let mut output = [0u8; 3];
 
     base64_url_encode(&mut output, &input);
@@ -292,7 +293,8 @@ fn base64_url_encode_32_byte_hash() {
         0x1f, 0x12, 0x91, 0x38, 0xa2, 0xf2, 0xa1, 0x1f, 0x8e, 0x87, 0x02, 0xee, 0xdb, 0xb7, 0x92,
         0x92, 0x2e,
     ];
-    let mut output = [0u8; 43]; // 32 bytes -> 43 chars in base64url (no padding)
+    let mut output = [0u8; 43]; // 32 bytes -> 43 chars in base64url (no
+                                // padding)
 
     base64_url_encode(&mut output, &input);
 

--- a/packages/accounts/src/verifiers/test/webauthn.rs
+++ b/packages/accounts/src/verifiers/test/webauthn.rs
@@ -389,7 +389,8 @@ fn webauthn_batch_canonicalize_key_preserves_order() {
     let address = e.register(MockContract, ());
 
     e.as_contract(&address, || {
-        // Three keys with different 65-byte public keys and credential ID suffixes.
+        // Three keys with different 65-byte public keys and credential ID
+        // suffixes.
         let pub1 = Bytes::from_array(&e, &[1u8; 65]);
         let mut key1 = pub1.clone();
         key1.extend_from_array(&[0xAA; 10]);

--- a/packages/accounts/src/verifiers/webauthn.rs
+++ b/packages/accounts/src/verifiers/webauthn.rs
@@ -313,8 +313,8 @@ pub fn verify(
     // - type: 12 bytes ("webauthn.get")
     // - crossOrigin: optional boolean
     // - tokenBinding: optional field with a variable length
-    // - origin: variable length, but in almost all cases will fit into a couple of
-    //   dozens bytes
+    // - origin: variable length, but in almost all cases will fit into a couple
+    //   of dozens bytes
     //
     // https://www.w3.org/TR/webauthn-2/#client-data
     if client_data.len() > CLIENT_DATA_MAX_LEN as u32 {

--- a/packages/contract-utils/src/crypto/test/grumpkin.rs
+++ b/packages/contract-utils/src/crypto/test/grumpkin.rs
@@ -277,8 +277,8 @@ fn mul_by_two_matches_doubling() {
 #[test]
 fn mul_matches_reference_for_small_scalars() {
     let e = Env::default();
-    // For each k in {3, 7, 13, 100, u128::MAX}, verify Grumpkin::mul(p, k) matches
-    // ark's p * k for an arbitrary base point.
+    // For each k in {3, 7, 13, 100, u128::MAX}, verify Grumpkin::mul(p, k)
+    // matches ark's p * k for an arbitrary base point.
     let p_ark = scalar_mul_g(scalar_from_bytes(&[0xDE; 32]));
     let p = to_point(&e, &p_ark);
     for &k in &[3u128, 7, 13, 100, 1u128 << 64, u128::MAX] {

--- a/packages/contract-utils/src/crypto/test/merkle.rs
+++ b/packages/contract-utils/src/crypto/test/merkle.rs
@@ -177,7 +177,8 @@ fn verifies_valid_proofs() {
 
 #[test]
 fn sha256_verifies_valid_proofs() {
-    // generated with the same data as above but using sha256 as a hashing function
+    // generated with the same data as above but using sha256 as a hashing
+    // function
     let e = Env::default();
     let root = to_bytes!(e, "b0d388be1fe96067c100c6731770b70f87fa1287c4d6ddf9e107bdd015ae445c");
     let leaf_a = to_bytes!(e, "9c707ca1d6e1963a6a974a40f20c51f899cc96c9a7edef911953f424186641bf");
@@ -221,7 +222,8 @@ fn rejects_invalid_proofs() {
 
 #[test]
 fn sha256_rejects_invalid_proofs() {
-    // generated with the same data as above but using sha256 as a hashing function
+    // generated with the same data as above but using sha256 as a hashing
+    // function
     let e = Env::default();
     let root = to_bytes!(e, "d132af2ab11889f767680c257c81620b4678f10c014eec1c4711991ab7a02ab4");
     let leaf = to_bytes!(e, "b9e9db137d987ce376feabe4acc5ee8b23a2d460699cc8bd7e1fe001cbd99df0");
@@ -259,7 +261,8 @@ fn rejects_proofs_with_invalid_length() {
 
 #[test]
 fn sha256_rejects_proofs_with_invalid_length() {
-    // generated with the same data as above but using sha256 as a hashing function
+    // generated with the same data as above but using sha256 as a hashing
+    // function
     let e = Env::default();
     let root = to_bytes!(e, "d132af2ab11889f767680c257c81620b4678f10c014eec1c4711991ab7a02ab4");
     let leaf = to_bytes!(e, "b9e9db137d987ce376feabe4acc5ee8b23a2d460699cc8bd7e1fe001cbd99df0");
@@ -296,7 +299,8 @@ fn verify_empty_proof_should_mean_leaf_equal_to_root() {
 
 #[test]
 fn sha256_verify_empty_proof_should_mean_leaf_equal_to_root() {
-    // generated with the same data as above but using sha256 as a hashing function
+    // generated with the same data as above but using sha256 as a hashing
+    // function
     let e = Env::default();
     let root = to_bytes!(e, "d132af2ab11889f767680c257c81620b4678f10c014eec1c4711991ab7a02ab4");
     let leaf = to_bytes!(e, "b9e9db137d987ce376feabe4acc5ee8b23a2d460699cc8bd7e1fe001cbd99df0");

--- a/packages/contract-utils/src/math/test/i256_fixed_point.rs
+++ b/packages/contract-utils/src/math/test/i256_fixed_point.rs
@@ -95,8 +95,8 @@ fn test_mul_div_floor_large_number() {
 fn test_mul_div_floor_phantom_overflow() {
     let env = Env::default();
     let x: I256 = I256::from_i128(&env, i128::MAX);
-    // 256 bit max ~= 5.8e76, 128 bit max ~= 1.7e38, need to multiply by at least
-    // 10^39
+    // 256 bit max ~= 5.8e76, 128 bit max ~= 1.7e38, need to multiply by at
+    // least 10^39
     let y: I256 = I256::from_i128(&env, 10i128.pow(39));
     let denominator: I256 = I256::from_i128(&env, 10i128.pow(18));
 
@@ -145,8 +145,8 @@ fn test_mul_div_ceil_large_number() {
 fn test_mul_div_ceil_phantom_overflow() {
     let env = Env::default();
     let x: I256 = I256::from_i128(&env, i128::MAX);
-    // 256 bit max ~= 5.8e76, 128 bit max ~= 1.7e38, need to multiply by at least
-    // 10^39
+    // 256 bit max ~= 5.8e76, 128 bit max ~= 1.7e38, need to multiply by at
+    // least 10^39
     let y: I256 = I256::from_i128(&env, 10i128.pow(39));
     let denominator: I256 = I256::from_i128(&env, 10i128.pow(18));
 

--- a/packages/contract-utils/src/math/test/wad.rs
+++ b/packages/contract-utils/src/math/test/wad.rs
@@ -381,7 +381,8 @@ fn test_checked_div_overflow() {
     let e = Env::default();
     let a = Wad::from_raw(i128::MAX);
     let b = Wad::from_raw(1);
-    let result = a.checked_div(&e, b); // MAX * WAD_SCALE will overflow even with I256
+    let result = a.checked_div(&e, b); // MAX * WAD_SCALE will overflow even
+                                       // with I256
     assert_eq!(result, None);
 }
 
@@ -389,9 +390,9 @@ fn test_checked_div_overflow() {
 fn test_checked_div_phantom_overflow_handled() {
     let e = Env::default();
     // 5000 WAD / 5000 WAD = 1 WAD
-    // The intermediate calculation (5000 * WAD_SCALE * WAD_SCALE) would overflow
-    // i128 but the final result (1 WAD) fits, so phantom overflow should be
-    // handled
+    // The intermediate calculation (5000 * WAD_SCALE * WAD_SCALE) would
+    // overflow i128 but the final result (1 WAD) fits, so phantom overflow
+    // should be handled
     let a = Wad::from_integer(&e, 5_000);
     let b = Wad::from_integer(&e, 5_000);
     let result = a.checked_div(&e, b);
@@ -684,7 +685,8 @@ fn test_powi_truncation_behavior() {
     let base = Wad::from_raw(1_414_213_562_373_095_048); // √2 ≈ 1.414213562373095048
     let result = base.powi(&e, 2);
 
-    // (√2)^2 should be very close to 2, but truncation may cause slight deviation
+    // (√2)^2 should be very close to 2, but truncation may cause slight
+    // deviation
     let two = Wad::from_integer(&e, 2);
     let diff = (result.raw() - two.raw()).abs();
 
@@ -1159,7 +1161,8 @@ fn test_powf_compound_interest_fractional() {
 #[test]
 fn test_powf_negative_exponent() {
     let e = Env::default();
-    // 2^(-1) = 0.5 — falls through to general path (negative non-integer-flagged y)
+    // 2^(-1) = 0.5 — falls through to general path (negative
+    // non-integer-flagged y)
     let two = Wad::from_integer(&e, 2);
     let neg_one = Wad::from_integer(&e, -1);
     let result = two.powf(&e, neg_one);
@@ -1236,7 +1239,8 @@ fn test_checked_powf_one_base() {
     // 1^y = 1 for any y, via the x==1 fast path.
     let e = Env::default();
     let one = Wad::from_integer(&e, 1);
-    let weird_y = Wad::from_ratio(&e, 355, 113); // π-ish, definitely non-integer
+    let weird_y = Wad::from_ratio(&e, 355, 113); // π-ish, definitely
+                                                 // non-integer
     assert_eq!(one.checked_powf(&e, weird_y), Some(one));
 }
 

--- a/packages/contract-utils/src/math/wad.rs
+++ b/packages/contract-utils/src/math/wad.rs
@@ -464,9 +464,9 @@ impl Wad {
         // Result: x^8 * x^2 = x^10
         //
         // Note: We use checked_mul_div to handle phantom overflow
-        // (where intermediate multiplication overflows i128 but final result fits).
-        // This automatically scales to i256 when needed and returns None if the
-        // result doesn't fit in i128.
+        // (where intermediate multiplication overflows i128 but final result
+        // fits). This automatically scales to i256 when needed and
+        // returns None if the result doesn't fit in i128.
         while exponent > 0 {
             if exponent & 1 == 1 {
                 // result = result * base (in fixed-point)

--- a/packages/contract-utils/src/merkle_distributor/test.rs
+++ b/packages/contract-utils/src/merkle_distributor/test.rs
@@ -55,17 +55,14 @@ fn get_valid_args_sorted(e: &Env) -> (Bytes32, LeafData, Vec<Bytes32>) {
 
 fn get_valid_args_unsorted(e: &Env) -> (Bytes32, LeafData, Vec<Bytes32>) {
     // constructed with the following data and sha256 hasher
-    //[
-    //{ index: 0, address:
-    //{ "GDD4CDYMGZ2TST2P3FI453VPP5HYKQJZXPDUQEV23V4E2BFI2U7W6BH6", amount: 101
-    //{ } index: 1, address:
-    //{ "GBJWGSVNARYGOM3HSXRCTM2P7Z7D36KCH63WSE4IICTUGOFG736AR6WU", amount: 102
-    //{ } index: 2, address:
-    //{ "GA5WRXT22B7I2GS4HCUXGYZWRINJYPJMIVMXGXDSBQCMRJ2EXRKSB35B", amount: 103
-    //{ } index: 3, address:
-    //{ "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX", amount: 100
-    //{ }
-    //]
+    // ```
+    // [
+    //   { index: 0, address: "GDD4CDYMGZ2TST2P3FI453VPP5HYKQJZXPDUQEV23V4E2BFI2U7W6BH6", amount: 101 },
+    //   { index: 1, address: "GBJWGSVNARYGOM3HSXRCTM2P7Z7D36KCH63WSE4IICTUGOFG736AR6WU", amount: 102 },
+    //   { index: 2, address: "GA5WRXT22B7I2GS4HCUXGYZWRINJYPJMIVMXGXDSBQCMRJ2EXRKSB35B", amount: 103 },
+    //   { index: 3, address: "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX", amount: 100 },
+    // ]
+    // ```
     let root = Bytes32::from_array(
         e,
         &hex!("103d1530956325ffc0b01abc52b7b3bedecf9a0b013553e864e3cecddf3bea2d"),

--- a/packages/contract-utils/src/merkle_distributor/test.rs
+++ b/packages/contract-utils/src/merkle_distributor/test.rs
@@ -57,13 +57,14 @@ fn get_valid_args_unsorted(e: &Env) -> (Bytes32, LeafData, Vec<Bytes32>) {
     // constructed with the following data and sha256 hasher
     //[
     //{ index: 0, address:
-    //{ "GDD4CDYMGZ2TST2P3FI453VPP5HYKQJZXPDUQEV23V4E2BFI2U7W6BH6", amount: 101 }
-    //{ index: 1, address:
-    //{ "GBJWGSVNARYGOM3HSXRCTM2P7Z7D36KCH63WSE4IICTUGOFG736AR6WU", amount: 102 }
-    //{ index: 2, address:
-    //{ "GA5WRXT22B7I2GS4HCUXGYZWRINJYPJMIVMXGXDSBQCMRJ2EXRKSB35B", amount: 103 }
-    //{ index: 3, address:
-    //{ "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX", amount: 100 }
+    //{ "GDD4CDYMGZ2TST2P3FI453VPP5HYKQJZXPDUQEV23V4E2BFI2U7W6BH6", amount: 101
+    //{ } index: 1, address:
+    //{ "GBJWGSVNARYGOM3HSXRCTM2P7Z7D36KCH63WSE4IICTUGOFG736AR6WU", amount: 102
+    //{ } index: 2, address:
+    //{ "GA5WRXT22B7I2GS4HCUXGYZWRINJYPJMIVMXGXDSBQCMRJ2EXRKSB35B", amount: 103
+    //{ } index: 3, address:
+    //{ "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX", amount: 100
+    //{ }
     //]
     let root = Bytes32::from_array(
         e,

--- a/packages/fee-abstraction/src/storage.rs
+++ b/packages/fee-abstraction/src/storage.rs
@@ -195,8 +195,8 @@ pub fn collect_fee(
                     &expiration_ledger,
                 );
             } else {
-                // assuming that in the other cases the expiration ledger is validated in
-                // `token.approve()`
+                // assuming that in the other cases the expiration ledger is
+                // validated in `token.approve()`
                 validate_expiration_ledger(e, expiration_ledger);
             }
         }
@@ -268,7 +268,8 @@ pub fn set_allowed_fee_token(e: &Env, token: &Address, allowed: bool) {
         let remove_index = existing_index
             .unwrap_or_else(|| panic_with_error!(e, FeeAbstractionError::FeeTokenNotAllowed));
 
-        // Can't underflow, it would've been caught be the above panic_with_error
+        // Can't underflow, it would've been caught be the above
+        // panic_with_error
         let last_index = count - 1;
         let last_key = FeeAbstractionStorageKey::Token(last_index);
 

--- a/packages/tokens/src/confidential/test.rs
+++ b/packages/tokens/src/confidential/test.rs
@@ -771,7 +771,8 @@ fn set_underlying_asset_twice_panics() {
 #[should_panic(expected = "Error(Contract, #3512)")]
 fn set_address_as_field_element_twice_panics() {
     // `__constructor` already populated the entry; calling
-    // `set_address_as_field_element` again must trip `AddressAsFieldAlreadySet`.
+    // `set_address_as_field_element` again must trip
+    // `AddressAsFieldAlreadySet`.
     let h = setup();
     h.e.as_contract(&h.token_addr, || {
         token_storage::set_address_as_field_element(&h.e);

--- a/packages/tokens/src/fungible/extensions/capped/test.rs
+++ b/packages/tokens/src/fungible/extensions/capped/test.rs
@@ -117,7 +117,8 @@ fn test_invalid_cap() {
     let contract_address = e.register(MockContract, ());
 
     e.as_contract(&contract_address, || {
-        // Attempt to set a negative cap value, which should trigger InvalidCap error
+        // Attempt to set a negative cap value, which should trigger InvalidCap
+        // error
         set_cap(&e, -100);
     });
 }
@@ -129,8 +130,8 @@ fn test_cap_not_set() {
     let contract_address = e.register(MockContract, ());
 
     e.as_contract(&contract_address, || {
-        // Try to query cap without setting it first, which should trigger CapNotSet
-        // error
+        // Try to query cap without setting it first, which should trigger
+        // CapNotSet error
         let _ = query_cap(&e);
     });
 }

--- a/packages/tokens/src/fungible/storage.rs
+++ b/packages/tokens/src/fungible/storage.rs
@@ -268,8 +268,8 @@ impl Base {
 
         if amount > 0 {
             // NOTE: cannot revert because of the check above;
-            // NOTE: 1 is not added to `live_for` as in the SAC implementation which
-            // is a bug tracked in https://github.com/stellar/rs-soroban-env/issues/1519
+            // NOTE: 1 is not added to `live_for` as in the SAC implementation
+            // which is a bug tracked in https://github.com/stellar/rs-soroban-env/issues/1519
             let live_for = live_until_ledger - current_ledger;
 
             e.storage().temporary().extend_ttl(&key, live_for, live_for);
@@ -428,7 +428,8 @@ impl Base {
         }
 
         if let Some(account) = to {
-            // NOTE: can't overflow because balance + amount is at most total_supply.
+            // NOTE: can't overflow because balance + amount is at most
+            // total_supply.
             let to_balance = Base::balance(e, account) + amount;
             e.storage()
                 .persistent()
@@ -436,8 +437,8 @@ impl Base {
         } else {
             // `to` is None, so we're burning tokens.
 
-            // NOTE: can't overflow because amount <= total_supply or amount <= from_balance
-            // <= total_supply.
+            // NOTE: can't overflow because amount <= total_supply or amount <=
+            // from_balance <= total_supply.
             let total_supply = Base::total_supply(e) - amount;
             e.storage().instance().set(&FungibleStorageKey::TotalSupply, &total_supply);
         }

--- a/packages/tokens/src/non_fungible/extensions/consecutive/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/consecutive/storage.rs
@@ -132,8 +132,9 @@ impl Consecutive {
             })
             // scan for a set bit and maps it to an ID
             .find_map(|(i, bucket)| {
-                // If we're in the starting bucket, begin search from the token's relative
-                // position; otherwise, start from the beginning of the bucket.
+                // If we're in the starting bucket, begin search from the
+                // token's relative position; otherwise, start
+                // from the beginning of the bucket.
                 let from_id = if i == bucket_index { relative_id } else { 0 };
                 find_bit_in_bucket(bucket, from_id)
                     .map(|pos_in_bucket| i * ids_in_bucket + pos_in_bucket)
@@ -432,9 +433,10 @@ impl Consecutive {
             let approval_key = NFTConsecutiveStorageKey::Approval(token_id);
             e.storage().temporary().remove(&approval_key);
 
-            // Set the token_id - 1 to previous owner to preserve the ownership inference.
-            // `set_owner_for_previous_token` does this, but will skip it if the previous id
-            // doesn't exist, was burned or has already an owner.
+            // Set the token_id - 1 to previous owner to preserve the ownership
+            // inference. `set_owner_for_previous_token` does this,
+            // but will skip it if the previous id doesn't exist,
+            // was burned or has already an owner.
             Consecutive::set_owner_for_previous_token(e, from_address, token_id);
         } else {
             // nothing to do for the `None` case, since we don't track
@@ -535,8 +537,8 @@ impl Consecutive {
         let mask: u32 = 1 << (ids_in_item - bit_index - 1);
         let mut item = bucket.get(item_index).expect("token_id out of allowed range");
 
-        // return early if the bit was already set in a previous action (transfer, burn
-        // or batch_mint)
+        // return early if the bit was already set in a previous action
+        // (transfer, burn or batch_mint)
         if item & mask != 0 {
             return;
         }
@@ -613,8 +615,8 @@ pub(crate) fn find_bit_in_item(input: Option<u32>, start: u32) -> Option<u32> {
 
         for i in (0..=(last - start)).rev() {
             if (num & (1 << i)) != 0 {
-                // i goes from MSB toward LSB relative to `start`, but we want to return
-                // MSB-relative index
+                // i goes from MSB toward LSB relative to `start`, but we want
+                // to return MSB-relative index
                 return Some(last - i);
             }
         }

--- a/packages/tokens/src/non_fungible/extensions/enumerable/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/enumerable/storage.rs
@@ -493,15 +493,16 @@ impl Enumerable {
         };
         e.storage().persistent().extend_ttl(&key, TOKEN_TTL_THRESHOLD, TOKEN_EXTEND_AMOUNT);
 
-        // owner's balance is already decremented by 1, so it will be the index of the
-        // last token in the enumeration list.
+        // owner's balance is already decremented by 1, so it will be the index
+        // of the last token in the enumeration list.
         let last_token_index = Base::balance(e, owner);
 
         // Update the `OwnerTokens`.
         if to_be_removed_index != last_token_index {
             // Before swap: [A, B, C, D]  (burning `B`, which is at index 1)
-            // After swap:  [A, D, C, D]  (`D` moves to index 1, note that `B` isn't moved)
-            // After deletion: [A, D, C]  (last item is deleted, effectively removing `B`)
+            // After swap:  [A, D, C, D]  (`D` moves to index 1, note that `B`
+            // isn't moved) After deletion: [A, D, C]  (last item is
+            // deleted, effectively removing `B`)
             let last_token_id = Enumerable::get_owner_token_id(e, owner, last_token_index);
             e.storage().persistent().set(
                 &NFTEnumerableStorageKey::OwnerTokens(OwnerTokensKey {
@@ -565,12 +566,13 @@ impl Enumerable {
         e.storage().persistent().extend_ttl(&key, TOKEN_TTL_THRESHOLD, TOKEN_EXTEND_AMOUNT);
 
         // unlike `remove_from_owner_enumeration`, we perform the swap without
-        // checking if it's already the last token_id to avoid extra gas cost (being
-        // last item in the global list is far less likely)
+        // checking if it's already the last token_id to avoid extra gas cost
+        // (being last item in the global list is far less likely)
 
         // Before swap: [A, B, C, D]  (burning `B`, which is at index 1)
-        // After swap:  [A, D, C, D]  (`D` moves to index 1, note that `B` isn't moved)
-        // After deletion: [A, D, C]  (last item is deleted, effectively removing `B`)
+        // After swap:  [A, D, C, D]  (`D` moves to index 1, note that `B` isn't
+        // moved) After deletion: [A, D, C]  (last item is deleted,
+        // effectively removing `B`)
         let last_token_id = Enumerable::get_token_id(e, last_token_index);
         e.storage()
             .persistent()

--- a/packages/tokens/src/non_fungible/storage.rs
+++ b/packages/tokens/src/non_fungible/storage.rs
@@ -209,8 +209,8 @@ impl Base {
         let len = base_uri.len() as usize;
 
         if len > 0 {
-            // account for potentially the max num of digits of the type representing
-            // `token_id`` (currently `u32`)
+            // account for potentially the max num of digits of the type
+            // representing `token_id`` (currently `u32`)
             let uri = &mut [0u8; MAX_BASE_URI_LEN + MAX_NUM_DIGITS];
 
             let (id, digits) = Base::token_id_to_string(e, token_id);

--- a/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
@@ -280,9 +280,10 @@ pub fn on_transfer(
     // `from`'s live identity entry may have been removed by account recovery
     // (`recover_identity` moves the identity to the new wallet and deletes the
     // old mapping). When the live lookup fails with a contract error, resolve
-    // the sender through the recovery record so a forced/recovery transfer stays
-    // bookkeeping-correct instead of reverting here. A sender that was never
-    // registered (failed lookup, no recovery record) re-raises the IRS error.
+    // the sender through the recovery record so a forced/recovery transfer
+    // stays bookkeeping-correct instead of reverting here. A sender that
+    // was never registered (failed lookup, no recovery record) re-raises
+    // the IRS error.
     let id_from = match irs.try_stored_identity(from) {
         Ok(Ok(id)) => id,
         Err(Ok(err)) => match irs.get_recovered_to(from) {

--- a/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/test.rs
@@ -433,7 +433,8 @@ fn recovery_transfer_after_identity_recovery_is_noop_and_does_not_revert() {
         // `TransferKind::Recovery` by `recover_balance`.
         on_transfer(&e, &old_wallet, &new_wallet, 80, &TransferKind::Recovery, &token);
 
-        // Same identity on both sides => the aggregate is unchanged and correct.
+        // Same identity on both sides => the aggregate is unchanged and
+        // correct.
         assert_eq!(get_id_balance(&e, &token, &identity), 80);
     });
 }

--- a/packages/tokens/src/rwa/extensions/doc_manager/storage.rs
+++ b/packages/tokens/src/rwa/extensions/doc_manager/storage.rs
@@ -263,7 +263,8 @@ pub fn remove_document(e: &Env, name: &BytesN<32>) {
         let (last_name, last_doc) =
             last_bucket.get(last_offset).expect("last document entry to be present");
 
-        // Update the last document's index to point to the removed document's position
+        // Update the last document's index to point to the removed document's
+        // position
         let last_index_key = DocumentStorageKey::Index(last_name.clone());
         e.storage().persistent().set(&last_index_key, &document_index);
 

--- a/packages/tokens/src/rwa/extensions/doc_manager/test.rs
+++ b/packages/tokens/src/rwa/extensions/doc_manager/test.rs
@@ -79,7 +79,8 @@ fn set_document_update_existing() {
         assert_eq!(doc2.document_hash, hash2);
         assert!(doc2.timestamp >= doc1.timestamp);
 
-        // Verify document count didn't increase (it's an update, not a new document)
+        // Verify document count didn't increase (it's an update, not a new
+        // document)
         assert_eq!(get_document_count(&e), 1);
     });
 }
@@ -428,7 +429,8 @@ fn swap_and_pop_across_different_buckets() {
         let uri = String::from_str(&e, "https://example.com/doc.pdf");
         let hash = create_test_hash(&e, "content");
 
-        // Add 75 documents (will span 2 buckets: 50 in bucket 0, 25 in bucket 1)
+        // Add 75 documents (will span 2 buckets: 50 in bucket 0, 25 in bucket
+        // 1)
         for i in 0..75 {
             let name = create_test_name(&e, &std::format!("doc_{}", i));
             set_document(&e, &name, &uri, &hash);
@@ -437,7 +439,8 @@ fn swap_and_pop_across_different_buckets() {
         assert_eq!(get_document_count(&e), 75);
 
         // Remove a document from bucket 0 (index 10)
-        // This should swap with the last document (doc_74 at index 74 in bucket 1)
+        // This should swap with the last document (doc_74 at index 74 in bucket
+        // 1)
         let name_to_remove = create_test_name(&e, "doc_10");
         remove_document(&e, &name_to_remove);
 

--- a/packages/tokens/src/rwa/identity_verification/claim_issuer/test.rs
+++ b/packages/tokens/src/rwa/identity_verification/claim_issuer/test.rs
@@ -777,7 +777,8 @@ fn bidirectional_mapping_same_key_same_registry_same_topic_fails() {
     e.as_contract(&contract_id, || {
         allow_key(&e, &public_key, &registry, scheme, topic);
 
-        // Try to add same key again for same topic and same registry - should fail
+        // Try to add same key again for same topic and same registry - should
+        // fail
         allow_key(&e, &public_key, &registry, scheme, topic);
     });
 }
@@ -884,7 +885,8 @@ fn bidirectional_mapping_same_key_different_topics() {
         let topic_keys_43 = get_keys_for_topic(&e, 43);
         assert_eq!(topic_keys_43.len(), 1);
 
-        // Verify Registries mapping has 2 entries (one per topic/registry combination)
+        // Verify Registries mapping has 2 entries (one per topic/registry
+        // combination)
         let signing_key = SigningKey { public_key: public_key.clone(), scheme };
         let registries = get_registries(&e, &signing_key);
         assert_eq!(registries.len(), 2);
@@ -990,8 +992,8 @@ fn allow_key_topic_not_allowed() {
     let topic = 42u32;
 
     e.as_contract(&contract_id, || {
-        // Try to allow key for topic 42 which is not in the issuer's allowed topics -
-        // should panic
+        // Try to allow key for topic 42 which is not in the issuer's allowed
+        // topics - should panic
         allow_key(&e, &public_key, &registry_id, scheme, topic);
     });
 }
@@ -1078,8 +1080,8 @@ fn remove_key_prevents_dangling_keys_across_multiple_topics() {
         // Step 2: Remove key from (T2, R2) - this is the last registry pair
         remove_key(&e, &public_key, &registry2, scheme, topic2);
 
-        // After removing the last registry pair, the key should NOT be allowed for ANY
-        // topic
+        // After removing the last registry pair, the key should NOT be allowed
+        // for ANY topic
         assert!(!is_key_allowed_for_topic(&e, &public_key, scheme, topic1));
         assert!(!is_key_allowed_for_topic(&e, &public_key, scheme, topic2));
 
@@ -1206,8 +1208,8 @@ fn signature_invalidation_vs_per_claim_revocation() {
         assert!(is_claim_revoked(&e, &identity, claim_topic, &claim_data_1));
         assert!(!is_claim_revoked(&e, &identity, claim_topic, &claim_data_2));
 
-        // Signature invalidation: increment nonce invalidates all previous SIGNATURES
-        // but does NOT affect per-claim revocation status
+        // Signature invalidation: increment nonce invalidates all previous
+        // SIGNATURES but does NOT affect per-claim revocation status
         invalidate_claim_signatures(&e, &identity, claim_topic);
 
         // The per-claim revocation persists even after nonce change
@@ -1242,7 +1244,8 @@ fn invalidate_claim_signatures_nonce_overflow() {
         // Verify nonce is at max
         assert_eq!(get_current_nonce_for(&e, &identity, claim_topic), u32::MAX);
 
-        // Attempt to invalidate signatures - should panic with MathOverflow (361)
+        // Attempt to invalidate signatures - should panic with MathOverflow
+        // (361)
         invalidate_claim_signatures(&e, &identity, claim_topic);
     });
 }
@@ -1289,7 +1292,8 @@ fn is_claim_expired_returns_false_for_future_expiration() {
 #[test]
 fn is_claim_expired_returns_true_for_past_expiration() {
     let e = Env::default();
-    e.ledger().with_mut(|li| li.timestamp = 10000); // Set ledger timestamp to 10000
+    e.ledger().with_mut(|li| li.timestamp = 10000); // Set ledger timestamp to
+                                                    // 10000
     let contract_id = e.register(MockContract, ());
 
     e.as_contract(&contract_id, || {
@@ -1300,7 +1304,8 @@ fn is_claim_expired_returns_true_for_past_expiration() {
 
         let encoded = encode_claim_data_expiration(&e, created_at, valid_until, &claim_data);
 
-        // Current ledger timestamp (10000) is much higher than valid_until (2000)
+        // Current ledger timestamp (10000) is much higher than valid_until
+        // (2000)
         assert!(is_claim_expired(&e, &encoded));
     });
 }
@@ -1308,7 +1313,8 @@ fn is_claim_expired_returns_true_for_past_expiration() {
 #[test]
 fn is_claim_expired_returns_true_for_current_timestamp() {
     let e = Env::default();
-    e.ledger().with_mut(|li| li.timestamp = 5000); // Set ledger timestamp to 5000
+    e.ledger().with_mut(|li| li.timestamp = 5000); // Set ledger timestamp to
+                                                   // 5000
     let contract_id = e.register(MockContract, ());
 
     e.as_contract(&contract_id, || {

--- a/packages/tokens/src/rwa/identity_verification/claim_topics_and_issuers/storage.rs
+++ b/packages/tokens/src/rwa/identity_verification/claim_topics_and_issuers/storage.rs
@@ -488,8 +488,9 @@ pub fn update_issuer_claim_topics(e: &Env, trusted_issuer: &Address, claim_topic
     // Add issuer to new topics
     for topic_to_add in topics_to_add {
         let mut topic_issuers = get_claim_topic_issuers(e, topic_to_add);
-        // We are sure that the issuer is not in the list, because `topics_to_add` only
-        // consists of the difference between old and new topics
+        // We are sure that the issuer is not in the list, because
+        // `topics_to_add` only consists of the difference between old
+        // and new topics
         topic_issuers.push_back(trusted_issuer.clone());
         let topic_key = ClaimTopicsAndIssuersStorageKey::ClaimTopicIssuers(topic_to_add);
         e.storage().persistent().set(&topic_key, &topic_issuers);

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/test.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/test.rs
@@ -162,8 +162,8 @@ fn remove_identity_success() {
         assert_eq!(get_country_data_entries(&e, &account).len(), 1);
 
         remove_identity(&e, &account);
-        // 1 IdentityStored + 1 CountryDataAdded (from add) + 1 IdentityUnstored + 1
-        // CountryDataRemoved (from remove)
+        // 1 IdentityStored + 1 CountryDataAdded (from add) + 1 IdentityUnstored
+        // + 1 CountryDataRemoved (from remove)
         assert_eq!(e.events().all().events().len(), 4);
 
         stored_identity(&e, &account);
@@ -1047,8 +1047,8 @@ fn recover_to_already_recovered_account_panics() {
         // Recover account1 to account2
         recover_identity(&e, &account1, &account2);
 
-        // Try to recover account3 to account1 (account1 was already recovered, should
-        // panic)
+        // Try to recover account3 to account1 (account1 was already recovered,
+        // should panic)
         recover_identity(&e, &account3, &account1);
     });
 }

--- a/packages/tokens/src/rwa/identity_verification/storage.rs
+++ b/packages/tokens/src/rwa/identity_verification/storage.rs
@@ -95,7 +95,8 @@ pub fn verify_identity(e: &Env, account: &Address) {
 
         for (issuer, claim_id, is_last) in issuers_with_claim_ids {
             if account_claim_ids.contains(&claim_id) {
-                // Here, we can assume claim exists so no need to use `try_get_claim()`.
+                // Here, we can assume claim exists so no need to use
+                // `try_get_claim()`.
                 let claim: Claim = identity_client.get_claim(&claim_id);
 
                 if validate_claim(e, &claim, claim_topic, &issuer, &identity_addr) {

--- a/packages/tokens/src/rwa/identity_verification/test.rs
+++ b/packages/tokens/src/rwa/identity_verification/test.rs
@@ -387,8 +387,8 @@ fn verify_identity_fails_no_matched_ids() {
             e.storage().persistent().set(&symbol_short!("claim_ids"), &Vec::from_array(&e, [id3]));
         });
 
-        // Update claim topics and issuers to include issuer1 and issuer2, but not
-        // issuer3
+        // Update claim topics and issuers to include issuer1 and issuer2, but
+        // not issuer3
         e.as_contract(&cti, || {
             e.storage()
                 .persistent()

--- a/packages/tokens/src/rwa/storage.rs
+++ b/packages/tokens/src/rwa/storage.rs
@@ -157,8 +157,8 @@ impl RWA {
         let total_balance = Base::balance(e, user_address);
         let frozen_tokens = Self::get_frozen_tokens(e, user_address);
 
-        // frozen tokens cannot be greater than total balance, necessary checks are done
-        // in state changing functions
+        // frozen tokens cannot be greater than total balance, necessary checks
+        // are done in state changing functions
         total_balance - frozen_tokens
     }
 
@@ -485,7 +485,8 @@ impl RWA {
         let identity_verifier_client = IdentityVerifierClient::new(e, &identity_verifier_addr);
         identity_verifier_client.verify_identity(new_account);
 
-        // Verify that the new account is the recovery target for the old account
+        // Verify that the new account is the recovery target for the old
+        // account
         let recovery_target = identity_verifier_client
             .recovery_target(old_account)
             .unwrap_or_else(|| panic_with_error!(e, RWAError::IdentityMismatch));
@@ -494,8 +495,8 @@ impl RWA {
             panic_with_error!(e, RWAError::IdentityMismatch);
         }
 
-        // Get the balance of the old account, if there is nothing to transfer, return
-        // false
+        // Get the balance of the old account, if there is nothing to transfer,
+        // return false
         let lost_balance = Base::balance(e, old_account);
         if lost_balance == 0 {
             return false;

--- a/packages/tokens/src/rwa/test.rs
+++ b/packages/tokens/src/rwa/test.rs
@@ -429,8 +429,8 @@ fn partial_token_freezing() {
         // Unfreeze some tokens
         RWA::unfreeze_partial_tokens(&e, &user, 10);
         assert_eq!(RWA::get_frozen_tokens(&e, &user), 20);
-        // 1 IdentityVerifierSet + 1 ComplianceSet + 1 Minted + 1 TokensFrozen + 1
-        // TokensUnfrozen
+        // 1 IdentityVerifierSet + 1 ComplianceSet + 1 Minted + 1 TokensFrozen +
+        // 1 TokensUnfrozen
         assert_eq!(e.events().all().events().len(), 5);
     });
 }
@@ -952,12 +952,14 @@ fn recover_balance_without_recovery_target_fails() {
         let _ = set_and_return_compliance(&e);
 
         // Do NOT set recovery target - this should cause the test to panic
-        // The mock function will return None, which triggers IdentityMismatch error
+        // The mock function will return None, which triggers IdentityMismatch
+        // error
 
         // Mint tokens to old account
         RWA::mint(&e, &old_account, 100);
 
-        // Attempt recovery without setting recovery target - should fail with #313
+        // Attempt recovery without setting recovery target - should fail with
+        // #313
         RWA::recover_balance(&e, &old_account, &new_account);
     });
 }

--- a/packages/tokens/src/vault/storage.rs
+++ b/packages/tokens/src/vault/storage.rs
@@ -729,18 +729,19 @@ impl Vault {
         from: &Address,
         operator: &Address,
     ) {
-        // This function assumes prior authorization of the operator and validation of
-        // amounts.
+        // This function assumes prior authorization of the operator and
+        // validation of amounts.
         let token_client = token::Client::new(e, &Self::query_asset(e));
-        // `safeTransfer` mechanism is not present in the base module, (will be provided
-        // as an extension)
+        // `safeTransfer` mechanism is not present in the base module, (will be
+        // provided as an extension)
 
         if operator == from {
             // Direct transfer: `operator` is depositing their own assets
             token_client.transfer(from, e.current_contract_address(), &assets);
         } else {
-            // Allowance-based transfer: `operator` is depositing on behalf of `from`
-            // This requires that `from` has approved `operator` on the underlying asset
+            // Allowance-based transfer: `operator` is depositing on behalf of
+            // `from` This requires that `from` has approved
+            // `operator` on the underlying asset
             token_client.transfer_from(operator, from, &e.current_contract_address(), &assets);
         }
 
@@ -781,15 +782,15 @@ impl Vault {
         shares: i128,
         operator: &Address,
     ) {
-        // This function assumes prior authorization of the operator and validation of
-        // amounts.
+        // This function assumes prior authorization of the operator and
+        // validation of amounts.
         if operator != owner {
             Base::spend_allowance(e, owner, operator, shares);
         }
         Base::update(e, Some(owner), None, shares);
         let token_client = token::Client::new(e, &Self::query_asset(e));
-        // `safeTransfer` mechanism is not present in the base module, (will be provided
-        // as an extension)
+        // `safeTransfer` mechanism is not present in the base module, (will be
+        // provided as an extension)
         token_client.transfer(&e.current_contract_address(), receiver, &assets);
     }
 


### PR DESCRIPTION
`cargo +nightly fmt --all -- --check` fails on `main`, breaking CI for every open PR.

**Root cause:** [rustfmt#6802 "Make comment wrapping indent aware"](https://github.com/rust-lang/rustfmt/pull/6802) (merged 2026-08-20, in nightly since). `comment_width` now subtracts the block indent before wrapping; previously indent was ignored, so comments could run past 80 columns. This repo sets `wrap_comments = true`, so it is directly affected. Upstream states the change is intentionally not backwards compatible.

Bisected: `nightly-2026-08-13` clean, `nightly-2026-08-30` reports 100 diffs.

**Fix:** `cargo +nightly fmt --all`. 45 files, comment-only — every changed line is a `//` line or a trailing comment on otherwise byte-identical code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and readability of comments across token, account, access-control, cryptography, compliance, vault, and example modules.
  * Clarified explanations for authorization, recovery flows, test scenarios, serialization, and validation behavior.
* **Tests**
  * Updated test comments and fixtures for clearer descriptions without changing assertions, test logic, or runtime behavior.
* **Compatibility**
  * No functional changes, public API changes, or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->