### PR TITLE
carry freeze status on 0 balance recovery

### DIFF
--- a/packages/tokens/src/rwa/mod.rs
+++ b/packages/tokens/src/rwa/mod.rs
@@ -244,6 +244,12 @@ pub trait RWAToken: Pausable + FungibleToken<ContractType = RWA> {
     /// privileges. RBAC checks are expected to be enforced on the
     /// `operator`.
     ///
+    /// Balances and address freezes are stored per token, so after the
+    /// identity is recovered in the registry, this function should be called on
+    /// each token separately. A token where the old account holds nothing
+    /// still needs the call when the account is frozen there, otherwise the
+    /// freeze status is not carried over to the new account.
+    ///
     /// # Arguments
     ///
     /// * `e` - Access to the Soroban environment.
@@ -258,6 +264,11 @@ pub trait RWAToken: Pausable + FungibleToken<ContractType = RWA> {
     ///
     /// # Events
     ///
+    /// Emitted when the old account is fully frozen:
+    /// * topics - `["address_frozen", new_account: Address, is_frozen: bool]`
+    /// * data - `[]`
+    ///
+    /// Emitted only when tokens are moved:
     /// * topics - `["transfer", old_account: Address, new_account: Address]`
     /// * data - `[amount: i128]`
     /// * topics - `["recovery_success", old_account: Address, new_account:

--- a/packages/tokens/src/rwa/storage.rs
+++ b/packages/tokens/src/rwa/storage.rs
@@ -432,7 +432,7 @@ impl RWA {
     /// Recovery function used to force transfer tokens from a old account to a
     /// new account. This function transfers all tokens and preserves the frozen
     /// status from the old account to the new account. Returns `true` if
-    /// recovery was successful, `false` if no tokens to recover.
+    /// tokens were moved, `false` if the old account held no tokens.
     ///
     /// # Arguments
     ///
@@ -449,6 +449,11 @@ impl RWA {
     ///
     /// # Events
     ///
+    /// Emitted when the old account is fully frozen:
+    /// * topics - `["address_frozen", new_account: Address, is_frozen: bool]`
+    /// * data - `[]`
+    ///
+    /// Emitted only when tokens are moved:
     /// * topics - `["transfer", old_account: Address, new_account: Address]`
     /// * data - `[amount: i128]`
     /// * topics - `["recovery_success", old_account: Address, new_account:
@@ -459,7 +464,11 @@ impl RWA {
     ///
     /// This function preserves the frozen status (both partial and full) from
     /// the old account and applies it to the new account, maintaining
-    /// regulatory compliance.
+    /// regulatory compliance. The full-address freeze is a wallet-level
+    /// restriction, so it follows the investor to the new account even when the
+    /// old account holds no tokens. The partially frozen amount is bounded by
+    /// the balance, so there is nothing to migrate in that case.
+    ///
     ///
     /// State owned by this contract (the frozen status) is migrated directly
     /// by this function. State held by compliance modules is handled through
@@ -495,6 +504,10 @@ impl RWA {
             panic_with_error!(e, RWAError::IdentityMismatch);
         }
 
+        if Self::is_frozen(e, old_account) {
+            Self::set_address_frozen(e, new_account, true);
+        }
+
         // Get the balance of the old account, if there is nothing to transfer,
         // return false
         let lost_balance = Base::balance(e, old_account);
@@ -502,9 +515,8 @@ impl RWA {
             return false;
         }
 
-        // Store frozen status before transfer
+        // Store the partially frozen amount before the transfer unfreezes it
         let frozen_tokens = Self::get_frozen_tokens(e, old_account);
-        let is_address_frozen = Self::is_frozen(e, old_account);
 
         // Move all tokens with the shared privileged mechanics (handles
         // unfreezing as needed), reporting the movement as a recovery so
@@ -521,11 +533,6 @@ impl RWA {
         // Preserve frozen tokens on the new account if there were any
         if frozen_tokens > 0 {
             Self::freeze_partial_tokens(e, new_account, frozen_tokens);
-        }
-
-        // Preserve address frozen status on the new account if it was frozen
-        if is_address_frozen {
-            Self::set_address_frozen(e, new_account, true);
         }
 
         emit_recovery_success(e, old_account, new_account);

--- a/packages/tokens/src/rwa/test.rs
+++ b/packages/tokens/src/rwa/test.rs
@@ -578,6 +578,7 @@ fn recovery_with_zero_balance_returns_false() {
         // No tokens in old account
         let success = RWA::recover_balance(&e, &old_account, &new_account);
         assert!(!success); // Should return false for zero balance
+        assert!(!RWA::is_frozen(&e, &new_account));
     });
 }
 
@@ -935,6 +936,35 @@ fn recover_balance_with_both_frozen_tokens_and_address() {
         assert_eq!(RWA::balance(&e, &old_account), 0);
         assert_eq!(RWA::balance(&e, &new_account), 100);
         assert_eq!(RWA::get_frozen_tokens(&e, &new_account), 80);
+        assert!(RWA::is_frozen(&e, &new_account));
+    });
+}
+
+#[test]
+fn recover_balance_with_zero_balance_preserves_frozen_address() {
+    let e = Env::default();
+    let address = e.register(MockRWAContract, ());
+    let old_account = Address::generate(&e);
+    let new_account = Address::generate(&e);
+
+    e.as_contract(&address, || {
+        let identity_verifier = set_and_return_identity_verifier(&e);
+        let _ = set_and_return_compliance(&e);
+
+        // Set recovery target in the identity verifier contract's storage
+        e.as_contract(&identity_verifier, || {
+            e.storage().persistent().set(&symbol_short!("recovery"), &new_account);
+        });
+
+        // Freeze the address while it holds no tokens
+        RWA::set_address_frozen(&e, &old_account, true);
+        assert!(RWA::is_frozen(&e, &old_account));
+
+        // Nothing to move, but the address freeze must still follow
+        let success = RWA::recover_balance(&e, &old_account, &new_account);
+        assert!(!success);
+
+        assert_eq!(RWA::balance(&e, &new_account), 0);
         assert!(RWA::is_frozen(&e, &new_account));
     });
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #870 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Account recovery now preserves a fully frozen source address on the destination, even when the source holds no balance.
  - Recovery continues to transfer frozen balances only when tokens are moved.

- **Documentation**
  - Clarified that recovery must be performed separately for each token.
  - Documented recovery outcomes and emitted events, including address-freeze notifications and transfer-related events.

- **Tests**
  - Added coverage for preserving frozen status when recovering an account with no balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->