### PR TITLE
fee-abstraction: consume the whole eager approval

### DIFF
--- a/examples/fee-forwarder-permissionless/src/contract.rs
+++ b/examples/fee-forwarder-permissionless/src/contract.rs
@@ -45,8 +45,10 @@
 //!
 //! 6. **Contract executes atomically**:
 //!    - Validates both user and relayer authorizations
-//!    - User approves contract to spend up to `max_fee_amount` tokens
-//!    - Contract transfers exactly `fee_amount` tokens from user to itself
+//!    - User approves contract to spend `max_fee_amount` tokens
+//!    - Contract pulls `max_fee_amount` tokens from the user, pays `fee_amount`
+//!      to the relayer and returns the remainder to the user, leaving no
+//!      allowance behind
 //!    - Contract forwards call to `target_contract.target_fn(target_args)`
 //!    - If any step fails, entire transaction reverts (including token
 //!      transfer)

--- a/examples/fee-forwarder-permissionless/src/test.rs
+++ b/examples/fee-forwarder-permissionless/src/test.rs
@@ -143,6 +143,8 @@ fn forward_basic() {
 
     assert_eq!(token.balance(&user), initial_user_balance - fee_amount);
     assert_eq!(token.balance(&relayer), initial_relayer_balance + fee_amount);
+    assert_eq!(token.balance(&fee_forwarder.address), 0);
+    assert_eq!(token.allowance(&user, &fee_forwarder.address), 0);
 }
 
 #[test]

--- a/packages/fee-abstraction/src/lib.rs
+++ b/packages/fee-abstraction/src/lib.rs
@@ -13,7 +13,8 @@
 //! - **Approval strategies**: utilities for collecting fee from users support
 //!   two approval semantics:
 //!   - [`FeeAbstractionApproval::Eager`]: always approve `max_fee_amount`
-//!     (overwriting any existing allowance)
+//!     (overwriting any existing allowance) and consume the whole approval
+//!     within the collection, leaving no residual allowance
 //!   - [`FeeAbstractionApproval::Lazy`]: only approve if the current allowance
 //!     is less than `max_fee_amount`
 //!

