### PR TITLE
RWA: recovery target reassignment

### DIFF
--- a/packages/tokens/src/rwa/compliance/modules/country_allow/mod.rs
+++ b/packages/tokens/src/rwa/compliance/modules/country_allow/mod.rs
@@ -32,6 +32,11 @@ use crate::rwa::compliance::modules::ComplianceModule;
 /// the sender or scale with amount, those belong in a different compliance
 /// module that you register alongside this one.
 ///
+/// Country data is read for the recipient wallet, not for its identity: the
+/// Identity Registry Storage keeps a profile per wallet, so sibling wallets of
+/// one investor are admitted on their own entries. A jurisdiction change for
+/// an investor must reach every wallet registered under that identity.
+///
 /// Countries are identified by ISO 3166-1 numeric codes and tracked
 /// per-`token`, so a single compliance module contract can serve multiple
 /// tokens with independent allowlists.

--- a/packages/tokens/src/rwa/compliance/modules/country_restrict/mod.rs
+++ b/packages/tokens/src/rwa/compliance/modules/country_restrict/mod.rs
@@ -32,6 +32,11 @@ use crate::rwa::compliance::modules::ComplianceModule;
 /// constrain the sender or scale with amount, those belong in a different
 /// compliance module that you register alongside this one.
 ///
+/// Country data is read for the recipient wallet, not for its identity: the
+/// Identity Registry Storage keeps a profile per wallet, so sibling wallets of
+/// one investor are blocked on their own entries. A jurisdiction change for
+/// an investor must reach every wallet registered under that identity.
+///
 /// Countries are identified by ISO 3166-1 numeric codes and tracked
 /// per-`token`, so a single compliance module contract can serve multiple
 /// tokens with independent restriction lists.

