### PR TITLE
make votes work with enumerable and consecutive

### DIFF
--- a/packages/tokens/src/fungible/extensions/burnable/mod.rs
+++ b/packages/tokens/src/fungible/extensions/burnable/mod.rs
@@ -4,17 +4,9 @@ mod storage;
 mod test;
 
 use soroban_sdk::{contractevent, contracttrait, Address, Env};
+pub use storage::Burnable;
 
 use crate::fungible::{overrides::BurnableOverrides, FungibleToken};
-
-/// Type-level name of the burnable extension, for use in a
-/// [`crate::fungible::combinations::Compose`] list.
-///
-/// Burnable is additive: it does not override the base behavior, so listing
-/// it is purely declarative and does not affect the resolved contract type.
-/// Burning is enabled by implementing [`FungibleBurnable`], whether or not
-/// `Burnable` is listed.
-pub enum Burnable {}
 
 /// Burnable Trait for Fungible Token
 ///

--- a/packages/tokens/src/fungible/extensions/burnable/storage.rs
+++ b/packages/tokens/src/fungible/extensions/burnable/storage.rs
@@ -2,6 +2,16 @@ use soroban_sdk::{Address, Env};
 
 use crate::fungible::{extensions::burnable::emit_burn, Base};
 
+/// Type-level name of the burnable extension, for use in a
+/// [`crate::fungible::combinations::Compose`] list.
+///
+/// Burnable is additive: it does not override the base behavior, so listing
+/// it is purely declarative and does not affect the resolved contract type.
+/// Burning is enabled by implementing
+/// [`crate::fungible::burnable::FungibleBurnable`], whether or not `Burnable`
+/// is listed.
+pub enum Burnable {}
+
 impl Base {
     /// Destroys `amount` of tokens from `from`. Updates the total
     /// supply accordingly.

--- a/packages/tokens/src/non_fungible/extensions/burnable/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/burnable/mod.rs
@@ -5,15 +5,7 @@ use crate::non_fungible::{overrides::BurnableOverrides, NonFungibleToken};
 mod test;
 
 use soroban_sdk::{contractevent, contracttrait, Address, Env};
-
-/// Type-level name of the burnable extension, for use in a
-/// [`crate::non_fungible::combinations::Compose`] list.
-///
-/// Burnable is additive: it does not override the base behavior, so listing
-/// it is purely declarative and does not affect the resolved contract type.
-/// Burning is enabled by implementing [`NonFungibleBurnable`], whether or not
-/// `Burnable` is listed.
-pub enum Burnable {}
+pub use storage::Burnable;
 
 /// Burnable Trait for Non-Fungible Token
 ///

--- a/packages/tokens/src/non_fungible/extensions/burnable/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/burnable/storage.rs
@@ -2,6 +2,16 @@ use soroban_sdk::{Address, Env};
 
 use crate::non_fungible::{burnable::emit_burn, Base};
 
+/// Type-level name of the burnable extension, for use in a
+/// [`crate::non_fungible::combinations::Compose`] list.
+///
+/// Burnable is additive: it does not override the base behavior, so listing
+/// it is purely declarative and does not affect the resolved contract type.
+/// Burning is enabled by implementing
+/// [`crate::non_fungible::burnable::NonFungibleBurnable`], whether or not
+/// `Burnable` is listed.
+pub enum Burnable {}
+
 impl Base {
     /// Destroys the token with `token_id` from `from`, ensuring ownership
     /// checks, and emits a `burn` event.

--- a/packages/tokens/src/non_fungible/extensions/combinations/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/combinations/mod.rs
@@ -29,16 +29,20 @@
 //! impl NonFungibleBurnable for MyToken {}
 //! ```
 //!
-//! No multi-type combinations of contract types are curated for non-fungible
-//! tokens yet; every valid list currently holds at most one contract type
-//! (plus any additive extensions). Invalid lists do not compile: `Enumerable`
-//! and `Consecutive` are mutually exclusive, and implementing an extension
-//! trait the list does not back (e.g.
+//! Curated multi-type combinations: [`NonFungibleVotes`] can be combined with
+//! either [`Enumerable`] or [`Consecutive`], e.g.
+//! `Compose<(Enumerable, NonFungibleVotes)>`. Invalid lists do not compile:
+//! `Enumerable` and `Consecutive` are mutually exclusive, and implementing an
+//! extension trait the list does not back (e.g.
 //! [`crate::non_fungible::enumerable::NonFungibleEnumerable`] without
 //! `Enumerable` in the list) is rejected by that trait's bound.
 
+mod storage;
+
 #[cfg(test)]
 mod test;
+
+use storage::{ConsecutiveVotes, EnumerableVotes};
 
 use crate::non_fungible::{
     extensions::{
@@ -67,6 +71,8 @@ pub type Compose<L> = <L as Composable>::Out;
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a valid contract type combination",
     note = "valid single contract types: `Base`, `Enumerable`, `Consecutive`, `NonFungibleVotes`",
+    note = "curated combinations: `(Enumerable, NonFungibleVotes)`, `(Consecutive, \
+            NonFungibleVotes)`",
     note = "additive extensions (e.g. `Burnable`, `Royalties`) may be listed alongside a contract \
             type; they do not affect the resolved type",
     note = "lists of up to 5 entries are supported"
@@ -145,8 +151,8 @@ impl Extension for Royalties {
 
 // Identity rows: combining with `Nil` changes nothing. One pair of rows per
 // contract type, plus the `Nil`/`Nil` row for lists of only additive
-// extensions. Curated multi-type combinations would be added here as
-// additional rows (in both orders, so lists stay order-insensitive).
+// extensions. Curated multi-type combinations are additional rows, declared
+// in both orders so lists stay order-insensitive.
 impl Combine<Nil> for Nil {
     type Out = Nil;
 }
@@ -174,6 +180,26 @@ impl Combine<Nil> for NonFungibleVotes {
 impl Combine<NonFungibleVotes> for Nil {
     type Out = NonFungibleVotes;
 }
+impl Combine<Nil> for EnumerableVotes {
+    type Out = EnumerableVotes;
+}
+impl Combine<Nil> for ConsecutiveVotes {
+    type Out = ConsecutiveVotes;
+}
+
+// Curated pairs.
+impl Combine<NonFungibleVotes> for Enumerable {
+    type Out = EnumerableVotes;
+}
+impl Combine<Enumerable> for NonFungibleVotes {
+    type Out = EnumerableVotes;
+}
+impl Combine<NonFungibleVotes> for Consecutive {
+    type Out = ConsecutiveVotes;
+}
+impl Combine<Consecutive> for NonFungibleVotes {
+    type Out = ConsecutiveVotes;
+}
 
 impl Finalize for Nil {
     type Out = Base;
@@ -189,6 +215,12 @@ impl Finalize for Consecutive {
 }
 impl Finalize for NonFungibleVotes {
     type Out = NonFungibleVotes;
+}
+impl Finalize for EnumerableVotes {
+    type Out = EnumerableVotes;
+}
+impl Finalize for ConsecutiveVotes {
+    type Out = ConsecutiveVotes;
 }
 
 // Bare forms: a single entry may also be written without the one-element

--- a/packages/tokens/src/non_fungible/extensions/combinations/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/combinations/storage.rs
@@ -1,0 +1,173 @@
+use soroban_sdk::{Address, Env, String};
+use stellar_governance::votes::transfer_voting_units;
+
+use crate::non_fungible::{
+    extensions::{
+        consecutive::{Consecutive, ConsecutiveContractType},
+        enumerable::{Enumerable, EnumerableContractType},
+    },
+    overrides::{BurnableOverrides, ContractOverrides},
+};
+
+/// Contract type combining the [`Enumerable`] bookkeeping with vote
+/// checkpoints: every mint, transfer and burn updates the enumeration and
+/// moves the corresponding voting unit.
+pub struct EnumerableVotes;
+
+// The combined contract type keeps backing the enumerable extension.
+impl EnumerableContractType for EnumerableVotes {}
+
+impl ContractOverrides for EnumerableVotes {
+    fn transfer(e: &Env, from: &Address, to: &Address, token_id: u32) {
+        EnumerableVotes::transfer(e, from, to, token_id);
+    }
+
+    fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, token_id: u32) {
+        EnumerableVotes::transfer_from(e, spender, from, to, token_id);
+    }
+}
+
+impl BurnableOverrides for EnumerableVotes {
+    fn burn(e: &Env, from: &Address, token_id: u32) {
+        EnumerableVotes::burn(e, from, token_id);
+    }
+
+    fn burn_from(e: &Env, spender: &Address, from: &Address, token_id: u32) {
+        EnumerableVotes::burn_from(e, spender, from, token_id);
+    }
+}
+
+impl EnumerableVotes {
+    /// refer to [`Enumerable::sequential_mint`] and [`transfer_voting_units`]
+    /// for the inline documentation.
+    pub fn sequential_mint(e: &Env, to: &Address) -> u32 {
+        let token_id = Enumerable::sequential_mint(e, to);
+        transfer_voting_units(e, None, Some(to), 1);
+        token_id
+    }
+
+    /// refer to [`Enumerable::non_sequential_mint`] and
+    /// [`transfer_voting_units`] for the inline documentation.
+    pub fn non_sequential_mint(e: &Env, to: &Address, token_id: u32) {
+        Enumerable::non_sequential_mint(e, to, token_id);
+        transfer_voting_units(e, None, Some(to), 1);
+    }
+
+    /// refer to [`Enumerable::transfer`] and [`transfer_voting_units`] for
+    /// the inline documentation.
+    pub fn transfer(e: &Env, from: &Address, to: &Address, token_id: u32) {
+        Enumerable::transfer(e, from, to, token_id);
+        transfer_voting_units(e, Some(from), Some(to), 1);
+    }
+
+    /// refer to [`Enumerable::transfer_from`] and [`transfer_voting_units`]
+    /// for the inline documentation.
+    pub fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, token_id: u32) {
+        Enumerable::transfer_from(e, spender, from, to, token_id);
+        transfer_voting_units(e, Some(from), Some(to), 1);
+    }
+
+    /// refer to [`Enumerable::burn`] and [`transfer_voting_units`] for the
+    /// inline documentation.
+    pub fn burn(e: &Env, from: &Address, token_id: u32) {
+        Enumerable::burn(e, from, token_id);
+        transfer_voting_units(e, Some(from), None, 1);
+    }
+
+    /// refer to [`Enumerable::burn_from`] and [`transfer_voting_units`] for
+    /// the inline documentation.
+    pub fn burn_from(e: &Env, spender: &Address, from: &Address, token_id: u32) {
+        Enumerable::burn_from(e, spender, from, token_id);
+        transfer_voting_units(e, Some(from), None, 1);
+    }
+}
+
+/// Contract type combining the [`Consecutive`] accounting model with vote
+/// checkpoints: batch minting adds the matching amount of voting units in a
+/// single checkpoint update, and every transfer and burn moves the
+/// corresponding voting unit.
+pub struct ConsecutiveVotes;
+
+// The combined contract type keeps backing the consecutive extension.
+impl ConsecutiveContractType for ConsecutiveVotes {}
+
+impl ContractOverrides for ConsecutiveVotes {
+    // Ownership resolution and metadata follow the consecutive bucket model
+    // unchanged.
+    fn owner_of(e: &Env, token_id: u32) -> Address {
+        Consecutive::owner_of(e, token_id)
+    }
+
+    fn token_uri(e: &Env, token_id: u32) -> String {
+        Consecutive::token_uri(e, token_id)
+    }
+
+    fn approve(
+        e: &Env,
+        approver: &Address,
+        approved: &Address,
+        token_id: u32,
+        live_until_ledger: u32,
+    ) {
+        Consecutive::approve(e, approver, approved, token_id, live_until_ledger);
+    }
+
+    fn transfer(e: &Env, from: &Address, to: &Address, token_id: u32) {
+        ConsecutiveVotes::transfer(e, from, to, token_id);
+    }
+
+    fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, token_id: u32) {
+        ConsecutiveVotes::transfer_from(e, spender, from, to, token_id);
+    }
+}
+
+impl BurnableOverrides for ConsecutiveVotes {
+    fn burn(e: &Env, from: &Address, token_id: u32) {
+        ConsecutiveVotes::burn(e, from, token_id);
+    }
+
+    fn burn_from(e: &Env, spender: &Address, from: &Address, token_id: u32) {
+        ConsecutiveVotes::burn_from(e, spender, from, token_id);
+    }
+}
+
+impl ConsecutiveVotes {
+    /// Creates a batch of `amount` tokens for `to` and adds the matching
+    /// amount of voting units in a single checkpoint update.
+    ///
+    /// refer to [`Consecutive::batch_mint`] and [`transfer_voting_units`] for
+    /// the inline documentation.
+    pub fn batch_mint(e: &Env, to: &Address, amount: u32) -> u32 {
+        let last_id = Consecutive::batch_mint(e, to, amount);
+        transfer_voting_units(e, None, Some(to), u128::from(amount));
+        last_id
+    }
+
+    /// refer to [`Consecutive::transfer`] and [`transfer_voting_units`] for
+    /// the inline documentation.
+    pub fn transfer(e: &Env, from: &Address, to: &Address, token_id: u32) {
+        Consecutive::transfer(e, from, to, token_id);
+        transfer_voting_units(e, Some(from), Some(to), 1);
+    }
+
+    /// refer to [`Consecutive::transfer_from`] and [`transfer_voting_units`]
+    /// for the inline documentation.
+    pub fn transfer_from(e: &Env, spender: &Address, from: &Address, to: &Address, token_id: u32) {
+        Consecutive::transfer_from(e, spender, from, to, token_id);
+        transfer_voting_units(e, Some(from), Some(to), 1);
+    }
+
+    /// refer to [`Consecutive::burn`] and [`transfer_voting_units`] for the
+    /// inline documentation.
+    pub fn burn(e: &Env, from: &Address, token_id: u32) {
+        Consecutive::burn(e, from, token_id);
+        transfer_voting_units(e, Some(from), None, 1);
+    }
+
+    /// refer to [`Consecutive::burn_from`] and [`transfer_voting_units`] for
+    /// the inline documentation.
+    pub fn burn_from(e: &Env, spender: &Address, from: &Address, token_id: u32) {
+        Consecutive::burn_from(e, spender, from, token_id);
+        transfer_voting_units(e, Some(from), None, 1);
+    }
+}

--- a/packages/tokens/src/non_fungible/extensions/combinations/test.rs
+++ b/packages/tokens/src/non_fungible/extensions/combinations/test.rs
@@ -152,6 +152,9 @@ fn consecutive_votes_tracks_batches_and_voting_units() {
         assert_eq!(get_voting_units(&e, &alice), 4);
         assert_eq!(get_voting_units(&e, &bob), 1);
         assert_eq!(Consecutive::owner_of(&e, last_id), bob);
+        // transferring the batch boundary materializes the previous token's
+        // owner, keeping the rest of the batch resolvable
+        assert_eq!(Consecutive::owner_of(&e, last_id - 1), alice);
 
         <ConsecutiveVotes as BurnableOverrides>::burn(&e, &bob, last_id);
         assert_eq!(get_voting_units(&e, &bob), 0);

--- a/packages/tokens/src/non_fungible/extensions/combinations/test.rs
+++ b/packages/tokens/src/non_fungible/extensions/combinations/test.rs
@@ -2,6 +2,9 @@ extern crate std;
 
 use core::any::TypeId;
 
+use soroban_sdk::{contract, testutils::Address as _, Address, Env, String};
+use stellar_governance::votes::get_voting_units;
+
 use crate::non_fungible::{
     extensions::{
         burnable::Burnable,
@@ -11,8 +14,14 @@ use crate::non_fungible::{
         royalties::Royalties,
         votes::NonFungibleVotes,
     },
+    overrides::{BurnableOverrides, ContractOverrides},
     Base,
 };
+
+type EnumerableVotes = Compose<(Enumerable, NonFungibleVotes)>;
+// deliberately the swapped order, asserting that the list is
+// order-insensitive
+type ConsecutiveVotes = Compose<(NonFungibleVotes, Consecutive)>;
 
 // Pins every `Composable` mapping: the resolved `Out` type must be exactly the
 // expected contract type. Invalid lists are rejected at compile time and
@@ -60,4 +69,91 @@ fn additive_only_lists_resolve_to_base() {
     assert_composes_to::<Burnable, Base>();
     assert_composes_to::<Royalties, Base>();
     assert_composes_to::<(Burnable, Royalties), Base>();
+}
+
+#[test]
+fn votes_combinations_are_order_insensitive() {
+    assert_eq!(
+        TypeId::of::<Compose<(Enumerable, NonFungibleVotes)>>(),
+        TypeId::of::<Compose<(NonFungibleVotes, Enumerable)>>(),
+    );
+    assert_eq!(
+        TypeId::of::<Compose<(Consecutive, NonFungibleVotes)>>(),
+        TypeId::of::<Compose<(NonFungibleVotes, Consecutive)>>(),
+    );
+    // the combined types are distinct from their members
+    assert_ne!(TypeId::of::<EnumerableVotes>(), TypeId::of::<Enumerable>());
+    assert_ne!(TypeId::of::<EnumerableVotes>(), TypeId::of::<NonFungibleVotes>());
+    assert_ne!(TypeId::of::<ConsecutiveVotes>(), TypeId::of::<Consecutive>());
+    // additive markers stay ignored around a curated pair
+    assert_eq!(
+        TypeId::of::<Compose<(Enumerable, Burnable, NonFungibleVotes, Royalties)>>(),
+        TypeId::of::<EnumerableVotes>(),
+    );
+}
+
+#[contract]
+struct MockContract;
+
+fn setup_env() -> (Env, Address) {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_address = e.register(MockContract, ());
+
+    e.as_contract(&contract_address, || {
+        Base::set_metadata(
+            &e,
+            String::from_str(&e, "https://example.com/"),
+            String::from_str(&e, "Test NFT"),
+            String::from_str(&e, "TNFT"),
+        );
+    });
+
+    (e, contract_address)
+}
+
+#[test]
+fn enumerable_votes_tracks_enumeration_and_voting_units() {
+    let (e, contract_address) = setup_env();
+    let alice = Address::generate(&e);
+    let bob = Address::generate(&e);
+
+    e.as_contract(&contract_address, || {
+        let token_id = EnumerableVotes::sequential_mint(&e, &alice);
+        assert_eq!(Enumerable::total_supply(&e), 1);
+        assert_eq!(Enumerable::get_owner_token_id(&e, &alice, 0), token_id);
+        assert_eq!(get_voting_units(&e, &alice), 1);
+
+        <EnumerableVotes as ContractOverrides>::transfer(&e, &alice, &bob, token_id);
+        assert_eq!(get_voting_units(&e, &alice), 0);
+        assert_eq!(get_voting_units(&e, &bob), 1);
+        assert_eq!(Enumerable::get_owner_token_id(&e, &bob, 0), token_id);
+
+        <EnumerableVotes as BurnableOverrides>::burn(&e, &bob, token_id);
+        assert_eq!(get_voting_units(&e, &bob), 0);
+        assert_eq!(Enumerable::total_supply(&e), 0);
+    });
+}
+
+#[test]
+fn consecutive_votes_tracks_batches_and_voting_units() {
+    let (e, contract_address) = setup_env();
+    let alice = Address::generate(&e);
+    let bob = Address::generate(&e);
+
+    e.as_contract(&contract_address, || {
+        let last_id = ConsecutiveVotes::batch_mint(&e, &alice, 5);
+        // one checkpoint update covers the whole batch
+        assert_eq!(get_voting_units(&e, &alice), 5);
+        // ownership resolves for non-boundary tokens of the batch
+        assert_eq!(Consecutive::owner_of(&e, last_id - 2), alice);
+
+        <ConsecutiveVotes as ContractOverrides>::transfer(&e, &alice, &bob, last_id);
+        assert_eq!(get_voting_units(&e, &alice), 4);
+        assert_eq!(get_voting_units(&e, &bob), 1);
+        assert_eq!(Consecutive::owner_of(&e, last_id), bob);
+
+        <ConsecutiveVotes as BurnableOverrides>::burn(&e, &bob, last_id);
+        assert_eq!(get_voting_units(&e, &bob), 0);
+    });
 }

--- a/packages/tokens/src/non_fungible/extensions/combinations/test.rs
+++ b/packages/tokens/src/non_fungible/extensions/combinations/test.rs
@@ -157,3 +157,85 @@ fn consecutive_votes_tracks_batches_and_voting_units() {
         assert_eq!(get_voting_units(&e, &bob), 0);
     });
 }
+
+#[test]
+fn enumerable_votes_non_sequential_mint_and_transfer_from() {
+    let (e, contract_address) = setup_env();
+    let alice = Address::generate(&e);
+    let bob = Address::generate(&e);
+    let spender = Address::generate(&e);
+
+    e.as_contract(&contract_address, || {
+        EnumerableVotes::non_sequential_mint(&e, &alice, 42);
+        assert_eq!(Enumerable::get_owner_token_id(&e, &alice, 0), 42);
+        assert_eq!(get_voting_units(&e, &alice), 1);
+
+        Base::approve(&e, &alice, &spender, 42, e.ledger().sequence() + 100);
+        <EnumerableVotes as ContractOverrides>::transfer_from(&e, &spender, &alice, &bob, 42);
+        assert_eq!(get_voting_units(&e, &alice), 0);
+        assert_eq!(get_voting_units(&e, &bob), 1);
+        assert_eq!(Enumerable::get_owner_token_id(&e, &bob, 0), 42);
+    });
+}
+
+#[test]
+fn enumerable_votes_burn_from() {
+    let (e, contract_address) = setup_env();
+    let alice = Address::generate(&e);
+    let spender = Address::generate(&e);
+
+    e.as_contract(&contract_address, || {
+        let token_id = EnumerableVotes::sequential_mint(&e, &alice);
+
+        Base::approve(&e, &alice, &spender, token_id, e.ledger().sequence() + 100);
+        <EnumerableVotes as BurnableOverrides>::burn_from(&e, &spender, &alice, token_id);
+        assert_eq!(get_voting_units(&e, &alice), 0);
+        assert_eq!(Enumerable::total_supply(&e), 0);
+    });
+}
+
+#[test]
+fn consecutive_votes_queries_and_transfer_from() {
+    let (e, contract_address) = setup_env();
+    let alice = Address::generate(&e);
+    let bob = Address::generate(&e);
+    let spender = Address::generate(&e);
+
+    e.as_contract(&contract_address, || {
+        let last_id = ConsecutiveVotes::batch_mint(&e, &alice, 3);
+
+        // queries route through the consecutive bucket model unchanged
+        assert_eq!(<ConsecutiveVotes as ContractOverrides>::owner_of(&e, last_id - 1), alice);
+        assert_eq!(
+            <ConsecutiveVotes as ContractOverrides>::token_uri(&e, last_id),
+            Consecutive::token_uri(&e, last_id)
+        );
+
+        <ConsecutiveVotes as ContractOverrides>::approve(
+            &e,
+            &alice,
+            &spender,
+            last_id,
+            e.ledger().sequence() + 100,
+        );
+        <ConsecutiveVotes as ContractOverrides>::transfer_from(&e, &spender, &alice, &bob, last_id);
+        assert_eq!(get_voting_units(&e, &alice), 2);
+        assert_eq!(get_voting_units(&e, &bob), 1);
+        assert_eq!(Consecutive::owner_of(&e, last_id), bob);
+    });
+}
+
+#[test]
+fn consecutive_votes_burn_from() {
+    let (e, contract_address) = setup_env();
+    let alice = Address::generate(&e);
+    let spender = Address::generate(&e);
+
+    e.as_contract(&contract_address, || {
+        let last_id = ConsecutiveVotes::batch_mint(&e, &alice, 2);
+
+        Base::approve(&e, &alice, &spender, last_id, e.ledger().sequence() + 100);
+        <ConsecutiveVotes as BurnableOverrides>::burn_from(&e, &spender, &alice, last_id);
+        assert_eq!(get_voting_units(&e, &alice), 1);
+    });
+}

--- a/packages/tokens/src/non_fungible/extensions/consecutive/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/consecutive/mod.rs
@@ -63,7 +63,7 @@
 //!   the logic of tracking ownership.
 pub mod storage;
 use soroban_sdk::{contractevent, Address, Env};
-pub use storage::Consecutive;
+pub use storage::{Consecutive, ConsecutiveContractType};
 
 use crate::non_fungible::NonFungibleToken;
 
@@ -74,7 +74,7 @@ use crate::non_fungible::NonFungibleToken;
 /// The `consecutive` extension provides its own business logic for creating and
 /// destroying tokens. Therefore, this trait is INCOMPATIBLE with the
 /// `Enumerable` extension.
-pub trait NonFungibleConsecutive: NonFungibleToken<ContractType = Consecutive> {}
+pub trait NonFungibleConsecutive: NonFungibleToken<ContractType: ConsecutiveContractType> {}
 
 #[cfg(test)]
 mod test;

--- a/packages/tokens/src/non_fungible/extensions/consecutive/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/consecutive/storage.rs
@@ -15,6 +15,16 @@ use crate::non_fungible::{
 
 pub struct Consecutive;
 
+/// Marker for the contract types backing the
+/// [`crate::non_fungible::consecutive::NonFungibleConsecutive`] trait:
+/// [`Consecutive`] itself and the curated combinations that include it.
+/// Contract authors never interact with this trait; it only appears as the
+/// bound enforcing that the selected `ContractType` follows the consecutive
+/// accounting model.
+pub trait ConsecutiveContractType {}
+
+impl ConsecutiveContractType for Consecutive {}
+
 impl ContractOverrides for Consecutive {
     fn owner_of(e: &Env, token_id: u32) -> Address {
         Consecutive::owner_of(e, token_id)

--- a/packages/tokens/src/non_fungible/extensions/enumerable/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/enumerable/mod.rs
@@ -4,7 +4,7 @@ pub mod storage;
 mod test;
 
 use soroban_sdk::{contracttrait, Address, Env};
-pub use storage::Enumerable;
+pub use storage::{Enumerable, EnumerableContractType};
 
 use crate::non_fungible::NonFungibleToken;
 
@@ -41,7 +41,7 @@ use crate::non_fungible::NonFungibleToken;
 ///    exists for the use-cases where the enumeration is required as an on-chain
 ///    operation.
 #[contracttrait]
-pub trait NonFungibleEnumerable: NonFungibleToken<ContractType = Enumerable> {
+pub trait NonFungibleEnumerable: NonFungibleToken<ContractType: EnumerableContractType> {
     /// Returns the total amount of tokens stored by the contract.
     ///
     /// # Arguments

--- a/packages/tokens/src/non_fungible/extensions/enumerable/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/enumerable/storage.rs
@@ -7,6 +7,16 @@ use crate::non_fungible::{
 
 pub struct Enumerable;
 
+/// Marker for the contract types backing the
+/// [`crate::non_fungible::enumerable::NonFungibleEnumerable`] trait:
+/// [`Enumerable`] itself and the curated combinations that include it.
+/// Contract authors never interact with this trait; it only appears as the
+/// bound enforcing that the selected `ContractType` keeps the enumeration
+/// bookkeeping.
+pub trait EnumerableContractType {}
+
+impl EnumerableContractType for Enumerable {}
+
 impl ContractOverrides for Enumerable {
     fn transfer(e: &Env, from: &Address, to: &Address, token_id: u32) {
         Enumerable::transfer(e, from, to, token_id);

--- a/packages/tokens/src/non_fungible/extensions/royalties/mod.rs
+++ b/packages/tokens/src/non_fungible/extensions/royalties/mod.rs
@@ -5,15 +5,7 @@ use crate::non_fungible::{Base, NonFungibleToken};
 mod test;
 
 use soroban_sdk::{contractevent, contracttrait, Address, Env};
-
-/// Type-level name of the royalties extension, for use in a
-/// [`crate::non_fungible::combinations::Compose`] list.
-///
-/// Royalties is additive: it does not override the base behavior, so listing
-/// it is purely declarative and does not affect the resolved contract type.
-/// Royalty support is enabled by implementing [`NonFungibleRoyalties`],
-/// whether or not `Royalties` is listed.
-pub enum Royalties {}
+pub use storage::Royalties;
 
 /// Royalties Trait for Non-Fungible Token (ERC2981)
 ///

--- a/packages/tokens/src/non_fungible/extensions/royalties/storage.rs
+++ b/packages/tokens/src/non_fungible/extensions/royalties/storage.rs
@@ -5,6 +5,16 @@ use crate::non_fungible::{
     Base, NonFungibleTokenError, OWNER_EXTEND_AMOUNT, OWNER_TTL_THRESHOLD,
 };
 
+/// Type-level name of the royalties extension, for use in a
+/// [`crate::non_fungible::combinations::Compose`] list.
+///
+/// Royalties is additive: it does not override the base behavior, so listing
+/// it is purely declarative and does not affect the resolved contract type.
+/// Royalty support is enabled by implementing
+/// [`crate::non_fungible::royalties::NonFungibleRoyalties`], whether or not
+/// `Royalties` is listed.
+pub enum Royalties {}
+
 /// Storage container for royalty information
 #[contracttype]
 pub struct RoyaltyInfo {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #877

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added NFT contract combinations that support enumeration or consecutive minting alongside governance voting units.
  - Voting units now update automatically during minting, transfers, delegated transfers, and burns.
  - Consecutive batch minting credits the recipient with the complete minted amount.
  - NFT extension composition now supports compatible contract types, enabling more flexible combinations.
- **Bug Fixes**
  - Improved support for ownership, metadata, approvals, token queries, and voting-unit updates across combined NFT extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->