--- a/packages/fee-abstraction/src/storage.rs
+++ b/packages/fee-abstraction/src/storage.rs
@@ -25,8 +25,11 @@ pub enum FeeAbstractionStorageKey {
 #[contracttype]
 pub enum FeeAbstractionApproval {
     /// Only approve `max_fee_amount` if the existing allowance is insufficient.
+    /// The unspent remainder stays approved for later collections.
     Lazy,
-    /// Always approve `max_fee_amount`, overwriting previous allowances.
+    /// Always approve `max_fee_amount`, overwriting previous allowances, and
+    /// consume the whole approval within the same collection so that no
+    /// allowance remains afterwards.
     Eager,
 }
 
@@ -119,9 +122,15 @@ pub fn collect_fee_and_invoke(
 /// Low-level helper to collect a fee from the user in a given token by checking
 /// whether the token is allowed when allow list is enabled.
 ///
-/// It can be used with either eager or lazy approval semantics. `Eager` always
-/// approves `max_fee_amount` (overwriting any existing allowance); `Lazy` only
-/// approves if the current allowance is less than `max_fee_amount`.
+/// It can be used with either eager or lazy approval semantics. `Lazy` only
+/// approves if the current allowance is less than `max_fee_amount` and leaves
+/// the unspent remainder approved for later collections. `Eager` always
+/// approves `max_fee_amount` (overwriting any existing allowance) and consumes
+/// the whole approval at once: `max_fee_amount` is pulled from the user, the
+/// fee is paid to the recipient and the remainder is returned to the user, so
+/// no allowance survives the collection. The user therefore needs a spendable
+/// balance of at least `max_fee_amount` for an eager collection; the token
+/// rejects it otherwise.
 ///
 /// # Arguments
 ///
@@ -175,34 +184,32 @@ pub fn collect_fee(
     validate_fee_bounds(e, fee_amount, max_fee_amount);
 
     let token_client = TokenClient::new(e, fee_token);
+    let contract_address = e.current_contract_address();
 
     match approval {
         FeeAbstractionApproval::Eager => {
-            token_client.approve(
-                user,
-                &e.current_contract_address(),
-                &max_fee_amount,
-                &expiration_ledger,
-            );
+            token_client.approve(user, &contract_address, &max_fee_amount, &expiration_ledger);
+            token_client.transfer_from(&contract_address, user, &contract_address, &max_fee_amount);
+            if *fee_recipient != contract_address {
+                token_client.transfer(&contract_address, fee_recipient, &fee_amount);
+            }
+            let remainder = max_fee_amount - fee_amount;
+            if remainder > 0 {
+                token_client.transfer(&contract_address, user, &remainder);
+            }
         }
         FeeAbstractionApproval::Lazy => {
-            let allowance = token_client.allowance(user, &e.current_contract_address());
+            let allowance = token_client.allowance(user, &contract_address);
             if allowance < max_fee_amount {
-                token_client.approve(
-                    user,
-                    &e.current_contract_address(),
-                    &max_fee_amount,
-                    &expiration_ledger,
-                );
+                token_client.approve(user, &contract_address, &max_fee_amount, &expiration_ledger);
             } else {
                 // assuming that in the other cases the expiration ledger is
                 // validated in `token.approve()`
                 validate_expiration_ledger(e, expiration_ledger);
             }
+            token_client.transfer_from(&contract_address, user, fee_recipient, &fee_amount);
         }
     }
-
-    token_client.transfer_from(&e.current_contract_address(), user, fee_recipient, &fee_amount);
 
     emit_fee_collected(e, user, fee_recipient, fee_token, fee_amount);
 }

--- a/packages/fee-abstraction/src/test.rs
+++ b/packages/fee-abstraction/src/test.rs
@@ -71,14 +71,120 @@ fn collect_fee_with_eager_approval_overwrites_allowance() {
     });
 
     let events = e.events().all();
-    // approval, transfer and collect fee
-    assert_eq!(events.events().len(), 3);
+    // approval, pull of the max fee, fee transfer, remainder refund and collect
+    // fee
+    assert_eq!(events.events().len(), 5);
 
     let allowance = token_client.allowance(&user, &contract_address);
-    assert_eq!(allowance, 30);
+    assert_eq!(allowance, 0);
 
-    let balance = token_client.balance(&recipient);
-    assert_eq!(balance, 20);
+    assert_eq!(token_client.balance(&recipient), 20);
+    assert_eq!(token_client.balance(&user), 980);
+    assert_eq!(token_client.balance(&contract_address), 0);
+}
+
+#[test]
+fn collect_fee_with_eager_approval_no_remainder() {
+    let e = Env::default();
+    e.mock_all_auths_allowing_non_root_auth();
+
+    let contract_address = e.register(MockContract, ());
+    let user = Address::generate(&e);
+    let token_address = e.register(MockToken, (user.clone(),));
+    let recipient = Address::generate(&e);
+
+    let token_client = TokenClient::new(&e, &token_address);
+
+    e.as_contract(&contract_address, || {
+        // approve 50, spend 50
+        collect_fee(
+            &e,
+            &token_address,
+            50,
+            50,
+            100,
+            &user,
+            &recipient,
+            FeeAbstractionApproval::Eager,
+        );
+    });
+
+    let events = e.events().all();
+    // approval, pull of the max fee, fee transfer and collect fee
+    assert_eq!(events.events().len(), 4);
+
+    let allowance = token_client.allowance(&user, &contract_address);
+    assert_eq!(allowance, 0);
+
+    assert_eq!(token_client.balance(&recipient), 50);
+    assert_eq!(token_client.balance(&user), 950);
+    assert_eq!(token_client.balance(&contract_address), 0);
+}
+
+#[test]
+fn collect_fee_with_eager_approval_to_current_contract() {
+    let e = Env::default();
+    e.mock_all_auths_allowing_non_root_auth();
+
+    let contract_address = e.register(MockContract, ());
+    let user = Address::generate(&e);
+    let token_address = e.register(MockToken, (user.clone(),));
+
+    let token_client = TokenClient::new(&e, &token_address);
+
+    e.as_contract(&contract_address, || {
+        // approve 50, spend 20, the fee stays on the contract
+        collect_fee(
+            &e,
+            &token_address,
+            20,
+            50,
+            100,
+            &user,
+            &contract_address,
+            FeeAbstractionApproval::Eager,
+        );
+    });
+
+    let events = e.events().all();
+    // approval, pull of the max fee, remainder refund and collect fee
+    assert_eq!(events.events().len(), 4);
+
+    let allowance = token_client.allowance(&user, &contract_address);
+    assert_eq!(allowance, 0);
+
+    assert_eq!(token_client.balance(&contract_address), 20);
+    assert_eq!(token_client.balance(&user), 980);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #100)")]
+fn collect_fee_with_eager_approval_requires_max_fee_balance() {
+    let e = Env::default();
+    e.mock_all_auths_allowing_non_root_auth();
+
+    let contract_address = e.register(MockContract, ());
+    let user = Address::generate(&e);
+    let token_address = e.register(MockToken, (user.clone(),));
+    let recipient = Address::generate(&e);
+    let other = Address::generate(&e);
+
+    let token_client = TokenClient::new(&e, &token_address);
+    // the user keeps 25, which covers the fee but not the approved maximum
+    token_client.transfer(&user, &other, &975);
+
+    e.as_contract(&contract_address, || {
+        collect_fee(
+            &e,
+            &token_address,
+            20,
+            50,
+            100,
+            &user,
+            &recipient,
+            FeeAbstractionApproval::Eager,
+        );
+    });
 }
 
 #[test]

--- a/packages/fee-abstraction/src/test.rs
+++ b/packages/fee-abstraction/src/test.rs
@@ -2,14 +2,14 @@ use soroban_sdk::{
     contract, contractimpl,
     testutils::{Address as _, Events, Ledger},
     token::TokenClient,
-    vec, Address, Env, FromVal, MuxedAddress, String, Symbol, Val, Vec,
+    vec, Address, Env, Event, FromVal, MuxedAddress, String, Symbol, Val, Vec,
 };
-use stellar_tokens::fungible::{Base, FungibleToken};
+use stellar_tokens::fungible::{Approve, Base, FungibleToken, Transfer};
 
 use crate::{
     collect_fee, collect_fee_and_invoke, is_allowed_fee_token, is_fee_token_allowlist_enabled,
     set_allowed_fee_token, sweep_token, validate_expiration_ledger, validate_fee_bounds,
-    FeeAbstractionApproval, FeeAbstractionStorageKey,
+    FeeAbstractionApproval, FeeAbstractionStorageKey, FeeCollected,
 };
 
 #[contract]
@@ -71,9 +71,42 @@ fn collect_fee_with_eager_approval_overwrites_allowance() {
     });
 
     let events = e.events().all();