--- a/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
+++ b/packages/tokens/src/rwa/compliance/modules/max_balance/storage.rs
@@ -238,7 +238,11 @@ pub fn mark_preset_completed(e: &Env, token: &Address) {
 /// recovery, the sender is resolved through the IRS recovery record rather than
 /// reverting on the source lookup, so a forced/recovery transfer still updates
 /// the books. Once `from` recovered to `to`, both sides resolve to the same
-/// identity and the movement is a same-identity no-op.
+/// identity and the movement is a same-identity no-op. Reading the recovery
+/// target's current identity is sound because the IRS pins the recovered
+/// identity to the target until `from` has been drained: the target can
+/// neither be re-registered under another identity nor recovered onward
+/// while `from` still holds tokens in a linked token.
 ///
 /// # Arguments
 ///

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
@@ -29,14 +29,20 @@
 //!   so two wallets of the same investor each carry their own copy.
 //! - `RecoveredTo(old_wallet) -> new_wallet`: a permanent tombstone written by
 //!   account recovery; recovered wallets can never be registered again.
+//! - `RecoveredFrom(new_wallet) -> old_wallet`: the reverse link, kept only
+//!   while the recovered identity is still linked to `new_wallet`. It pins the
+//!   identity to the new wallet until the old wallet's tokens have been
+//!   recovered.
 //!
 //! ## Lifecycle Operations
 //!
 //! - `add_identity` registers a wallet under an identity contract.
 //! - `remove_identity` deletes a wallet's registration and profile. It is
-//!   rejected while the wallet still holds a balance in any linked token.
+//!   rejected while the wallet still holds a balance in any linked token, and
+//!   while the wallet is a recovery target whose old wallet still holds one.
 //! - `recover_identity` handles wallet loss: the same identity moves to a new
-//!   wallet, and the old wallet is tombstoned.
+//!   wallet, and the old wallet is tombstoned. Recoveries chain, but each hop's
+//!   balance must be recovered before the identity moves on again.
 //!
 //! ## Replacing an Identity
 //!
@@ -478,7 +484,8 @@ pub trait IdentityRegistryStorage: TokenBinder {
     /// implementation.
     ///
     /// The library-provided [`remove_identity`] rejects removal while
-    /// `account` holds a non-zero balance in any linked token, so that
+    /// `account` holds a non-zero balance in any linked token, or while it is
+    /// the target of a recovery whose old account still holds one, so that
     /// identity-keyed compliance state is never orphaned; refer to its
     /// documentation.
     fn remove_identity(e: &Env, account: Address, operator: Address);
@@ -507,6 +514,11 @@ pub trait IdentityRegistryStorage: TokenBinder {
     /// operation that requires custom access control. Access control should be
     /// enforced on `operator` before calling [`recover_identity`] for the
     /// implementation.
+    ///
+    /// The library-provided [`recover_identity`] rejects moving the identity
+    /// on from `old_account` while `old_account` is itself the target of an
+    /// earlier recovery whose old account still holds a balance in any linked
+    /// token; refer to its documentation.
     fn recover_identity(e: &Env, old_account: Address, new_account: Address, operator: Address);
 
     /// Retrieves the stored identity for a given account.
@@ -672,6 +684,9 @@ pub enum IRSError {
     AccountHasBalance = 328,
     /// The parallel arrays of a batch call have different lengths.
     BatchSizeMismatch = 329,
+    /// The account is a recovery target whose old account still holds a
+    /// balance in a linked token.
+    PendingRecovery = 330,
 }
 
 // ################## CONSTANTS ##################

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/mod.rs
@@ -26,7 +26,10 @@
 //!   identity: the identity represents the investor, the wallets are its keys.
 //! - `IdentityProfile(wallet)`: registry-side metadata, an [`IdentityType`]
 //!   plus the country data entries. This is kept per wallet, not per identity,
-//!   so two wallets of the same investor each carry their own copy.
+//!   so two wallets of the same investor each carry their own copy. The copies
+//!   are not reconciled: a jurisdiction change for an investor is applied by
+//!   the operator to every wallet registered under that identity, which the
+//!   `identity_stored` and `identity_recovered` events enumerate.
 //! - `RecoveredTo(old_wallet) -> new_wallet`: a permanent tombstone written by
 //!   account recovery; recovered wallets can never be registered again.
 //! - `RecoveredFrom(new_wallet) -> old_wallet`: the reverse link, kept only

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/storage.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/storage.rs
@@ -214,6 +214,10 @@ pub enum IRSStorageKey {
     IdentityProfile(Address),
     /// Maps old account to new account after recovery
     RecoveredTo(Address),
+    /// Maps a recovery target back to the old account whose identity it
+    /// received. Present only while the recovered identity is still linked to
+    /// the target.
+    RecoveredFrom(Address),
 }
 
 // ################## QUERY STATE ##################
@@ -471,6 +475,9 @@ pub fn batch_add_identity(
 ///   `account`.
 /// * [`IRSError::AccountHasBalance`] - If `account` holds a non-zero balance in
 ///   any linked token.
+/// * [`IRSError::PendingRecovery`] - If `account` is the target of an identity
+///   recovery whose old account still holds a non-zero balance in any linked
+///   token.
 ///
 /// # Events
 ///
@@ -483,11 +490,20 @@ pub fn batch_add_identity(
 ///
 /// # Notes
 ///
-/// One cross-contract `balance` call is made per linked token; the token
-/// binder's `MAX_TOKENS` cap is sized so this sweep fits within a single
-/// transaction. The zero balance check is only as complete as the token
-/// binder registry: a token that resolves identities through this contract
-/// without being bound to it is not checked.
+/// One cross-contract `balance` call is made per linked token, and one more
+/// per linked token when `account` is a recovery target, since the old
+/// account's balance is checked as well; the token binder's `MAX_TOKENS` cap
+/// is sized so this sweep fits within a single transaction. The zero balance
+/// check is only as complete as the token binder registry: a token that
+/// resolves identities through this contract without being bound to it is
+/// not checked.
+///
+/// A recovery target keeps the recovered identity until the old account has
+/// been drained. Balance recovery on the token side moves the old account's
+/// tokens to the target under the identity the target currently resolves to,
+/// so re-registering the target under another identity beforehand would hand
+/// those tokens to a different investor and desynchronize identity-keyed
+/// compliance accounting.
 ///
 /// The check covers balance-backed module state. Time-windowed transfer
 /// counters are flow-based and stay keyed to the old identity: a wallet
@@ -519,6 +535,8 @@ pub fn remove_identity(e: &Env, account: &Address) {
             panic_with_error!(e, IRSError::AccountHasBalance);
         }
     }
+
+    settle_recovery_target(e, account);
 
     e.storage().persistent().remove(&identity_key);
 
@@ -557,12 +575,22 @@ pub fn remove_identity(e: &Env, account: &Address) {
 ///   recovered to another account.
 /// * [`IRSError::IdentityOverwrite`] - If the `new_account` is already linked
 ///   to an identity.
+/// * [`IRSError::PendingRecovery`] - If `old_account` is itself the target of
+///   an earlier recovery whose old account still holds a non-zero balance in
+///   any linked token.
 ///
 /// # Events
 ///
 /// * topics - `["identity_recovered", old_account: Address, new_account:
 ///   Address]`
 /// * data - `[]`
+///
+/// # Notes
+///
+/// Recoveries can be chained, but the balance of each hop must be recovered
+/// before the identity moves on: a wallet whose identity has left it can no
+/// longer be the destination of a balance recovery, so the tokens of an
+/// undrained earlier hop would otherwise be stranded.
 ///
 /// # Security Warning
 ///
@@ -591,8 +619,11 @@ pub fn recover_identity(e: &Env, old_account: &Address, new_account: &Address) {
         panic_with_error!(e, IRSError::IdentityOverwrite)
     }
 
+    settle_recovery_target(e, old_account);
+
     e.storage().persistent().set(&new_identity_key, &identity);
     e.storage().persistent().remove(&old_identity_key);
+    e.storage().persistent().set(&IRSStorageKey::RecoveredFrom(new_account.clone()), old_account);
 
     // Recover identity profile
     let old_profile_key = IRSStorageKey::IdentityProfile(old_account.clone());
@@ -770,6 +801,36 @@ pub fn delete_country_data(e: &Env, account: &Address, index: u32) {
 }
 
 // ################## HELPERS ##################
+
+/// Releases `account` from its role as a recovery target, if it has one, so
+/// that the recovered identity may leave it. Panics while the old account the
+/// identity came from still holds tokens in any linked token, since those
+/// tokens can only be recovered into `account` under the identity it holds
+/// now.
+///
+/// # Arguments
+///
+/// * `e` - The Soroban environment.
+/// * `account` - The account whose identity is about to be removed or moved.
+///
+/// # Errors
+///
+/// * [`IRSError::PendingRecovery`] - If `account` is a recovery target whose
+///   old account holds a non-zero balance in any linked token.
+fn settle_recovery_target(e: &Env, account: &Address) {
+    let key = IRSStorageKey::RecoveredFrom(account.clone());
+    let Some(old_account) = e.storage().persistent().get::<_, Address>(&key) else {
+        return;
+    };
+
+    for token in linked_tokens(e).iter() {
+        if TokenClient::new(e, &token).balance(&old_account) != 0 {
+            panic_with_error!(e, IRSError::PendingRecovery);
+        }
+    }
+
+    e.storage().persistent().remove(&key);
+}
 
 /// Validates a single country data entry to ensure metadata constraints are
 /// met.

--- a/packages/tokens/src/rwa/identity_verification/identity_registry_storage/test.rs
+++ b/packages/tokens/src/rwa/identity_verification/identity_registry_storage/test.rs
@@ -1322,3 +1322,123 @@ fn batch_add_identity_accepts_an_empty_batch() {
         assert_eq!(e.events().all().events().len(), 0);
     });
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #330)")] // PendingRecovery
+fn remove_identity_recovery_target_with_undrained_old_account_panics() {
+    let e = Env::default();
+    let contract_id = e.register(MockContract, ());
+    let token = e.register(MockToken, ());
+
+    let old_account = Address::generate(&e);
+    let new_account = Address::generate(&e);
+    let identity = Address::generate(&e);
+    MockTokenClient::new(&e, &token).set_balance(&old_account, &100);
+
+    e.as_contract(&contract_id, || {
+        let country = CountryData { country: residence(840), metadata: None };
+
+        bind_token(&e, &token);
+        add_identity(&e, &old_account, &identity, IdentityType::Individual, &vec![&e, country]);
+        recover_identity(&e, &old_account, &new_account);
+
+        // The recovered identity is pinned to `new_account` until the old
+        // account's tokens have been recovered into it.
+        remove_identity(&e, &new_account);
+    });
+}
+
+#[test]
+fn remove_identity_recovery_target_after_old_account_drained_succeeds() {
+    let e = Env::default();
+    let contract_id = e.register(MockContract, ());
+    let token = e.register(MockToken, ());
+    let token_client = MockTokenClient::new(&e, &token);
+
+    let old_account = Address::generate(&e);
+    let new_account = Address::generate(&e);
+    let identity = Address::generate(&e);
+    let other_identity = Address::generate(&e);
+
+    e.as_contract(&contract_id, || {
+        let country = CountryData { country: residence(840), metadata: None };
+
+        bind_token(&e, &token);
+        add_identity(&e, &old_account, &identity, IdentityType::Individual, &vec![&e, country]);
+        recover_identity(&e, &old_account, &new_account);
+
+        remove_identity(&e, &new_account);
+        assert_eq!(get_recovered_to(&e, &old_account), Some(new_account.clone()));
+    });
+
+    // Once released, the target is an ordinary wallet again and no longer
+    // tracks the old account: a later balance on the old account does not
+    // block its removal.
+    token_client.set_balance(&old_account, &100);
+
+    e.as_contract(&contract_id, || {
+        let country = CountryData { country: residence(840), metadata: None };
+
+        add_identity(
+            &e,
+            &new_account,
+            &other_identity,
+            IdentityType::Individual,
+            &vec![&e, country],
+        );
+        assert_eq!(stored_identity(&e, &new_account), other_identity);
+
+        remove_identity(&e, &new_account);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #330)")] // PendingRecovery
+fn recover_identity_from_undrained_recovery_target_panics() {
+    let e = Env::default();
+    let contract_id = e.register(MockContract, ());
+    let token = e.register(MockToken, ());
+
+    let account1 = Address::generate(&e);
+    let account2 = Address::generate(&e);
+    let account3 = Address::generate(&e);
+    let identity = Address::generate(&e);
+    MockTokenClient::new(&e, &token).set_balance(&account1, &100);
+
+    e.as_contract(&contract_id, || {
+        let country = CountryData { country: residence(840), metadata: None };
+
+        bind_token(&e, &token);
+        add_identity(&e, &account1, &identity, IdentityType::Individual, &vec![&e, country]);
+        recover_identity(&e, &account1, &account2);
+
+        // account1's tokens can only be recovered into account2, so the
+        // identity may not move on before they are.
+        recover_identity(&e, &account2, &account3);
+    });
+}
+
+#[test]
+fn recover_identity_from_drained_recovery_target_succeeds() {
+    let e = Env::default();
+    let contract_id = e.register(MockContract, ());
+    let token = e.register(MockToken, ());
+
+    let account1 = Address::generate(&e);
+    let account2 = Address::generate(&e);
+    let account3 = Address::generate(&e);
+    let identity = Address::generate(&e);
+
+    e.as_contract(&contract_id, || {
+        let country = CountryData { country: residence(840), metadata: None };
+
+        bind_token(&e, &token);
+        add_identity(&e, &account1, &identity, IdentityType::Individual, &vec![&e, country]);
+        recover_identity(&e, &account1, &account2);
+        recover_identity(&e, &account2, &account3);
+
+        assert_eq!(stored_identity(&e, &account3), identity);
+        assert_eq!(get_recovered_to(&e, &account1), Some(account2.clone()));
+        assert_eq!(get_recovered_to(&e, &account2), Some(account3.clone()));
+    });
+}


### PR DESCRIPTION
fix #886 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that country compliance checks apply independently to each recipient wallet.
  - Documented identity recovery behavior, including linked balances, chained recoveries, and wallet-specific identity profiles.

- **Bug Fixes**
  - Improved identity removal and recovery validation when previous or linked wallets retain token balances.
  - Added clearer handling for pending recoveries, preventing further recovery actions until linked balances are cleared.
  - Recovery-linked records are now cleaned up once balances have been fully resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->