### PR TITLE
chore: bump soroban-sdk to P28

### DIFF
--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -142,7 +142,7 @@ rule).
 
 ```bash
 # WASM release build — catches no_std and target-specific issues
-cargo build --target wasm32v1-none --release --package <name>
+stellar contract build --package <name>
 
 # Unit + integration tests
 cargo test --package <name>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,9 @@ cargo clippy --release --locked --all-targets -- -D warnings
 # Test the workspace
 cargo test
 
-# WASM release build (per-package; see CI note in .github/workflows/generic.yml)
-cargo build --target wasm32v1-none --release --package <name>
+# WASM release build (per-package; plain `cargo build --target wasm32v1-none`
+# fails since soroban-sdk 28 — spec shaking needs stellar-cli >= 25.2.0)
+stellar contract build --package <name>
 
 # Coverage (CI threshold: 90% line coverage)
 cargo llvm-cov --workspace --fail-under-lines 90

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,8 @@ As a contributor, you are expected to fork this repository, work on your own for
     # run tests
     cargo test
 
-    # build
-    cargo build --target wasm32v1-none --release
+    # build (per package; needs stellar-cli >= 25.2.0)
+    stellar contract build --package <name>
 
     # run linter
     cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,9 +2151,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77bc93d930032c487cb1506b6ed166b2af49db76d52678ec4887ac621ecce01"
+checksum = "86ffd329211a50add3965a8f4a8f70e24fc5c8268c945566ab963029b12dce40"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -2163,12 +2163,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b22e9981cdd444f3aa6734bc58d76195bf7eca3ccf1dd432b875af5d02da068"
+checksum = "610bb12ee937a56c2b629f8eb16efb7e47607cba4e79ab0c24132b9a53dd19a0"
 dependencies = [
  "arbitrary",
- "crate-git-revision 0.0.6",
+ "crate-git-revision 0.0.9",
  "ethnum",
  "num-derive",
  "num-traits",
@@ -2182,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6072f99ca6bf8e8d5b04e05d083dac785e5357d9c0f36a6658f819c2fd7d67"
+checksum = "7d383176b27bb286f718ab0ff5713bd9b01132089151266359bd9b20f38684cf"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -2192,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c06afd7c75ce150ce53e4d77a77645b18e3fb61856a0ddc42bfcecdc39fa3b9"
+checksum = "36d7e5920c200939164cc58038224e2d90d7e2fabbfa505d6e2129d648dce7e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254 0.5.0",
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647811bdd28a3ec40296987f6635781e5e1141c8f5affbbd53ba12b6295b7bb6"
+checksum = "077600bb175ea54592c1ac5983b8fb34ec9ab7a65f298af11d687b61e9d646a4"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ea48b5d5e22c0cbaa370f813111016c9f5a8a6632edb0684c72be6531c4d3a"
+checksum = "9e68b020e9838df2affe8488998943b81d183c7ea4990691a863b39c13d3516e"
 dependencies = [
  "serde",
  "serde_json",
@@ -2258,18 +2258,17 @@ dependencies = [
 
 [[package]]
 name = "soroban-poseidon"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b241822373adc51c23d5412e412b3b91b0d6b6bba146584946391aa32667820d"
+version = "28.0.0-rc.1"
+source = "git+https://github.com/brozorec/rs-soroban-poseidon?branch=sdk-28#5205fb95419d449bf62a6f5fc867afa439d02213"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-sdk"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfa78af0110f0830d3af9db0361b6cdb50507846cedb8725189318134218b80"
+checksum = "864a530b8a1eb07c364f3f4b2f069b737ae87df203fd290baebddb9119f2dfe5"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -2291,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db611bd0acfe5fd348ffdcef16c84090c6ab051f3e325b5ac049a73044a7ee6"
+checksum = "d66c2bfe91c8ec2179dcab5284ee99215d9271fed2eb8b9819bcd45001ac861f"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -2311,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8061fe31998fe9fba8fcd7175b3e3ca914a6f6e3bf829fe91fdf7f930b1251d9"
+checksum = "2f20e3c44fa7939fece5c8988efa7c9e062ab5596ae7497035a2bc59ffd48816"
 dependencies = [
  "base64",
  "sha2",
@@ -2324,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2180cddacf3023a439827cb35c0e391ec413b1328173fe7c8c2743fc67b3af9e"
+checksum = "43eb9293928c35e949818f83fe5eacfe0cf45ebb32552304aaea66279b7c8403"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2485,14 +2484,14 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+checksum = "f93d09ff8b9f919b084f664003c4c546ac66a76affd5429460dbe29f4b326f8e"
 dependencies = [
  "arbitrary",
  "base64",
  "cfg_eval",
- "crate-git-revision 0.0.6",
+ "crate-git-revision 0.0.9",
  "escape-bytes",
  "ethnum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,8 @@ categories = ["no-std", "wasm"]
 version = "0.7.1"
 
 [workspace.dependencies]
-soroban-sdk = { version = "27.0.2", features = [
-    "experimental_spec_shaking_v2",
-] }
-soroban-poseidon = "27.0.0"
+soroban-sdk = "28.0.0-rc.1"
+soroban-poseidon = "28.0.0-rc.1"
 proc-macro2 = "1.0"
 proptest = "1"
 quote = "1.0"
@@ -92,3 +90,7 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
+
+# TODO(#865): remove once soroban-poseidon publishes a 28.x release.
+[patch.crates-io]
+soroban-poseidon = { git = "https://github.com/brozorec/rs-soroban-poseidon", branch = "sdk-28" }

--- a/examples/multisig-smart-account/webauthn-verifier/src/test.rs
+++ b/examples/multisig-smart-account/webauthn-verifier/src/test.rs
@@ -94,7 +94,7 @@ fn verify_success() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Object, UnexpectedSize)")]
+#[should_panic(expected = "WebAuthnSigData with correct format")]
 fn verify_sig_data_invalid_fails() {
     let e = Env::default();
     let contract_id = e.register(WebauthnVerifierContract, ());

--- a/packages/accounts/README.md
+++ b/packages/accounts/README.md
@@ -56,7 +56,8 @@ Context rules function like routing tables for authorization: for each `Context`
 - **Context Type**: Scope of the rule
   - `Default`: Applies to any context
   - `CallContract(Address)`: Specific contract calls
-  - `CreateContract(BytesN<32>)`: Contract deployments
+  - `CreateContract(BytesN<32>)`: Contract deployments from a specific WASM hash
+  - `CreateContractExternalRef(Address, String)`: Contract deployments from the executable reference an owner contract stores under a tag (Protocol 28, CAP-85); the WASM hash is resolved at deployment time, so the rule trusts the owner contract
 - **Valid Until**: Optional expiration (ledger sequence)
 - **Signers**: List of authorized signers (max: 15)
 - **Policies**: Map of policy contracts and their parameters (max: 5)
@@ -74,7 +75,7 @@ A single smart account can hold any number of context rules. There is no upper l
 `soroban_sdk::auth::Context` is a Soroban SDK type representing a single authorized operation within a transaction. When `__check_auth` is invoked, the runtime passes `auth_contexts: Vec<Context>` — one entry per `require_auth` call in the transaction. Each variant captures the operation details:
 
 - `Contract(ContractContext)` — a contract function call, carrying the `contract` address, `fn_name`, and `args`
-- `CreateContractHostFn(CreateContractHostFnContext)` — a contract deployment without constructor arguments, carrying `executable` (WASM hash) and `salt`
+- `CreateContractHostFn(CreateContractHostFnContext)` — a contract deployment without constructor arguments, carrying `executable` (`ContractExecutable::Wasm(hash)` or `ContractExecutable::ExternalRef { owner, tag }`) and `salt`
 - `CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext)` — a contract deployment with constructor arguments
 
 A `ContextRule` is this library's concept: a stored authorization requirements entry that lives in the smart account's own storage. A `ContextRule` is bound to a `ContextRuleType` that narrows which `Context` variants it can authorize. A smart account can hold **any number of `ContextRule`s covering the same context type** — for example, an admin rule and a time-limited session rule can both be scoped to `CallContract(dex_address)`.

--- a/packages/accounts/src/smart_account/mod.rs
+++ b/packages/accounts/src/smart_account/mod.rs
@@ -34,6 +34,12 @@
 //! - `CreateContractWithCtorHostFn(...)` — contract deployment with constructor
 //!   arguments
 //!
+//! The `executable` of a deployment is either `ContractExecutable::Wasm(hash)`
+//! or, since Protocol 28, `ContractExecutable::ExternalRef { owner, tag }`: a
+//! reference to a WASM hash that the `owner` contract stores under `tag` and
+//! may change later. The corresponding [`ContextRuleType`] variants are
+//! `CreateContract(hash)` and `CreateContractExternalRef(owner, tag)`.
+//!
 //! A [`ContextRule`] is this library's stored authorization entry, bound to a
 //! [`ContextRuleType`] that narrows which `Context` variants it can authorize.
 //! A smart account can hold **multiple [`ContextRule`]s for the same context

--- a/packages/accounts/src/smart_account/storage.rs
+++ b/packages/accounts/src/smart_account/storage.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{
     auth::{
-        Context, ContractContext, ContractExecutable, CreateContractHostFnContext,
-        CreateContractWithConstructorHostFnContext,
+        Context, ContractContext, ContractExecutable, ContractExecutableRef,
+        CreateContractHostFnContext, CreateContractWithConstructorHostFnContext,
     },
     contracttype,
     crypto::Hash,
@@ -147,6 +147,9 @@ pub enum ContextRuleType {
     CallContract(Address),
     /// Rules specific to creating a contract with a particular WASM hash.
     CreateContract(BytesN<32>),
+    /// Rules specific to creating a contract from the executable reference that
+    /// `owner` stores under `tag`.
+    CreateContractExternalRef(Address, String),
 }
 
 /// A complete context rule defining authorization requirements.
@@ -290,14 +293,16 @@ pub fn get_validated_context_by_id(
         Context::Contract(ContractContext { contract, .. }) => {
             ContextRuleType::CallContract(contract)
         }
-        Context::CreateContractHostFn(CreateContractHostFnContext {
-            executable: ContractExecutable::Wasm(wasm),
+        Context::CreateContractHostFn(CreateContractHostFnContext { executable, .. })
+        | Context::CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext {
+            executable,
             ..
-        }) => ContextRuleType::CreateContract(wasm),
-        Context::CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext {
-            executable: ContractExecutable::Wasm(wasm),
-            ..
-        }) => ContextRuleType::CreateContract(wasm),
+        }) => match executable {
+            ContractExecutable::Wasm(wasm) => ContextRuleType::CreateContract(wasm),
+            ContractExecutable::ExternalRef(ContractExecutableRef { owner, tag }) => {
+                ContextRuleType::CreateContractExternalRef(owner, tag)
+            }
+        },
     };
 
     let context_type_matches = context_rule.context_type == ContextRuleType::Default

--- a/packages/accounts/src/smart_account/test/context_rules.rs
+++ b/packages/accounts/src/smart_account/test/context_rules.rs
@@ -2,8 +2,8 @@ extern crate std;
 
 use soroban_sdk::{
     auth::{
-        Context, ContractContext, ContractExecutable, CreateContractHostFnContext,
-        CreateContractWithConstructorHostFnContext,
+        Context, ContractContext, ContractExecutable, ContractExecutableRef,
+        CreateContractHostFnContext, CreateContractWithConstructorHostFnContext,
     },
     contract, contractimpl, symbol_short,
     testutils::{Address as _, Events, Ledger},
@@ -910,6 +910,157 @@ fn get_validated_context_by_id_create_contract_with_ctor_success() {
         let (validated_rule, _, _) =
             get_validated_context_by_id(&e, &context, &rule.signers, rule.id);
         assert_eq!(validated_rule.id, rule.id);
+    });
+}
+
+#[test]
+fn get_validated_context_by_id_create_contract_external_ref_success() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let owner = Address::generate(&e);
+        let tag = String::from_str(&e, "pool");
+        let context_type = ContextRuleType::CreateContractExternalRef(owner.clone(), tag.clone());
+
+        let rule = add_context_rule(
+            &e,
+            &context_type,
+            &String::from_str(&e, "external_ref_rule"),
+            None,
+            &create_test_signers(&e),
+            &Map::new(&e),
+        );
+
+        let context = Context::CreateContractHostFn(CreateContractHostFnContext {
+            salt: BytesN::from_array(&e, &[3u8; 32]),
+            executable: ContractExecutable::ExternalRef(ContractExecutableRef { owner, tag }),
+        });
+
+        let (validated_rule, _, _) =
+            get_validated_context_by_id(&e, &context, &rule.signers, rule.id);
+        assert_eq!(validated_rule.id, rule.id);
+    });
+}
+
+#[test]
+fn get_validated_context_by_id_create_contract_external_ref_with_ctor_success() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let owner = Address::generate(&e);
+        let tag = String::from_str(&e, "pool");
+        let context_type = ContextRuleType::CreateContractExternalRef(owner.clone(), tag.clone());
+
+        let rule = add_context_rule(
+            &e,
+            &context_type,
+            &String::from_str(&e, "ext_ref_ctor_rule"),
+            None,
+            &create_test_signers(&e),
+            &Map::new(&e),
+        );
+
+        let context =
+            Context::CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext {
+                salt: BytesN::from_array(&e, &[4u8; 32]),
+                executable: ContractExecutable::ExternalRef(ContractExecutableRef { owner, tag }),
+                constructor_args: Vec::new(&e),
+            });
+
+        let (validated_rule, _, _) =
+            get_validated_context_by_id(&e, &context, &rule.signers, rule.id);
+        assert_eq!(validated_rule.id, rule.id);
+    });
+}
+
+#[test]
+fn get_validated_context_by_id_default_rule_matches_external_ref() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let rule = add_context_rule(
+            &e,
+            &ContextRuleType::Default,
+            &String::from_str(&e, "default_rule"),
+            None,
+            &create_test_signers(&e),
+            &Map::new(&e),
+        );
+
+        let context = Context::CreateContractHostFn(CreateContractHostFnContext {
+            salt: BytesN::from_array(&e, &[5u8; 32]),
+            executable: ContractExecutable::ExternalRef(ContractExecutableRef {
+                owner: Address::generate(&e),
+                tag: String::from_str(&e, "pool"),
+            }),
+        });
+
+        let (validated_rule, _, _) =
+            get_validated_context_by_id(&e, &context, &rule.signers, rule.id);
+        assert_eq!(validated_rule.id, rule.id);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3002)")]
+fn get_validated_context_by_id_wasm_rule_rejects_external_ref() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let rule = add_context_rule(
+            &e,
+            &ContextRuleType::CreateContract(BytesN::from_array(&e, &[9u8; 32])),
+            &String::from_str(&e, "wasm_rule"),
+            None,
+            &create_test_signers(&e),
+            &Map::new(&e),
+        );
+
+        let context = Context::CreateContractHostFn(CreateContractHostFnContext {
+            salt: BytesN::from_array(&e, &[6u8; 32]),
+            executable: ContractExecutable::ExternalRef(ContractExecutableRef {
+                owner: Address::generate(&e),
+                tag: String::from_str(&e, "pool"),
+            }),
+        });
+
+        get_validated_context_by_id(&e, &context, &rule.signers, rule.id);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3002)")]
+fn get_validated_context_by_id_external_ref_rule_rejects_other_tag() {
+    let e = Env::default();
+    let address = e.register(MockContract, ());
+
+    e.as_contract(&address, || {
+        let owner = Address::generate(&e);
+        let rule = add_context_rule(
+            &e,
+            &ContextRuleType::CreateContractExternalRef(
+                owner.clone(),
+                String::from_str(&e, "pool"),
+            ),
+            &String::from_str(&e, "external_ref_rule"),
+            None,
+            &create_test_signers(&e),
+            &Map::new(&e),
+        );
+
+        let context = Context::CreateContractHostFn(CreateContractHostFnContext {
+            salt: BytesN::from_array(&e, &[7u8; 32]),
+            executable: ContractExecutable::ExternalRef(ContractExecutableRef {
+                owner,
+                tag: String::from_str(&e, "vault"),
+            }),
+        });
+
+        get_validated_context_by_id(&e, &context, &rule.signers, rule.id);
     });
 }
 

--- a/packages/contract-utils/src/upgradeable/storage.rs
+++ b/packages/contract-utils/src/upgradeable/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, BytesN, Env};
+use soroban_sdk::{contracttype, BytesN, ContractExecutable, Env};
 
 #[contracttype]
 pub enum UpgradeableStorageKey {
@@ -52,5 +52,5 @@ pub fn set_schema_version(e: &Env, version: u32) {
 /// **IMPORTANT**: This function lacks authorization checks and should only
 /// be used in admin functions that implement their own authorization logic.
 pub fn upgrade(e: &Env, new_wasm_hash: &BytesN<32>) {
-    e.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+    e.deployer().update_current_contract(ContractExecutable::Wasm(new_wasm_hash.clone()));
 }


### PR DESCRIPTION
fix #865 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smart accounts now support deploying contracts through external executable references, allowing the executable to be resolved from an owner contract at deployment time.
  * Contract creation context rules now distinguish deployments using a specific WASM hash from those using an external reference.

* **Compatibility**
  * Updated Soroban SDK components for Protocol 28 support.

* **Documentation**
  * Updated contributor and development guidance with the current Stellar contract build workflow and required CLI version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->