### PR TITLE
Vault: reject deposits that mint zero shares

### DIFF
--- a/packages/tokens/src/vault/mod.rs
+++ b/packages/tokens/src/vault/mod.rs
@@ -153,6 +153,8 @@ pub trait FungibleVault: FungibleToken<ContractType = Vault> {
     /// * [`crate::vault::VaultTokenError::VaultExceededMaxDeposit`] - When
     ///   attempting to deposit more assets than the maximum allowed for the
     ///   receiver.
+    /// * [`crate::vault::VaultTokenError::VaultZeroShares`] - When a positive
+    ///   amount of assets would mint zero shares.
     /// * [`crate::vault::VaultTokenError::VaultInvalidAssetsAmount`] - When
     ///   `assets < 0`.
     /// * [`crate::vault::VaultTokenError::MathOverflow`] - When mathematical
@@ -408,6 +410,9 @@ pub enum VaultTokenError {
     VaultMaxDecimalsOffsetExceeded = 409,
     /// Indicates overflow due to mathematical operations
     MathOverflow = 410,
+    /// Attempted to deposit a positive amount of assets that would mint zero
+    /// shares.
+    VaultZeroShares = 411,
 }
 
 // ################## CONSTANTS ##################

--- a/packages/tokens/src/vault/storage.rs
+++ b/packages/tokens/src/vault/storage.rs
@@ -58,18 +58,28 @@ pub enum VaultStorageKey {
 /// representation between the underlying asset's decimals and the vault
 /// decimals.
 ///
-/// While not fully preventing the attack, analysis shows that the default
-/// offset (0) makes it non-profitable even if an attacker is able to capture
-/// value from multiple user deposits, as a result of the value being captured
-/// by the virtual shares (out of the attacker's donation) matching the
-/// attacker's expected gains. With a larger offset, the attack becomes orders
-/// of magnitude more expensive than it is profitable.
+/// The virtual shares and assets do not fully prevent the attack. With the
+/// default offset (0), diluting a single deposit costs the attacker at least
+/// as much as that deposit, so a single victim is never profitable. The
+/// rounding loss of each deposit, however, accrues to the existing
+/// shareholders, and an attacker holding most of the real shares profits once
+/// enough deposits land on the inflated price. With a larger offset, the
+/// attack becomes orders of magnitude more expensive than it is profitable.
 ///
 /// The drawback of this approach is that the virtual shares do capture (a very
 /// small) part of the value being accrued to the vault. Also, if the vault
 /// experiences losses, the users try to exit the vault, the virtual shares and
 /// assets will cause the first user to exit to experience reduced losses in
 /// detriment to the last users that will experience bigger losses.
+///
+/// ### 3. Zero-Share Deposit Rejection
+///
+/// [`Vault::deposit()`] rejects a positive deposit that would mint zero
+/// shares, so no depositor can lose their entire deposit to an inflated
+/// price. Each deposit still loses up to one share's worth of assets to
+/// rounding. Integrators that need a tighter bound should compare
+/// [`Vault::preview_deposit()`] against a caller-supplied minimum before
+/// depositing.
 ///
 /// If this is not the preferred solution, implementers can still use the
 /// default offset of 0 and implement their own safeguards.
@@ -318,6 +328,8 @@ impl Vault {
     ///
     /// * [`VaultTokenError::VaultExceededMaxDeposit`] - When attempting to
     ///   deposit more assets than the maximum allowed for the receiver.
+    /// * [`VaultTokenError::VaultZeroShares`] - When a positive amount of
+    ///   assets would mint zero shares.
     /// * also refer to [`Self::preview_deposit()`] errors.
     ///
     /// # Events
@@ -343,6 +355,9 @@ impl Vault {
             panic_with_error!(e, VaultTokenError::VaultExceededMaxDeposit);
         }
         let shares: i128 = Self::preview_deposit(e, assets);
+        if shares == 0 && assets > 0 {
+            panic_with_error!(e, VaultTokenError::VaultZeroShares);
+        }
         Self::deposit_internal(e, &receiver, assets, shares, &from, &operator);
         emit_deposit(e, &operator, &from, &receiver, assets, shares);
 

--- a/packages/tokens/src/vault/test.rs
+++ b/packages/tokens/src/vault/test.rs
@@ -482,6 +482,50 @@ fn convert_zero_assets() {
 }
 
 #[test]
+fn deposit_zero_assets() {
+    let e = Env::default();
+    let admin = Address::generate(&e);
+    let asset_address = create_asset_contract(&e, 1_000, &admin);
+    let vault_address = create_vault_contract(&e, &asset_address, 0);
+
+    e.mock_all_auths();
+
+    e.as_contract(&vault_address, || {
+        let shares = Vault::deposit(&e, 0, admin.clone(), admin.clone(), admin.clone());
+        assert_eq!(shares, 0);
+        assert_eq!(Base::total_supply(&e), 0);
+        assert_eq!(Vault::total_assets(&e), 0);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #411)")]
+fn deposit_zero_shares_after_donation() {
+    let e = Env::default();
+    let attacker = Address::generate(&e);
+    let victim = Address::generate(&e);
+    let asset_address = create_asset_contract(&e, 1_000, &attacker);
+    let asset_client = MockAssetContractClient::new(&e, &asset_address);
+    asset_client.mint(&victim, &1_000);
+    let vault_address = create_vault_contract(&e, &asset_address, 0);
+
+    e.mock_all_auths();
+
+    e.as_contract(&vault_address, || {
+        Vault::deposit(&e, 1, attacker.clone(), attacker.clone(), attacker.clone());
+    });
+    asset_client.transfer(&attacker, &vault_address, &100);
+
+    e.as_contract(&vault_address, || {
+        assert_eq!(Base::total_supply(&e), 1);
+        assert_eq!(Vault::total_assets(&e), 101);
+        assert_eq!(Vault::preview_deposit(&e, 50), 0);
+
+        Vault::deposit(&e, 50, victim.clone(), victim.clone(), victim.clone());
+    });
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #403)")]
 fn invalid_assets_amount() {
     let e = Env::default();


### PR DESCRIPTION
Fixes #882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deposits that would mint zero shares now fail with a clear `VaultZeroShares` error instead of completing unexpectedly.
  - Zero-asset deposits continue to return zero shares without changing vault assets or supply.
  - Improved protection against donation-related inflation scenarios that could result in zero-share deposits.

- **Documentation**
  - Clarified vault inflation-attack considerations, including residual risks from multiple deposits and zero-share deposit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->