-    // approval, pull of the max fee, fee transfer, remainder refund and collect
-    // fee
     assert_eq!(events.events().len(), 5);
+    assert_eq!(
+        events.events().first().unwrap(),
+        &Approve {
+            owner: user.clone(),
+            spender: contract_address.clone(),
+            amount: max_fee_amount,
+            live_until_ledger: 100,
+        }
+        .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(1).unwrap(),
+        &Transfer { from: user.clone(), to: contract_address.clone(), amount: max_fee_amount }
+            .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(2).unwrap(),
+        &Transfer { from: contract_address.clone(), to: recipient.clone(), amount: 20 }
+            .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(3).unwrap(),
+        &Transfer { from: contract_address.clone(), to: user.clone(), amount: 30 }
+            .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(4).unwrap(),
+        &FeeCollected {
+            user: user.clone(),
+            recipient: recipient.clone(),
+            token: token_address.clone(),
+            amount: 20,
+        }
+        .to_xdr(&e, &contract_address)
+    );
 
     let allowance = token_client.allowance(&user, &contract_address);
     assert_eq!(allowance, 0);
@@ -110,8 +143,37 @@ fn collect_fee_with_eager_approval_no_remainder() {
     });
 
     let events = e.events().all();
-    // approval, pull of the max fee, fee transfer and collect fee
     assert_eq!(events.events().len(), 4);
+    assert_eq!(
+        events.events().first().unwrap(),
+        &Approve {
+            owner: user.clone(),
+            spender: contract_address.clone(),
+            amount: 50,
+            live_until_ledger: 100,
+        }
+        .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(1).unwrap(),
+        &Transfer { from: user.clone(), to: contract_address.clone(), amount: 50 }
+            .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(2).unwrap(),
+        &Transfer { from: contract_address.clone(), to: recipient.clone(), amount: 50 }
+            .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(3).unwrap(),
+        &FeeCollected {
+            user: user.clone(),
+            recipient: recipient.clone(),
+            token: token_address.clone(),
+            amount: 50,
+        }
+        .to_xdr(&e, &contract_address)
+    );
 
     let allowance = token_client.allowance(&user, &contract_address);
     assert_eq!(allowance, 0);
@@ -147,8 +209,37 @@ fn collect_fee_with_eager_approval_to_current_contract() {
     });
 
     let events = e.events().all();
-    // approval, pull of the max fee, remainder refund and collect fee
     assert_eq!(events.events().len(), 4);
+    assert_eq!(
+        events.events().first().unwrap(),
+        &Approve {
+            owner: user.clone(),
+            spender: contract_address.clone(),
+            amount: 50,
+            live_until_ledger: 100,
+        }
+        .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(1).unwrap(),
+        &Transfer { from: user.clone(), to: contract_address.clone(), amount: 50 }
+            .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(2).unwrap(),
+        &Transfer { from: contract_address.clone(), to: user.clone(), amount: 30 }
+            .to_xdr(&e, &token_address)
+    );
+    assert_eq!(
+        events.events().get(3).unwrap(),
+        &FeeCollected {
+            user: user.clone(),
+            recipient: contract_address.clone(),
+            token: token_address.clone(),
+            amount: 20,
+        }
+        .to_xdr(&e, &contract_address)
+    );
 
     let allowance = token_client.allowance(&user, &contract_address);
     assert_eq!(allowance, 0);


### PR DESCRIPTION
fix https://github.com/OpenZeppelin/stellar-contracts/issues/875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Eager fee collection now uses the full approved maximum, pays the actual fee, refunds any remainder, and clears the allowance.
  - Eager collection requires sufficient token balance for the approved maximum and fails otherwise.
  - Lazy fee collection continues to transfer only the actual fee and preserves any unused allowance.

- **Documentation**
  - Clarified approval, refund, allowance, balance, and failure behavior for fee collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Credits go to @knQzx for identifying the issue and proposing a fix